### PR TITLE
EBS GP2 volumes should not start out larger than ~5.4 TiB

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -439,7 +439,8 @@
     "gp2": {
       "name": "gp2",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
-      "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90}
+      "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
+      "max_scale_size_gib": 16384
     }
   },
   "services": {

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -144,6 +144,8 @@ class Drive(BaseModel):
     # If this drive has single tenant IO capacity, for example a single
     # physical drive versus a virtualised drive
     single_tenant: bool = True
+    # If this drive can scale, how large can it scale to
+    max_scale_size_gib: int = 0
 
     annual_cost_per_gib: float = 0
     annual_cost_per_read_io: float = 0
@@ -157,6 +159,13 @@ class Drive(BaseModel):
     write_io_latency_ms: FixedInterval = FixedInterval(
         low=0.6, mid=2, high=3, confidence=0.9
     )
+
+    @property
+    def max_size_gib(self):
+        if self.max_scale_size_gib != 0:
+            return self.max_scale_size_gib
+        else:
+            return self.size_gib
 
     @property
     def annual_cost(self):

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -176,7 +176,7 @@ def _estimate_cassandra_cluster_zonal(
     required_cluster_size: Optional[int] = None,
     max_rps_to_disk: int = 500,
     max_local_disk_gib: int = 2048,
-    max_regional_size: int = 96,
+    max_regional_size: int = 192,
     max_write_buffer_percent: float = 0.25,
     max_table_buffer_percent: float = 0.11,
 ) -> Optional[CapacityPlan]:
@@ -251,7 +251,8 @@ def _estimate_cassandra_cluster_zonal(
         # a 90% hit rate, but take into account the reads per read
         # from the per node dataset using leveled compaction
         # FIXME: I feel like this can be improved
-        required_disk_ios=lambda x: _cass_io_per_read(x) * math.ceil(0.1 * rps),
+        required_disk_ios=lambda size, count: _cass_io_per_read(size)
+        * math.ceil(0.1 * rps / count),
         # C* requires ephemeral disks to be 25% full because compaction
         # and replacement time if we're underscaled.
         required_disk_space=lambda x: x * 4,
@@ -401,7 +402,7 @@ class NflxCassandraCapacityModel(CapacityModel):
             "required_cluster_size", None
         )
         max_rps_to_disk: int = extra_model_arguments.get("max_rps_to_disk", 500)
-        max_regional_size: int = extra_model_arguments.get("max_regional_size", 96)
+        max_regional_size: int = extra_model_arguments.get("max_regional_size", 192)
         max_local_disk_gib: int = extra_model_arguments.get("max_local_disk_gib", 2048)
         max_write_buffer_percent: float = min(
             0.5, extra_model_arguments.get("max_write_buffer_percent", 0.25)
@@ -459,7 +460,7 @@ class NflxCassandraCapacityModel(CapacityModel):
             ),
             (
                 "max_regional_size",
-                "int = 96",
+                "int = 192",
                 "What is the maximum size of a cluster in this region",
             ),
             (

--- a/service_capacity_modeling/models/org/netflix/crdb.py
+++ b/service_capacity_modeling/models/org/netflix/crdb.py
@@ -194,7 +194,8 @@ def _estimate_cockroachdb_cluster_zonal(
         # a 90% hit rate, but take into account the reads per read
         # from the per node dataset using leveled compaction
         # FIXME: I feel like this can be improved
-        required_disk_ios=lambda x: _crdb_io_per_read(x) * math.ceil(0.1 * rps),
+        required_disk_ios=lambda size, count: _crdb_io_per_read(size)
+        * math.ceil(0.1 * rps / count),
         # CRDB requires ephemeral disks to be 80% full because leveled
         # compaction can make progress as long as there is some headroom
         required_disk_space=lambda x: x * 1.2,

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -235,7 +235,8 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             # a 90% hit rate, but take into account the reads per read
             # from the per node dataset using leveled compaction
             # FIXME: I feel like this can be improved
-            required_disk_ios=lambda x: _es_io_per_read(x) * math.ceil(0.1 * data_rps),
+            required_disk_ios=lambda size, count: _es_io_per_read(size)
+            * math.ceil(0.1 * data_rps / count),
             # Elasticsearch requires ephemeral disks to be % full because tiered
             # merging can make progress as long as there is some headroom
             required_disk_space=lambda x: x * 1.4,
@@ -292,7 +293,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
                 # a 90% hit rate, but take into account the reads per read
                 # from the per node dataset using leveled compaction
                 # FIXME: I feel like this can be improved
-                required_disk_ios=lambda x: _es_io_per_read(x)
+                required_disk_ios=lambda size_gib, count: _es_io_per_read(size_gib)
                 * math.ceil(0.1 * search_rps),
                 # Elasticsearch requires ephemeral disks to be % full because tiered
                 # merging can make progress as long as there is some headroom
@@ -322,7 +323,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         clusters = Clusters(
             total_annual_cost=round(Decimal(ec2_cost), 2),
             zonal=data_clusters + search_clusters,
-            regional=list(),
+            regional=[],
         )
 
         plan = CapacityPlan(

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -188,7 +188,7 @@ def _estimate_evcache_cluster_zonal(
         needed_network_mbps=requirement.network_mbps.mid,
         # EVCache doesn't use cloud drives to store data, we will have
         # accounted for the data going on drives or memory via working set
-        required_disk_ios=lambda x: 0,
+        required_disk_ios=lambda x, y: 0,
         required_disk_space=lambda x: 0,
         max_local_disk_gib=max_local_disk_gib,
         # EVCache clusters should be balanced per zone
@@ -220,7 +220,7 @@ def _estimate_evcache_cluster_zonal(
     clusters = Clusters(
         total_annual_cost=round(Decimal(ec2_cost), 2),
         zonal=[cluster] * zones_per_region,
-        regional=list(),
+        regional=[],
     )
 
     return CapacityPlan(

--- a/service_capacity_modeling/models/org/netflix/rds.py
+++ b/service_capacity_modeling/models/org/netflix/rds.py
@@ -179,7 +179,7 @@ def _estimate_rds_regional(
         needed_disk_gib=int(requirement.disk_gib.mid),
         needed_memory_gib=int(requirement.mem_gib.mid),
         needed_network_mbps=requirement.network_mbps.mid,
-        required_disk_ios=lambda x: _rds_required_disk_ios(x, db_type)
+        required_disk_ios=lambda size_gib: _rds_required_disk_ios(size_gib, db_type)
         * math.ceil(0.1 * rps),
         required_disk_space=lambda x: x * 1.2,  # Unscientific random guess!
         core_reference_ghz=requirement.core_reference_ghz,
@@ -195,13 +195,13 @@ def _estimate_rds_regional(
 
     clusters = Clusters(
         total_annual_cost=round(cluster.annual_cost * replicas, 2),
-        zonal=list(),
+        zonal=[],
         regional=[cluster],
     )
 
     return CapacityPlan(
         requirements=Requirements(
-            zonal=list(),
+            zonal=[],
             regional=[requirement] * replicas,
             regrets=("spend", "disk", "mem"),
         ),

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -151,6 +151,8 @@ def test_worn_dataset():
         "m5."
     ) or lr_cluster.instance.name.startswith("r5.")
     assert lr_cluster.attached_drives[0].name == "gp2"
+    # gp2 should not provision massive drives, prefer to upcolor
+    assert lr_cluster.attached_drives[0].size_gib < 9000
     assert lr_cluster.attached_drives[0].size_gib * lr_cluster.count * 3 > 204800
     # We should have S3 backup cost
     assert lr.candidate_clusters.services[0].annual_cost > 5_000


### PR DESCRIPTION
Should fix the issues with highly dense clusters.
