### PR TITLE
Allow Cassandra to deploy to smaller instances

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -134,8 +134,8 @@ def _estimate_cassandra_cluster_zonal(
     max_regional_size: int = 96,
 ) -> Optional[CapacityPlan]:
 
-    # Cassandra doesn't like to deploy on really small instances
-    if instance.cpu < 8:
+    # Netflix Cassandra doesn't like to deploy on really small instances
+    if instance.cpu < 2 or instance.ram_gib < 14:
         return None
 
     # if we're not allowed to use gp2, skip EBS only types
@@ -184,6 +184,7 @@ def _estimate_cassandra_cluster_zonal(
         desires.data_shape.reserved_instance_app_mem_gib
         + desires.data_shape.reserved_instance_system_mem_gib
     )
+
     cluster = compute_stateful_zone(
         instance=instance,
         drive=drive,

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -76,9 +76,11 @@ def test_capacity_high_writes():
         extra_model_arguments={"copies_per_region": 2},
     )[0]
     high_writes_result = cap_plan.candidate_clusters.zonal[0]
-    assert high_writes_result.instance.name == "m5.2xlarge"
+    assert high_writes_result.instance.family == "m5"
     assert high_writes_result.count > 4
-    assert high_writes_result.instance.cpu * high_writes_result.count <= 128
+
+    num_cpus = high_writes_result.instance.cpu * high_writes_result.count
+    assert 32 < num_cpus <= 128
     assert high_writes_result.attached_drives[0].size_gib >= 400
     assert cap_plan.candidate_clusters.total_annual_cost < 40_000
 

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -40,12 +40,12 @@ def test_uncertain_planning():
     )
     lr = mid_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
-    assert 12 <= lr_cluster.count * lr_cluster.instance.cpu <= 64
+    assert 8 <= lr_cluster.count * lr_cluster.instance.cpu <= 64
     assert 5_000 <= lr.candidate_clusters.total_annual_cost < 40_000
 
     sr = mid_plan.least_regret[1]
     sr_cluster = sr.candidate_clusters.zonal[0]
-    assert 12 <= sr_cluster.count * sr_cluster.instance.cpu <= 64
+    assert 8 <= sr_cluster.count * sr_cluster.instance.cpu <= 64
     assert 5_000 <= sr.candidate_clusters.total_annual_cost < 40_000
 
     tiny_plan = planner.plan(
@@ -55,8 +55,8 @@ def test_uncertain_planning():
     )
     lr = tiny_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
-    assert 4 < lr_cluster.count * lr_cluster.instance.cpu < 16
-    assert 2_000 < lr.candidate_clusters.total_annual_cost < 8_000
+    assert 2 <= lr_cluster.count * lr_cluster.instance.cpu < 16
+    assert 1_000 < lr.candidate_clusters.total_annual_cost < 6_000
 
 
 def test_increasing_qps_simple():
@@ -96,7 +96,7 @@ def test_increasing_qps_simple():
         )
 
     # We should generally want cheap CPUs
-    assert all(r[0] in ("m5d", "m5", "i3") for r in result)
+    assert all(r[0] in ("r5", "m5d", "m5", "i3") for r in result)
 
     # Should have more capacity as requirement increases
     x = [r[1] for r in result]

--- a/tests/test_reproducible.py
+++ b/tests/test_reproducible.py
@@ -43,7 +43,7 @@ def test_multiple_options():
         region="us-east-1",
         desires=uncertain_mid,
         num_results=4,
-        simulations=128,
+        simulations=24,
     )
     least_regret = result.least_regret
     # With only 128 simulations we only have 3 instance families
@@ -51,7 +51,7 @@ def test_multiple_options():
     families = [lr.candidate_clusters.zonal[0].instance.family for lr in least_regret]
     assert set(families) == set(("r5", "m5d", "m5"))
 
-    # With 1024 simulations we get a 4th instance family (i3)
+    # With 1024 simulations we get a 4th instance family (i3en)
     result = planner.plan(
         model_name="org.netflix.cassandra",
         region="us-east-1",
@@ -63,4 +63,4 @@ def test_multiple_options():
     assert len(least_regret) == 4
 
     families = [lr.candidate_clusters.zonal[0].instance.family for lr in least_regret]
-    assert set(families) == set(("r5", "i3", "m5d", "m5"))
+    assert set(families) == set(("r5", "i3en", "m5d", "m5"))


### PR DESCRIPTION
For very small use cases we can save some decent money by using smaller
instances.

This aligns with our internal recommendation to spin r5.large as the smallest instance type.