### PR TITLE
Surface network transfer costs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
  -  repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
  -  repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pylintrc
+++ b/.pylintrc
@@ -13,8 +13,6 @@ disable =
   useless-return,
   # gets angry when you declare a module-level logger
   invalid-name,
-  # we use black for continuations
-  bad-continuation,
   # missing-*-docstring: we have no intention to require docstrings on everything
   C0111,
   # wrong-import-order classifies relative imports differently from the

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -299,6 +299,7 @@ class CapacityPlanner:
         instance_families: Optional[List[str]] = None,
         drives: Optional[List[str]] = None,
         num_results: Optional[int] = None,
+        num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
     ) -> Sequence[CapacityPlan]:
         if model_name not in self._models:
@@ -323,6 +324,7 @@ class CapacityPlanner:
                     region=region,
                     desires=sub_desires,
                     num_results=num_results,
+                    num_regions=num_regions,
                     extra_model_arguments=extra_model_arguments,
                     lifecycles=lifecycles,
                     instance_families=instance_families,
@@ -338,6 +340,7 @@ class CapacityPlanner:
         region: str,
         desires: CapacityDesires,
         num_results: Optional[int] = None,
+        num_regions: int = 3,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
         drives: Optional[Sequence[str]] = None,
@@ -354,6 +357,7 @@ class CapacityPlanner:
         context = RegionContext(
             zones_in_region=hardware.zones_in_region,
             services={n: s.copy(deep=True) for n, s in hardware.services.items()},
+            num_regions=num_regions
         )
 
         # Applications often set fixed reservations of heap or OS memory, we
@@ -401,6 +405,7 @@ class CapacityPlanner:
         percentiles: Tuple[int, ...] = (5, 50, 95),
         simulations: Optional[int] = None,
         num_results: Optional[int] = None,
+        num_regions: int = 3,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
         drives: Optional[Sequence[str]] = None,
@@ -445,6 +450,7 @@ class CapacityPlanner:
                             region=region,
                             desires=sim_desires,
                             num_results=1,
+                            num_regions=num_regions,
                             extra_model_arguments=extra_model_arguments,
                             lifecycles=lifecycles,
                             instance_families=instance_families,
@@ -511,6 +517,7 @@ class CapacityPlanner:
                 region=region,
                 desires=percentile_inputs[index],
                 extra_model_arguments=extra_model_arguments,
+                num_regions=num_regions,
             )
 
         result = UncertainCapacityPlan(
@@ -521,6 +528,7 @@ class CapacityPlanner:
                 region=region,
                 desires=mean_desires,
                 extra_model_arguments=extra_model_arguments,
+                num_regions=num_regions,
             ),
             percentiles=percentile_plans,
             explanation=PlanExplanation(

--- a/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved.json
+++ b/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved.json
@@ -65,6 +65,12 @@
         "annual_cost_per_gib": "0.252",
         "annual_cost_per_write_io": "0.000005",
         "annual_cost_per_read_io": "0.0000004"
+      },
+      "net.inter.region": {
+        "annual_cost_per_gib": 0.02
+      },
+      "net.intra.region": {
+        "annual_cost_per_gib": 0.02
       }
     },
     "zones_in_region": 3

--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -227,7 +227,7 @@
       "cpu_ghz": 3.1,
       "ram_gib": 95.54,
       "net_mbps": 12000,
-      "drive": {"name": "ephem", "size_gib": 6819, 
+      "drive": {"name": "ephem", "size_gib": 6819,
         "read_io_latency_ms": {"minimum_value":0.07, "low":0.08, "mid":0.12, "high":0.16, "maximum_value":2, "confidence":0.9},
         "read_io_per_s": 250000,"write_io_per_s": 200000, "block_size_kib": 4
       }
@@ -241,7 +241,7 @@
       "drive": {
         "name": "ephem", "size_gib": 70,
         "read_io_latency_ms": {"minimum_value":0.07, "low":0.08, "mid":0.12, "high":0.20, "maximum_value":2, "confidence":0.9, "single_tenant": false},
-        "read_io_per_s": 30000,"write_io_per_s": 15000, "block_size_kib": 4 
+        "read_io_per_s": 30000,"write_io_per_s": 15000, "block_size_kib": 4
       }
     },
     "m5d.xlarge": {
@@ -479,7 +479,7 @@
       "name": "gp3",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16, 
+      "max_scale_size_gib": 16384, "block_size_kib": 16,
       "lifecycle": "alpha"
     }
   },
