### PR TITLE
add netflix counter model.

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -221,7 +221,7 @@ def _add_requirement(requirement, accum):
 
 def _merge_models(plans_by_model, zonal_requirements, regional_requirements):
     capacity_plans = []
-    for composed in zip(*filter(lambda x:x, plans_by_model)):
+    for composed in zip(*filter(lambda x: x, plans_by_model)):
         merged_plans = [functools.reduce(merge_plan, composed)]
         if len(merged_plans) == 0:
             continue

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -89,7 +89,9 @@ def certain_float(x: float) -> Interval:
 
 
 def interval(samples: Sequence[float], low_p: int = 5, high_p: int = 95) -> Interval:
-    p = np.percentile(samples, [0, low_p, 50, high_p, 100], interpolation="nearest")
+    p = np.percentile(
+        samples, [0, low_p, 50, high_p, 100], None, None, False, "nearest"
+    )
     conf = (high_p - low_p) / 100
     return Interval(
         low=p[1],
@@ -104,7 +106,7 @@ def interval(samples: Sequence[float], low_p: int = 5, high_p: int = 95) -> Inte
 def interval_percentile(
     samples: Sequence[float], percentiles: Sequence[int]
 ) -> Sequence[Interval]:
-    p = np.percentile(samples, percentiles, interpolation="nearest")
+    p = np.percentile(samples, percentiles, None, None, False, "nearest")
     return [certain_float(i) for i in p]
 
 

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -2,7 +2,6 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 
 from service_capacity_modeling.interface import AccessConsistency
@@ -10,7 +9,6 @@ from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRegretParameters
-from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
@@ -19,6 +17,7 @@ from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.interface import certain_float
 
 __common_regrets__ = frozenset(("spend", "disk", "mem"))
 
@@ -185,24 +184,18 @@ class CapacityModel:
 
     @staticmethod
     def description() -> str:
-        """ Optional description of the model """
+        """Optional description of the model"""
         return "No description"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        """Optional list of extra keyword arguments
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        """Optional json schema of extra keyword arguments
 
         Some models might take additional arguments to capacity_plan.
         They can convey that context to callers here along with a
         description of each argument
-
-        Result is a sequence of (name, type = default, description) pairs
-        For example:
-            (
-                ("arg_name", "int = 3", "my custom arg"),
-            )
         """
-        return tuple()
+        return {"type": "object"}
 
     @staticmethod
     def compose_with(

--- a/service_capacity_modeling/models/org/netflix/__init__.py
+++ b/service_capacity_modeling/models/org/netflix/__init__.py
@@ -9,6 +9,7 @@ from .key_value import nflx_key_value_capacity_model
 from .rds import nflx_rds_capacity_model
 from .stateless_java import nflx_java_app_capacity_model
 from .time_series import nflx_time_series_capacity_model
+from .counter import nflx_counter_capacity_model
 from .zookeeper import nflx_zookeeper_capacity_model
 
 
@@ -18,6 +19,7 @@ def models():
         "org.netflix.stateless-java": nflx_java_app_capacity_model,
         "org.netflix.key-value": nflx_key_value_capacity_model,
         "org.netflix.time-series": nflx_time_series_capacity_model,
+        "org.netflix.counter": nflx_counter_capacity_model,
         "org.netflix.zookeeper": nflx_zookeeper_capacity_model,
         "org.netflix.evcache": nflx_evcache_capacity_model,
         "org.netflix.rds": nflx_rds_capacity_model,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1,20 +1,18 @@
 import logging
-import math
 from decimal import Decimal
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
-from typing import Sequence
-from typing import Tuple
+
+import math
+from pydantic import BaseModel, Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -27,6 +25,8 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ServiceCapacity
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -34,7 +34,6 @@ from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import working_set_from_drive_and_slo
 from service_capacity_modeling.models.utils import next_power_of_2
 from service_capacity_modeling.stats import dist_for_interval
-
 
 logger = logging.getLogger(__name__)
 
@@ -383,6 +382,42 @@ def _target_rf(desires: CapacityDesires, user_copies: Optional[int]) -> int:
     return 3
 
 
+class NflxCassandraArguments(BaseModel):
+    copies_per_region: int = Field(
+        default=3,
+        description="How many copies of the data will exist e.g. RF=3. If unsupplied"
+        " this will be deduced from durability and consistency desires",
+    )
+    require_local_disks: bool = Field(
+        default=False,
+        description="If local (ephemeral) drives are required",
+    )
+    max_rps_to_disk: int = Field(
+        default=500,
+        description="How many disk IOs should be allowed to hit disk per instance",
+    )
+    max_regional_size: int = Field(
+        default=96,
+        description="What is the maximum size of a cluster in this region",
+    )
+    max_local_disk_gib: int = Field(
+        default=2048,
+        description="The maximum amount of data we store per machine",
+    )
+    max_write_buffer_percent: float = Field(
+        default=0.25,
+        description="The amount of heap memory that can be used to buffer writes. "
+        "Note that if there are more than 100k writes this will "
+        "automatically adjust to 0.5",
+    )
+    max_table_buffer_percent: float = Field(
+        default=0.11,
+        description="How much of heap memory can be used for a single table. "
+        "Note that if there are more than 100k writes this will "
+        "automatically adjust to 0.2",
+    )
+
+
 class NflxCassandraCapacityModel(CapacityModel):
     @staticmethod
     def capacity_plan(
@@ -441,61 +476,18 @@ class NflxCassandraCapacityModel(CapacityModel):
         return "Netflix Streaming Cassandra Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return (
-            (
-                "copies_per_region",
-                "int = 3",
-                "How many copies of the data will exist e.g. RF=3. If unsupplied"
-                " this will be deduced from durability and consistency desires",
-            ),
-            (
-                "require_local_disks",
-                "bool = 0",
-                "If local (ephemeral) drives are required",
-            ),
-            (
-                "max_rps_to_disk",
-                "int = 500",
-                "How many disk IOs should be allowed to hit disk per instance",
-            ),
-            (
-                "max_regional_size",
-                "int = 96",
-                "What is the maximum size of a cluster in this region",
-            ),
-            (
-                "max_local_disk_gib",
-                "int = 2048",
-                "The maximum amount of data we store per machine",
-            ),
-            (
-                "max_write_buffer_percent",
-                "float = 0.25",
-                "The amount of heap memory that can be used to buffer writes. "
-                "Note that if there are more than 100k writes this will "
-                "automatically adjust to 0.5",
-            ),
-            (
-                "max_table_buffer_percent",
-                "float = 0.11",
-                "How much of heap memory can be used for a single table. "
-                "Note that if there are more than 100k writes this will "
-                "automatically adjust to 0.2",
-            ),
-        )
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return NflxCassandraArguments.schema()
 
     @staticmethod
     def default_desires(user_desires, extra_model_arguments: Dict[str, Any]):
-        acceptable_consistency = set(
-            (
-                None,
-                AccessConsistency.best_effort,
-                AccessConsistency.eventual,
-                AccessConsistency.read_your_writes,
-                AccessConsistency.never,
-            )
-        )
+        acceptable_consistency = {
+            None,
+            AccessConsistency.best_effort,
+            AccessConsistency.eventual,
+            AccessConsistency.read_your_writes,
+            AccessConsistency.never,
+        }
         for key, value in user_desires.query_pattern.access_consistency:
             if value.target_consistency not in acceptable_consistency:
                 raise ValueError(

--- a/service_capacity_modeling/models/org/netflix/counter.py
+++ b/service_capacity_modeling/models/org/netflix/counter.py
@@ -1,3 +1,5 @@
+import json
+from enum import Enum
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -5,7 +7,9 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
-from .stateless_java import nflx_java_app_capacity_model
+from pydantic import BaseModel
+from pydantic import Field
+
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
@@ -20,9 +24,40 @@ from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models import CapacityModel
+from .stateless_java import nflx_java_app_capacity_model, NflxJavaAppArguments
 
 
-class NflxKeyValueCapacityModel(CapacityModel):
+class NflxCounterCardinality(Enum):
+    low = "low"
+    medium = "medium"
+    unbounded = "unbounded"
+
+
+class NflxCounterMode(Enum):
+    best_effort = "best-effort"
+    eventual = "eventual"
+    exact = "exact"
+
+
+class NflxCounterArguments(NflxJavaAppArguments):
+    counter_global: bool = Field(
+        alias="counter.global",
+        description="Indicate if this use case requires global counts which "
+        "is more expensive than regional",
+    )
+    counter_cardinality: NflxCounterCardinality = Field(
+        alias="counter.cardinality",
+        description="Low means < 100, "
+        "medium means < 100000. "
+        "Unbounded means that. We assume unbounded",
+    )
+    counter_mode: NflxCounterMode = Field(
+        alias="counter.mode",
+        description="What mode of counting",
+    )
+
+
+class NflxCounterCapacityModel(CapacityModel):
     @staticmethod
     def capacity_plan(
         instance: Instance,
@@ -31,38 +66,39 @@ class NflxKeyValueCapacityModel(CapacityModel):
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
     ) -> Optional[CapacityPlan]:
-        # KeyValue wants 20GiB root volumes
+        # Counter wants 20GiB root volumes
         extra_model_arguments.setdefault("root_disk_gib", 20)
 
-        kv_app = nflx_java_app_capacity_model.capacity_plan(
+        counter_app = nflx_java_app_capacity_model.capacity_plan(
             instance=instance,
             drive=drive,
             context=context,
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         )
-        if kv_app is None:
+        if counter_app is None:
             return None
 
-        for cluster in kv_app.candidate_clusters.regional:
-            cluster.cluster_type = "dgwkv"
-        return kv_app
+        for cluster in counter_app.candidate_clusters.regional:
+            cluster.cluster_type = "dgwcounter"
+        return counter_app
 
     @staticmethod
     def description():
-        return "Netflix Streaming Key-Value Model"
+        return "Netflix Streaming Counter Model"
 
     @staticmethod
     def extra_model_arguments_schema() -> Dict[str, Any]:
-        return nflx_java_app_capacity_model.extra_model_arguments_schema()
+        return NflxCounterArguments.schema()
 
     @staticmethod
     def compose_with(
         user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
     ) -> Tuple[Tuple[str, Callable[[CapacityDesires], CapacityDesires]], ...]:
-        # In the future depending on the user desire we might need EVCache
-        # as well, e.g. if the latency SLO is reduced
-        return (("org.netflix.cassandra", lambda x: x),)
+        stores = [("org.netflix.evcache", lambda x: x)]
+        if extra_model_arguments["counter.mode"] != NflxCounterMode.best_effort.name:
+            stores.append(("org.netflix.cassandra", lambda x: x))
+        return tuple(stores)
 
     @staticmethod
     def default_desires(user_desires, extra_model_arguments):
@@ -72,7 +108,7 @@ class NflxKeyValueCapacityModel(CapacityModel):
                     access_pattern=AccessPattern.latency,
                     access_consistency=GlobalConsistency(
                         same_region=Consistency(
-                            target_consistency=AccessConsistency.read_your_writes,
+                            target_consistency=AccessConsistency.eventual,
                         ),
                         cross_region=Consistency(
                             target_consistency=AccessConsistency.eventual,
@@ -108,7 +144,6 @@ class NflxKeyValueCapacityModel(CapacityModel):
                         confidence=0.98,
                     ),
                 ),
-                # Most KeyValue clusters are small
                 data_shape=DataShape(
                     estimated_state_size_gib=Interval(
                         low=10, mid=50, high=200, confidence=0.98
@@ -122,7 +157,7 @@ class NflxKeyValueCapacityModel(CapacityModel):
                     access_pattern=AccessPattern.latency,
                     access_consistency=GlobalConsistency(
                         same_region=Consistency(
-                            target_consistency=AccessConsistency.read_your_writes,
+                            target_consistency=AccessConsistency.eventual,
                         ),
                         cross_region=Consistency(
                             target_consistency=AccessConsistency.eventual,
@@ -134,7 +169,7 @@ class NflxKeyValueCapacityModel(CapacityModel):
                     estimated_mean_write_size_bytes=Interval(
                         low=64, mid=128, high=1024, confidence=0.95
                     ),
-                    # KV scan queries can be more expensive
+                    # counter scan queries can be more expensive
                     estimated_mean_read_latency_ms=Interval(
                         low=0.2, mid=4, high=6, confidence=0.98
                     ),
@@ -160,7 +195,7 @@ class NflxKeyValueCapacityModel(CapacityModel):
                         confidence=0.98,
                     ),
                 ),
-                # Most throughput KV clusters are large
+                # Most throughput counter clusters are large
                 data_shape=DataShape(
                     estimated_state_size_gib=Interval(
                         low=100, mid=1000, high=4000, confidence=0.98
@@ -170,4 +205,4 @@ class NflxKeyValueCapacityModel(CapacityModel):
             )
 
 
-nflx_key_value_capacity_model = NflxKeyValueCapacityModel()
+nflx_counter_capacity_model = NflxCounterCapacityModel()

--- a/service_capacity_modeling/models/org/netflix/entity.py
+++ b/service_capacity_modeling/models/org/netflix/entity.py
@@ -53,8 +53,8 @@ class NflxEntityCapacityModel(CapacityModel):
         return "Netflix Streaming Entity Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return nflx_java_app_capacity_model.extra_model_arguments()
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return nflx_java_app_capacity_model.extra_model_arguments_schema()
 
     @staticmethod
     def compose_with(

--- a/service_capacity_modeling/models/org/netflix/rds.py
+++ b/service_capacity_modeling/models/org/netflix/rds.py
@@ -1,18 +1,16 @@
 import logging
-import math
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Sequence
-from typing import Tuple
+
+import math
+from pydantic import BaseModel, Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -25,6 +23,8 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import gp2_gib_for_io
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -209,6 +209,14 @@ def _estimate_rds_regional(
     )
 
 
+class NflxRDSArguments(BaseModel):
+    rds_engine: str = Field(
+        alias="rds.engine",
+        default="mysql",
+        description="RDS Database type",
+    )
+
+
 class NflxRDSCapacityModel(CapacityModel):
     @staticmethod
     def capacity_plan(
@@ -230,14 +238,8 @@ class NflxRDSCapacityModel(CapacityModel):
         return "Netflix RDS Cluster Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return (
-            (
-                "rds.engine",
-                "str = mysql",
-                "RDS Database type",
-            ),
-        )
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return NflxRDSArguments.schema()
 
     @staticmethod
     def default_desires(user_desires, extra_model_arguments):

--- a/service_capacity_modeling/models/org/netflix/stateless_java.py
+++ b/service_capacity_modeling/models/org/netflix/stateless_java.py
@@ -1,10 +1,10 @@
-import math
 from decimal import Decimal
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Sequence
-from typing import Tuple
+
+import math
+from pydantic import BaseModel, Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -12,8 +12,6 @@ from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRegretParameters
 from service_capacity_modeling.interface import CapacityRequirement
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -26,6 +24,8 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import compute_stateless_region
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -118,6 +118,19 @@ def _estimate_java_app_region(
     return None
 
 
+class NflxJavaAppArguments(BaseModel):
+    failover: bool = Field(
+        default=True, description="If this app participates in failover"
+    )
+    jvm_memory_overhead: float = Field(
+        default=1.2,
+        description="How much overhead does the heap have per read byte",
+    )
+    root_disk_gib: int = Field(
+        default=10, description="How many GiB of root volume to attach"
+    )
+
+
 class NflxJavaAppCapacityModel(CapacityModel):
     @staticmethod
     def capacity_plan(
@@ -148,16 +161,8 @@ class NflxJavaAppCapacityModel(CapacityModel):
         return "Netflix Streaming Java App Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return (
-            ("failover", "bool = 1", "If this app participates in failover"),
-            (
-                "jvm_memory_overhead",
-                "float = 1.2",
-                "How much overhead does the heap have per read byte",
-            ),
-            ("root_disk_gib", "int = 10", "How many GiB of root volume to attach"),
-        )
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return NflxJavaAppArguments.schema()
 
     @staticmethod
     def regret(

--- a/service_capacity_modeling/models/org/netflix/time_series.py
+++ b/service_capacity_modeling/models/org/netflix/time_series.py
@@ -2,7 +2,6 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 
 from .stateless_java import nflx_java_app_capacity_model
@@ -53,8 +52,8 @@ class NflxTimeSeriesCapacityModel(CapacityModel):
         return "Netflix Streaming TimeSeries Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return nflx_java_app_capacity_model.extra_model_arguments()
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return nflx_java_app_capacity_model.extra_model_arguments_schema()
 
     @staticmethod
     def compose_with(

--- a/service_capacity_modeling/models/org/netflix/zookeeper.py
+++ b/service_capacity_modeling/models/org/netflix/zookeeper.py
@@ -1,16 +1,14 @@
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Sequence
-from typing import Tuple
+
+from pydantic import BaseModel, Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -23,6 +21,8 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ZoneClusterCapacity
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -70,6 +70,17 @@ def _zk_requirement(
         mem_gib=certain_float(needed_memory),
         disk_gib=certain_float(needed_disk),
         network_mbps=certain_float(needed_network_mbps),
+    )
+
+
+class NflxZookeeperArguments(BaseModel):
+    heap_overhead: float = Field(
+        default=1.25,
+        description="Amount of heap overhead per byte stored",
+    )
+    snapshot_overhead: float = Field(
+        default=4,
+        description="Amount of disk overhead to keep for snapshots",
     )
 
 
@@ -132,19 +143,8 @@ class NflxZookeeperCapacityModel(CapacityModel):
         return "Netflix Zookeeper Coordination Cluster Model"
 
     @staticmethod
-    def extra_model_arguments() -> Sequence[Tuple[str, str, str]]:
-        return (
-            (
-                "heap_overhead",
-                "float = 1.25",
-                "Amount of heap overhead per byte stored",
-            ),
-            (
-                "snapshot_overhead",
-                "float = 4",
-                "Amount of disk overhead to keep for snapshots",
-            ),
-        )
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return NflxZookeeperArguments.schema()
 
     @staticmethod
     def default_desires(user_desires, extra_model_arguments):

--- a/tests/netflix/test_counter.py
+++ b/tests/netflix/test_counter.py
@@ -1,0 +1,80 @@
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
+
+def test_counter_increasing_qps_simple():
+    qps_values = (1000, 10_000, 100_000)
+    zonal_result = []
+    regional_result = []
+    for qps in qps_values:
+        simple = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_write_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=Interval(
+                    low=20, mid=200, high=2000, confidence=0.98
+                ),
+            ),
+        )
+
+        cap_plan = planner.plan(
+            model_name="org.netflix.counter",
+            region="us-east-1",
+            desires=simple,
+            simulations=256,
+            extra_model_arguments={'counter.mode': "exact"}
+        )
+
+        # Check the C* cluster
+        zlrs = cap_plan.least_regret[0].candidate_clusters.zonal
+        zlr = next(filter(lambda zlr: zlr.cluster_type == 'cassandra', zlrs))
+        zlr_cpu = zlr.count * zlr.instance.cpu
+        zlr_cost = cap_plan.least_regret[0].candidate_clusters.total_annual_cost
+        zlr_family = zlr.instance.family
+        if zlr.instance.drive is None:
+            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 200
+        else:
+            assert zlr.instance.drive.size_gib >= 100
+
+        zonal_result.append(
+            (
+                zlr_family,
+                zlr_cpu,
+                zlr_cost,
+                cap_plan.least_regret[0].requirements.zonal[0],
+            )
+        )
+
+        # Check the Java cluster
+        rlr = cap_plan.least_regret[0].candidate_clusters.regional[0]
+        regional_result.append(
+            (rlr.instance.family, rlr.count * rlr.instance.cpu, zlr_cost)
+        )
+        # We should never be paying for ephemeral drives
+        assert rlr.instance.drive is None
+
+    # We should generally want cheap CPUs for Cassandra
+    assert all(r[0] in ("r5", "m5d", "m5", "i3en") for r in zonal_result)
+
+    # We just want ram and cpus for a java app
+    assert all(r[0] in ("m5", "r5") for r in regional_result)
+
+    # Should have more capacity as requirement increases
+    x = [r[1] for r in zonal_result]
+    assert x[0] < x[-1]
+    assert sorted(x) == x
+
+    # Should have more capacity as requirement increases
+    x = [r[1] for r in regional_result]
+    assert x[0] < x[-1]
+    assert sorted(x) == x

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,7 @@
+from service_capacity_modeling.models.org.netflix import models
+
+
+def test_model_arguments():
+    for model in models().values():
+        schema = model.extra_model_arguments_schema()
+        assert schema is not None


### PR DESCRIPTION
primarily for the inclusion of new counter model which is a copy/change to the time series model. changed the way it composes with c* and evcache.

```
+class NflxCounterCapacityModel(CapacityModel):
-class NflxTimeSeriesCapacityModel(CapacityModel):
...
     @staticmethod
     def compose_with(
         user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
     ) -> Tuple[Tuple[str, Callable[[CapacityDesires], CapacityDesires]], ...]:
-        # In the future depending on the user desire we might need EVCache
-        # as well, e.g. if the latency SLO is reduced
-        return (("org.netflix.cassandra", lambda x: x),)
+        stores = [("org.netflix.evcache", lambda x: x)]
+        if extra_model_arguments["counter.mode"] != NflxCounterMode.best_effort.name:
+            stores.append(("org.netflix.cassandra", lambda x: x))
+        return tuple(stores)
```

also includes:
* ran black formatter
* hack to work around numpy breaking change (use args instead of kwargs)
* rewrote how schema for arguments are presented from homemade schema to a standard.
