### PR TITLE
Respect instance sizing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ information included in this repository are public prices.
 **NOTE**: Netflix confidential information should never enter this repo. Please
 consider this repository public when making changes to it.
 
-
 ## Trying it out
 
 Run the tests:
 ```bash
 # Test the capacity planner on included netflix models
 $ tox -e py38
+
+# Run a single test with a debugger attached if the test fails
+$ .tox/py38/bin/pytest -n0 -k test_java_heap_heavy --pdb --pdbcls=IPython.terminal.debugger:Pdb
 
 # Verify all type contracts
 $ tox -e mypy

--- a/service_capacity_modeling/models/org/netflix/stateless_java.py
+++ b/service_capacity_modeling/models/org/netflix/stateless_java.py
@@ -57,11 +57,7 @@ def _estimate_java_app_requirement(
     heap_allocation_gibps = (mem_allocation_mbps / 8) / 1024
     network_heap = heap_allocation_gibps * 2
 
-    needed_memory_gib = (
-        network_heap
-        + desires.data_shape.reserved_instance_app_mem_gib
-        + desires.data_shape.reserved_instance_system_mem_gib
-    )
+    needed_memory_gib = network_heap
 
     return CapacityRequirement(
         requirement_type="java-app",
@@ -116,7 +112,7 @@ def _estimate_java_app_region(
             candidate_clusters=Clusters(
                 total_annual_cost=round(Decimal(cluster.annual_cost), 2),
                 regional=[cluster],
-                zonal=list(),
+                zonal=[],
             ),
         )
     return None

--- a/tests/netflix/test_java_app.py
+++ b/tests/netflix/test_java_app.py
@@ -100,3 +100,34 @@ def test_uncertain_java_app():
     assert 0.5 <= float(kv_cores) / cores <= 1.5
 
     assert kv_least_regret.candidate_clusters.zonal[0].count > 0
+
+
+def test_java_heap_heavy():
+    needs_heap = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=2_000, mid=30_000, high=60_000, confidence=0.98
+            ),
+            estimated_write_per_second=Interval(
+                low=2_000, mid=30_000, high=60_000, confidence=0.98
+            ),
+        ),
+        # Should be ignored
+        data_shape=DataShape(
+            reserved_instance_app_mem_gib=40,
+        ),
+    )
+
+    java_cap_plan = planner.plan(
+        model_name="org.netflix.stateless-java",
+        region="us-east-1",
+        desires=needs_heap,
+    )
+    java_least_regret = java_cap_plan.least_regret[0]
+    java_result = java_least_regret.candidate_clusters.regional[0]
+
+    cores = java_result.count * java_result.instance.cpu
+    assert java_result.instance.name.startswith("r5.")
+    assert 100 <= cores <= 300
+    assert java_result.instance.mem_gib > 40


### PR DESCRIPTION
Hoists the logic to ensure we have enough instance memory to the planner interface.