@@ -488,6 +488,12 @@
       "name": "s3-standard",
       "read_io_latency_ms": {"low": 1, "mid": 5, "high": 50, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1, "mid": 10, "high": 50, "confidence": 0.90}
+    },
+    "net.inter.region": {
+      "name": "Inter-region transfer costs"
+    },
+    "net.intra.region": {
+      "name": "Intra-region (within) transfer costs"
     }
   }
 }

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -546,7 +546,7 @@ class NflxCassandraCapacityModel(CapacityModel):
                         low=128, mid=1024, high=65536, confidence=0.95
                     ),
                     estimated_mean_write_size_bytes=Interval(
-                        low=64, mid=128, high=1024, confidence=0.95
+                        low=64, mid=256, high=1024, confidence=0.95
                     ),
                     # Cassandra point queries usualy take just around 2ms
                     # of on CPU time for reads and 1ms for writes
@@ -608,7 +608,7 @@ class NflxCassandraCapacityModel(CapacityModel):
                         low=128, mid=1024, high=65536, confidence=0.95
                     ),
                     estimated_mean_write_size_bytes=Interval(
-                        low=64, mid=128, high=1024, confidence=0.95
+                        low=128, mid=1024, high=65536, confidence=0.95
                     ),
                     # Cassandra scan queries usually take longer
                     estimated_mean_read_latency_ms=Interval(

--- a/service_capacity_modeling/models/org/netflix/crdb.py
+++ b/service_capacity_modeling/models/org/netflix/crdb.py
@@ -1,17 +1,20 @@
 import logging
+import math
 from decimal import Decimal
 from typing import Any
 from typing import Dict
 from typing import Optional
 
-import math
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -23,8 +26,6 @@ from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -233,7 +234,7 @@ def _estimate_cockroachdb_cluster_zonal(
 
     cluster.cluster_type = "cockroachdb"
     clusters = Clusters(
-        total_annual_cost=round(Decimal(ec2_cost), 2),
+        annual_costs={"cockroachdb-zonal": Decimal(ec2_cost)},
         zonal=[cluster] * zones_per_region,
         regional=[],
     )

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -233,7 +233,7 @@ def _estimate_evcache_cluster_zonal(
         modified = desires.copy(deep=True)
         # Assume that DELETES replicating cross region mean 128 bytes
         # of key per evict.
-        modified.query_pattern.estimated_mean_write_size_bytes.mid = 128
+        modified.query_pattern.estimated_mean_write_size_bytes = certain_int(128)
         services.extend(
             network_services("evcache", context, modified, copies_per_region)
         )
@@ -371,7 +371,7 @@ class NflxEVCacheCapacityModel(CapacityModel):
                         low=128, mid=1024, high=65536, confidence=0.95
                     ),
                     estimated_mean_write_size_bytes=Interval(
-                        low=64, mid=128, high=1024, confidence=0.95
+                        low=64, mid=512, high=1024, confidence=0.95
                     ),
                     # memcache point queries usually take just around 100us
                     # of on CPU time for reads and writes. Memcache is very

--- a/service_capacity_modeling/models/org/netflix/rds.py
+++ b/service_capacity_modeling/models/org/netflix/rds.py
@@ -1,16 +1,19 @@
 import logging
+import math
 from typing import Any
 from typing import Dict
 from typing import Optional
 
-import math
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -23,8 +26,6 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import gp2_gib_for_io
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -193,8 +194,9 @@ def _estimate_rds_regional(
     else:
         replicas = 1
 
+    costs = {"rds-cluster.regional-clusters": cluster.annual_cost * replicas}
     clusters = Clusters(
-        total_annual_cost=round(cluster.annual_cost * replicas, 2),
+        annual_costs=costs,
         zonal=[],
         regional=[cluster],
     )

--- a/service_capacity_modeling/models/org/netflix/zookeeper.py
+++ b/service_capacity_modeling/models/org/netflix/zookeeper.py
@@ -2,13 +2,16 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
@@ -21,8 +24,6 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ZoneClusterCapacity
-from service_capacity_modeling.interface import certain_float
-from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -123,10 +124,12 @@ class NflxZookeeperCapacityModel(CapacityModel):
             zonal = [soln(1), soln(1), soln(1)]
 
         clusters = Clusters(
-            total_annual_cost=round(sum(z.annual_cost for z in zonal), 2),
+            annual_costs={
+                "zk-zonal.zonal-clusters": (round(sum(z.annual_cost for z in zonal), 2))
+            },
             zonal=zonal,
-            regional=list(),
-            services=list(),
+            regional=[],
+            services=[],
         )
 
         return CapacityPlan(

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -228,7 +228,7 @@ def test_reduced_durability():
             plan.candidate_clusters.zonal[0].cluster_params[
                 "cassandra.compaction.min_threshold"
             ]
-            == 4
+            == 8
         )
 
     assert (

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -41,12 +41,12 @@ def test_uncertain_planning():
     lr = mid_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
     assert 8 <= lr_cluster.count * lr_cluster.instance.cpu <= 64
-    assert 5_000 <= lr.candidate_clusters.total_annual_cost < 40_000
+    assert 5_000 <= lr.candidate_clusters.total_annual_cost < 45_000
 
     sr = mid_plan.least_regret[1]
     sr_cluster = sr.candidate_clusters.zonal[0]
     assert 8 <= sr_cluster.count * sr_cluster.instance.cpu <= 64
-    assert 5_000 <= sr.candidate_clusters.total_annual_cost < 40_000
+    assert 5_000 <= sr.candidate_clusters.total_annual_cost < 45_000
 
     tiny_plan = planner.plan(
         model_name="org.netflix.cassandra",

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -137,16 +137,20 @@ def test_worn_dataset():
         model_name="org.netflix.cassandra",
         region="us-east-1",
         desires=worn_desire,
-        extra_model_arguments=dict(
-            max_regional_size=200,
-            copies_per_region=2,
-        ),
+        extra_model_arguments={
+            "max_regional_size": 200,
+            "copies_per_region": 2,
+        },
     )
 
     lr = cap_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
     assert 128 <= lr_cluster.count * lr_cluster.instance.cpu <= 512
-    assert 100_000 <= lr.candidate_clusters.total_annual_cost < 900_000
+    assert (
+        100_000
+        <= lr.candidate_clusters.annual_costs["cassandra.zonal-clusters"]
+        < 900_000
+    )
     assert lr_cluster.instance.name.startswith(
         "m5."
     ) or lr_cluster.instance.name.startswith("r5.")

--- a/tests/netflix/test_evcache.py
+++ b/tests/netflix/test_evcache.py
@@ -1,4 +1,5 @@
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
@@ -38,6 +39,8 @@ def test_evcache_high_qps():
 
     # EVCache should be pretty cheap for 100k RPS with 10k WPS
     assert lr.candidate_clusters.annual_costs["evcache.zonal-clusters"] < 10000
+    # Without replication shouldn't have network costs
+    assert len(lr.candidate_clusters.annual_costs.keys()) == 1
 
     zc = lr.candidate_clusters.zonal[0]
 
@@ -47,3 +50,64 @@ def test_evcache_high_qps():
     else:
         # If we end up with RAM we want at least 100 GiB of ram per zone
         assert zc.count * zc.instance.ram_gib > 100
+
+
+def test_evcache_replication():
+    high_qps = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=Interval(
+                low=10_000, mid=100_000, high=1_000_000, confidence=0.98
+            ),
+            estimated_write_per_second=Interval(
+                low=10_000, mid=100_000, high=1_000_000, confidence=0.98
+            ),
+        ),
+        # This should work out to around 200 GiB of state
+        data_shape=DataShape(
+            estimated_state_item_count=Interval(
+                low=100_000_000, mid=1_000_000_000, high=10_000_000_000, confidence=0.98
+            )
+        ),
+    )
+    plan = planner.plan(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=high_qps,
+        extra_model_arguments={"cross_region_replication": "sets"},
+    )
+    assert len(plan.least_regret) >= 2
+
+    lr = plan.least_regret[0]
+    # EVCache should regret having too little RAM, disk and spending too much
+    assert all(k in lr.requirements.regrets for k in ("spend", "mem", "disk"))
+    assert lr.requirements.zonal[0].disk_gib.mid > 200
+
+    # EVCache should be pretty cheap for 100k RPS with 10k WPS
+    assert lr.candidate_clusters.annual_costs["evcache.zonal-clusters"] < 10000
+
+    set_inter_region = lr.candidate_clusters.annual_costs["evcache.net.inter.region"]
+
+    # With replication should have network costs
+    assert 10000 < set_inter_region < 15000
+    assert (
+        10000 < lr.candidate_clusters.annual_costs["evcache.net.intra.region"] < 15000
+    )
+
+    delete_plan = planner.plan(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=high_qps,
+        extra_model_arguments={"cross_region_replication": "evicts"},
+    )
+
+    lr = delete_plan.least_regret[0]
+
+    # Evicts should be cheaper than sets
+    evict_inter_region = lr.candidate_clusters.annual_costs["evcache.net.inter.region"]
+    assert evict_inter_region < set_inter_region
+
+    # With replication should have network costs
+    assert 2000 < evict_inter_region < 6000
+    assert 2000 < lr.candidate_clusters.annual_costs["evcache.net.intra.region"] < 6000

--- a/tests/netflix/test_evcache.py
+++ b/tests/netflix/test_evcache.py
@@ -13,16 +13,18 @@ def test_evcache_high_qps():
                 low=10_000, mid=100_000, high=1_000_000, confidence=0.98
             ),
             estimated_write_per_second=Interval(
-                low=1_000, mid=10_000, high=100_000, confidence=0.98
+                low=10_000, mid=100_000, high=1_000_000, confidence=0.98
             ),
         ),
         data_shape=DataShape(
             estimated_state_size_gib=Interval(
                 low=10, mid=100, high=1000, confidence=0.98
             ),
+            estimated_state_item_size=Interval(
+                low=10, mid=100, high=1000, confidence=0.98
+            ),
         ),
     )
