### PR TITLE
Fix off-by-N error on intra costs

### DIFF
--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -41,12 +41,16 @@ def test_uncertain_planning():
     lr = mid_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
     assert 8 <= lr_cluster.count * lr_cluster.instance.cpu <= 64
-    assert 5_000 <= lr.candidate_clusters.total_annual_cost < 45_000
+    assert (
+        5_000 <= lr.candidate_clusters.annual_costs["cassandra.zonal-clusters"] < 45_000
+    )
 
     sr = mid_plan.least_regret[1]
     sr_cluster = sr.candidate_clusters.zonal[0]
     assert 8 <= sr_cluster.count * sr_cluster.instance.cpu <= 64
-    assert 5_000 <= sr.candidate_clusters.total_annual_cost < 45_000
+    assert (
+        5_000 <= sr.candidate_clusters.annual_costs["cassandra.zonal-clusters"] < 45_000
+    )
 
     tiny_plan = planner.plan(
         model_name="org.netflix.cassandra",
@@ -56,7 +60,9 @@ def test_uncertain_planning():
     lr = tiny_plan.least_regret[0]
     lr_cluster = lr.candidate_clusters.zonal[0]
     assert 2 <= lr_cluster.count * lr_cluster.instance.cpu < 16
-    assert 1_000 < lr.candidate_clusters.total_annual_cost < 6_000
+    assert (
+        1_000 < lr.candidate_clusters.annual_costs["cassandra.zonal-clusters"] < 6_000
+    )
 
 
 def test_increasing_qps_simple():
@@ -89,7 +95,9 @@ def test_increasing_qps_simple():
 
         lr = cap_plan.least_regret[0].candidate_clusters.zonal[0]
         lr_cpu = lr.count * lr.instance.cpu
-        lr_cost = cap_plan.least_regret[0].candidate_clusters.total_annual_cost
+        lr_cost = cap_plan.least_regret[0].candidate_clusters.annual_costs[
+            "cassandra.zonal-clusters"
+        ]
         lr_family = lr.instance.family
         if lr.instance.drive is None:
             assert sum(dr.size_gib for dr in lr.attached_drives) >= 200
@@ -184,7 +192,11 @@ def test_very_small_has_disk():
     for lr in cap_plan.least_regret:
         lr_cluster = lr.candidate_clusters.zonal[0]
         assert 2 <= lr_cluster.count * lr_cluster.instance.cpu < 16
-        assert 1_000 < lr.candidate_clusters.total_annual_cost < 6_000
+        assert (
+            1_000
+            < lr.candidate_clusters.annual_costs["cassandra.zonal-clusters"]
+            < 6_000
+        )
         if lr_cluster.instance.drive is None:
             assert sum(dr.size_gib for dr in lr_cluster.attached_drives) > 10
         else:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -168,4 +168,4 @@ def test_network_services():
         cost_by_service[service.service_type] = service.annual_cost
 
     assert 3 * 1500 < cost_by_service["test.net.inter.region"] < 3 * 1500 + 100
-    assert 2 * 1500 < cost_by_service["test.net.intra.region"] < 2 * 1500 + 100
+    assert 2 * 4 * 1500 < cost_by_service["test.net.intra.region"] < 2 * 4 * 1500 + 100


### PR DESCRIPTION
Previously we did not account for the number of regions when billing cross zone costs. Now we do by multiplying the intra-region (inter-zone) costs by the number of regions. Note that non global databases simply will not add these services to their cost model.

cc @pkarumanchi9