### PR TITLE
Fixup IO calculations and revert back to 96 max per region

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -195,12 +195,12 @@ def compute_stateful_zone(
 
     attached_drives = []
     if instance.drive is None and required_disk_space(needed_disk_gib) > 0:
-        # If we don't have disks attach GP2 in at 50% space overprovision
-        # because we can only (as of 2020-10-31) scale EBS once per 6 hours
+        # If we don't have disks attach the cloud drive with enough
+        # space and IO for the requirement
 
         # Note that ebs is provisioned _per node_ and must be chosen for
         # the max of space and IOS.
-        space_gib = max(1, required_disk_space(needed_disk_gib) / count) * 1.5
+        space_gib = max(1, math.ceil(required_disk_space(needed_disk_gib) / count))
         io_gib = gp2_gib_for_io(required_disk_ios(space_gib, count))
 
         # Provision EBS in increments of 200 GiB

--- a/service_capacity_modeling/models/org/netflix/crdb.py
+++ b/service_capacity_modeling/models/org/netflix/crdb.py
@@ -190,12 +190,12 @@ def _estimate_cockroachdb_cluster_zonal(
         needed_memory_gib=requirement.mem_gib.mid,
         needed_network_mbps=requirement.network_mbps.mid,
         core_reference_ghz=requirement.core_reference_ghz,
-        # Assume that by provisioning enough memory we'll get
-        # a 90% hit rate, but take into account the reads per read
+        # Take into account the reads per read
         # from the per node dataset using leveled compaction
         # FIXME: I feel like this can be improved
-        required_disk_ios=lambda size, count: _crdb_io_per_read(size)
-        * math.ceil(0.1 * rps / count),
+        required_disk_ios=lambda size, count: (
+            _crdb_io_per_read(size) * math.ceil(rps / count)
+        ),
         # CRDB requires ephemeral disks to be 80% full because leveled
         # compaction can make progress as long as there is some headroom
         required_disk_space=lambda x: x * 1.2,

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -231,12 +231,11 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             needed_disk_gib=int(data_requirement.disk_gib.mid),
             needed_memory_gib=int(data_requirement.mem_gib.mid),
             needed_network_mbps=data_requirement.network_mbps.mid,
-            # Assume that by provisioning enough memory we'll get
-            # a 90% hit rate, but take into account the reads per read
+            # Take into account the reads per read
             # from the per node dataset using leveled compaction
-            # FIXME: I feel like this can be improved
-            required_disk_ios=lambda size, count: _es_io_per_read(size)
-            * math.ceil(0.1 * data_rps / count),
+            required_disk_ios=lambda size, count: (
+                _es_io_per_read(size) * math.ceil(data_rps / count)
+            ),
             # Elasticsearch requires ephemeral disks to be % full because tiered
             # merging can make progress as long as there is some headroom
             required_disk_space=lambda x: x * 1.4,
@@ -289,12 +288,11 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
                 needed_disk_gib=int(search_requirement.disk_gib.mid),
                 needed_memory_gib=int(search_requirement.mem_gib.mid),
                 needed_network_mbps=search_requirement.network_mbps.mid,
-                # Assume that by provisioning enough memory we'll get
-                # a 90% hit rate, but take into account the reads per read
-                # from the per node dataset using leveled compaction
-                # FIXME: I feel like this can be improved
-                required_disk_ios=lambda size_gib, count: _es_io_per_read(size_gib)
-                * math.ceil(0.1 * search_rps),
+                # FIXME: do search nodes need disk io? are they even
+                # having disk?
+                required_disk_ios=lambda size_gib, count: (
+                    _es_io_per_read(size_gib) * math.ceil(search_rps / count)
+                ),
                 # Elasticsearch requires ephemeral disks to be % full because tiered
                 # merging can make progress as long as there is some headroom
                 required_disk_space=lambda x: x * 1.4,


### PR DESCRIPTION
Should help bias us back towards ephems slightly more often.