-
     plan = planner.plan(
         model_name="org.netflix.evcache",
         region="us-east-1",
@@ -35,7 +37,7 @@ def test_evcache_high_qps():
     assert all(k in lr.requirements.regrets for k in ("spend", "mem", "disk"))
 
     # EVCache should be pretty cheap for 100k RPS with 10k WPS
-    assert lr.candidate_clusters.total_annual_cost < 10000
+    assert lr.candidate_clusters.annual_costs["evcache.zonal-clusters"] < 10000
 
     zc = lr.candidate_clusters.zonal[0]
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,14 +1,18 @@
 from decimal import Decimal
 
 from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
+from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models.common import merge_plan
+from service_capacity_modeling.models.common import network_services
 
 
 def test_merge_plan():
@@ -35,7 +39,7 @@ def test_merge_plan():
     left_plan = CapacityPlan(
         requirements=Requirements(zonal=[left_requirement]),
         candidate_clusters=Clusters(
-            total_annual_cost=Decimal(1234),
+            annual_costs={"left-zonal": Decimal(1234)},
             zonal=[
                 ZoneClusterCapacity(
                     cluster_type="left",
@@ -51,7 +55,7 @@ def test_merge_plan():
     right_plan = CapacityPlan(
         requirements=Requirements(zonal=[right_requirement]),
         candidate_clusters=Clusters(
-            total_annual_cost=Decimal(1468),
+            annual_costs={"right-zonal": Decimal(1234), "right-regional": Decimal(234)},
             regional=[
                 RegionClusterCapacity(
                     cluster_type="right",
@@ -91,6 +95,11 @@ def test_merge_plan():
 
     assert left_plan.candidate_clusters.zonal[0] in result.candidate_clusters.zonal
     assert right_plan.candidate_clusters.zonal[0] in result.candidate_clusters.zonal
+    assert "left-zonal" in result.candidate_clusters.annual_costs
+    assert "right-zonal" in result.candidate_clusters.annual_costs
+    assert result.candidate_clusters.total_annual_cost == (
+        Decimal(1468) + Decimal(1234)
+    )
 
 
 def test_interval_scale():
@@ -102,7 +111,9 @@ def test_interval_scale():
     assert s.minimum < s.low
     assert s.maximum > s.high
 
-    with_minmax = Interval(low=10, mid=100, high=1000, minimum_value=1, maximum_value=1010)
+    with_minmax = Interval(
+        low=10, mid=100, high=1000, minimum_value=1, maximum_value=1010
+    )
     s = with_minmax.scale(3)
     assert s.low == 30
     assert s.mid == 300
@@ -120,10 +131,41 @@ def test_interval_offset():
     assert s.minimum < s.low
     assert s.maximum > s.high
 
-    with_minmax = Interval(low=10, mid=100, high=1000, minimum_value=1, maximum_value=1010)
+    with_minmax = Interval(
+        low=10, mid=100, high=1000, minimum_value=1, maximum_value=1010
+    )
     s = with_minmax.offset(3)
     assert s.low == 13
     assert s.mid == 103
     assert s.high == 1003
     assert s.minimum == 4
     assert s.maximum == 1013
+
+
+def test_network_services():
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_write_per_second=Interval(
+                low=1000, mid=10000, high=100000, confidence=0.98
+            ),
+            estimated_mean_write_size_bytes=Interval(
+                low=128, mid=256, high=1024, confidence=0.98
+            ),
+        ),
+    )
+    hardware = shapes.region("us-east-1")
+    region_context = RegionContext(
+        services={n: s.copy(deep=True) for n, s in hardware.services.items()},
+        num_regions=4,
+        zones_in_region=3,
+    )
+    ns = network_services(
+        "test", context=region_context, desires=desires, copies_per_region=3
+    )
+    cost_by_service = {}
+    for service in ns:
+        cost_by_service[service.service_type] = service.annual_cost
+
+    assert 3 * 1500 < cost_by_service["test.net.inter.region"] < 3 * 1500 + 100
+    assert 2 * 1500 < cost_by_service["test.net.intra.region"] < 2 * 1500 + 100

--- a/tests/test_desire_merge.py
+++ b/tests/test_desire_merge.py
@@ -38,5 +38,9 @@ def test_cassandra_merge():
     assert merged.query_pattern.estimated_mean_write_latency_ms.mid == 1.0
 
     # Should come from overall defaults
-    assert merged.data_shape.estimated_state_item_count is None
     assert merged.core_reference_ghz == 2.3
+
+    # Should come from the default size producing the count
+    # 10 GiB / 512 byte items = 20971520 items
+    assert merged.data_shape.estimated_state_item_count is not None
+    assert int(merged.data_shape.estimated_state_item_count.mid) == 41943040

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     ipdb
     isodate
 commands =
-    pytest -n 8 {posargs}
+    pytest -x -n 8 {posargs}
     mypy --ignore-missing-imports --check-untyped-defs --show-error-codes --follow-imports silent service_capacity_modeling tests
 
 [testenv:dev]


### PR DESCRIPTION
Previously we didn't surface the costs of network transfer which might be quite significant for larger services like EVCache and Cassandra. Now models can include those cost components if they wish.

Original patch by @pkarumanchi9 in #43 . Reworked with him to move to network costs.