### PR TITLE
Adding instance lifecycle

### DIFF
--- a/service_capacity_modeling/hardware/__init__.py
+++ b/service_capacity_modeling/hardware/__init__.py
@@ -34,6 +34,8 @@ def price_hardware(hardware: Hardware, pricing: Pricing) -> GlobalHardware:
         for instance, iprice in region_pricing.instances.items():
             priced_instances[instance] = hardware.instances[instance].copy()
             priced_instances[instance].annual_cost = iprice.annual_cost
+            if iprice.lifecycle is not None:
+                priced_instances[instance].lifecycle = iprice.lifecycle
 
         for drive, dprice in region_pricing.drives.items():
             priced_drives[drive] = hardware.drives[drive].copy()

--- a/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved.json
+++ b/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved.json
@@ -1,6 +1,7 @@
 {
   "us-east-1": {
     "instances": {
+      "f5.large.deprecated": {"annual_cost": 300.0, "lifecycle": "deprecated"},
       "m5.large":     {"annual_cost": 316.3},
       "m5.xlarge":    {"annual_cost": 632.3},
       "m5.2xlarge":   {"annual_cost": 1264.6},

--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -1,6 +1,14 @@
 {
   "core_reference_ghz": 2.3,
   "instances": {
+    "f5.large.deprecated": {
+      "name": "f5.large.deprecated",
+      "cpu": 2,
+      "cpu_ghz": 3.1,
+      "ram_gib": 7.48,
+      "net_mbps": 500,
+      "drive": null
+    },
     "m5.large": {
       "name": "m5.large",
       "cpu": 2,

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -111,6 +111,24 @@ def interval_percentile(
 ###############################################################################
 
 
+class Lifecycle(str, Enum):
+    """Represents the lifecycle of hardware from initial preview
+    to end-of-life.
+
+    For example a particular shape of hardware might be released under
+    preview and adventurous models may wish to use those, and then
+    more risk-averse workloads may wait for stability.
+
+    By default models are shown beta and stable shapes to pick from
+    """
+
+    alpha = "alpha"
+    beta = "beta"
+    stable = "stable"
+    deprecated = "deprecated"
+    end_of_life = "end-of-life"
+
+
 class Drive(BaseModel):
     """Represents a cloud drive e.g. EBS
 
@@ -164,6 +182,7 @@ class Instance(BaseModel):
     net_mbps: float
     drive: Optional[Drive]
     annual_cost: float = 0
+    lifecycle: Lifecycle = Lifecycle.stable
 
     family_separator: str = "."
 
@@ -236,6 +255,7 @@ class GlobalHardware(BaseModel):
 
 class InstancePricing(BaseModel):
     annual_cost: float = 0
+    lifecycle: Optional[Lifecycle] = None
 
 
 class DrivePricing(BaseModel):


### PR DESCRIPTION
This will make it so we can mark the lifecycle of hardware so we can automatically stop provisioning new instances of a particular family.

Note that in general I expect lifecycle to be changed at pricing time (e.g. Netflix might deprecate an instance family before broad deprecation0, but once a family is more than 2 generations behind current we can mark it deprecated in the defaults (e.g. if we were to record m3 or r3 those should clearly be deprecated).