### PR TITLE
Add unit test of multiple options being returned

### DIFF
--- a/tests/test_reproducible.py
+++ b/tests/test_reproducible.py
@@ -35,3 +35,32 @@ def test_repeated_plans():
     a = [hash(x) for x in results]
     # We should end up with consistent results
     assert all(i == a[0] for i in a)
+
+
+def test_multiple_options():
+    result = planner.plan(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=uncertain_mid,
+        num_results=4,
+        simulations=128,
+    )
+    least_regret = result.least_regret
+    # With only 128 simulations we only have 3 instance families
+    assert len(least_regret) == 3
+    families = [lr.candidate_clusters.zonal[0].instance.family for lr in least_regret]
+    assert set(families) == set(("r5", "m5d", "m5"))
+
+    # With 1024 simulations we get a 4th instance family (i3)
+    result = planner.plan(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=uncertain_mid,
+        num_results=4,
+        simulations=1024,
+    )
+    least_regret = result.least_regret
+    assert len(least_regret) == 4
+
+    families = [lr.candidate_clusters.zonal[0].instance.family for lr in least_regret]
+    assert set(families) == set(("r5", "i3", "m5d", "m5"))


### PR DESCRIPTION
We've seen behavior in the past where the capacity planner does not always return multiple options, and for uncertain planning that happens because we are getting the options from the top N least regret options from the candidates (as opposed to all the specific plans).

This change just writes a test to show this behavior, but if we want to fix that behavior in the future we can change this test to reflect that we get the number of candidates regardless of simulation count.