### PR TITLE
Revert "Use multiple processes to get lowest latency capacity plans"

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import functools
 import logging
-import multiprocessing
 from hashlib import blake2b
-from multiprocessing import Pool
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -438,32 +436,22 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
         ):
             model_plans: List[Tuple[CapacityDesires, Sequence[CapacityPlan]]] = []
-            with Pool(multiprocessing.cpu_count()) as worker:
-                results = []
-                for sim_desires in model_desires(sub_desires, simulations):
-                    results.append(
-                        (
-                            sim_desires,
-                            worker.apply_async(
-                                self._plan_certain,
-                                tuple(),
-                                {
-                                    "model_name": sub_model,
-                                    "region": region,
-                                    "desires": sim_desires,
-                                    "num_results": 1,
-                                    "extra_model_arguments": extra_model_arguments,
-                                    "lifecycles": lifecycles,
-                                    "instance_families": instance_families,
-                                    "drives": drives,
-                                },
-                            ),
-                        )
+            for sim_desires in model_desires(sub_desires, simulations):
+                model_plans.append(
+                    (
+                        sim_desires,
+                        self._plan_certain(
+                            model_name=sub_model,
+                            region=region,
+                            desires=sim_desires,
+                            num_results=1,
+                            extra_model_arguments=extra_model_arguments,
+                            lifecycles=lifecycles,
+                            instance_families=instance_families,
+                            drives=drives,
+                        ),
                     )
-
-                for r in results:
-                    model_plans.append((r[0], r[1].get()))
-
+                )
             regret_clusters_by_model[sub_model] = _regret(
                 capacity_plans=[
                     (sim_desires, plan[0]) for sim_desires, plan in model_plans if plan


### PR DESCRIPTION
This reverts commit 96b58d07935d7a345a0621aa57418a176b4e250a.

It appears that multiprocessing plays badly with gevent which the server
is using, and we get deadlocks. Reverting for now.