### PR TITLE
Adding platform info for db instances

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -726,7 +726,7 @@
       "ram_gib": 15.71,
       "net_mbps": 500,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.xlarge": {
       "name": "db.r5.xlarge",
@@ -735,7 +735,7 @@
       "ram_gib": 31.65,
       "net_mbps": 1000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.2xlarge": {
       "name": "db.r5.2xlarge",
@@ -744,7 +744,7 @@
       "ram_gib": 63.62,
       "net_mbps": 2000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.4xlarge": {
       "name": "db.r5.4xlarge",
@@ -753,7 +753,7 @@
       "ram_gib": 128,
       "net_mbps": 4000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.8xlarge": {
       "name": "db.r5.8xlarge",
@@ -762,7 +762,7 @@
       "ram_gib": 256,
       "net_mbps": 10000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.12xlarge": {
       "name": "db.r5.12xlarge",
@@ -771,7 +771,7 @@
       "ram_gib": 384,
       "net_mbps": 10000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.16xlarge": {
       "name": "db.r5.16xlarge",
@@ -780,7 +780,7 @@
       "ram_gib": 512,
       "net_mbps": 13600,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     },
     "db.r5.24xlarge": {
       "name": "db.r5.24xlarge",
@@ -789,7 +789,7 @@
       "ram_gib": 768,
       "net_mbps": 19000,
       "drive": null,
-      "platforms": "Aurora MySQL,Aurora PostgreSQL"
+      "platforms": ["Aurora MySQL","Aurora PostgreSQL"]
     }
   },
   "drives": {

--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -725,7 +725,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 15.71,
       "net_mbps": 500,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.xlarge": {
       "name": "db.r5.xlarge",
@@ -733,7 +734,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 31.65,
       "net_mbps": 1000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.2xlarge": {
       "name": "db.r5.2xlarge",
@@ -741,7 +743,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 63.62,
       "net_mbps": 2000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.4xlarge": {
       "name": "db.r5.4xlarge",
@@ -749,7 +752,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 128,
       "net_mbps": 4000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.8xlarge": {
       "name": "db.r5.8xlarge",
@@ -757,7 +761,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 256,
       "net_mbps": 10000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.12xlarge": {
       "name": "db.r5.12xlarge",
@@ -765,7 +770,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 384,
       "net_mbps": 10000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.16xlarge": {
       "name": "db.r5.16xlarge",
@@ -773,7 +779,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 512,
       "net_mbps": 13600,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     },
     "db.r5.24xlarge": {
       "name": "db.r5.24xlarge",
@@ -781,7 +788,8 @@
       "cpu_ghz": 3.1,
       "ram_gib": 768,
       "net_mbps": 19000,
-      "drive": null
+      "drive": null,
+      "platforms": "Aurora MySQL,Aurora PostgreSQL"
     }
   },
   "drives": {

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -271,16 +271,21 @@ class Instance(ExcludeUnsetModel):
     drive: Optional[Drive]
     annual_cost: float = 0
     lifecycle: Lifecycle = Lifecycle.stable
+    platforms: str = "EC2"
 
     family_separator: str = "."
 
     @property
     def family(self):
-        return self.name[:self.name.rindex(self.family_separator)]
+        if self.name.startswith("db."):
+            return f"db.{self.name.split(self.family_separator)[1]}"
+        return self.name.split(self.family_separator)[0]
 
     @property
     def size(self):
-        return self.name.split(self.family_separator)[-1]
+        if self.name.startswith("db."):
+            return self.name.split(self.family_separator)[2]
+        return self.name.split(self.family_separator)[1]
 
 
 class Service(ExcludeUnsetModel):

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -16,6 +16,7 @@ from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Platform
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 
@@ -235,6 +236,15 @@ class CapacityModel:
         # quiet pylint
         (_, _) = user_desires, extra_model_arguments
         return tuple()
+
+    @staticmethod
+    def allowed_platforms() -> Tuple[Platform, ...]:
+        """Return which platforms this model accepts.
+
+        Most software can run on amd64 (Intel and AMD), but some models might
+        accept others
+        """
+        return (Platform.amd64,)
 
     @staticmethod
     def default_desires(

--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -179,9 +179,13 @@ def _estimate_aurora_regional(
     desires: CapacityDesires,
     extra_model_arguments: Dict[str, Any],
 ) -> Optional[CapacityPlan]:
-    instance_family = instance.family
-    if instance_family not in ("db.x2g", "db.r6g", "db.r6i", "db.r5", "db.t4g"):
-        return None
+    db_type = extra_model_arguments.get("aurora.engine", "postgres")
+    if db_type == "postgres":
+        if "Aurora PostgreSQL" not in instance.platforms:
+            return None
+    else:
+        if "Aurora MySQL" not in instance.platforms:
+            return None
 
     if drive.name != "aurora":
         return None
@@ -190,7 +194,6 @@ def _estimate_aurora_regional(
     if desires.service_tier == 0:
         return None
 
-    db_type = extra_model_arguments.get("aurora.engine", "mysql")  # maybe we use postgres as default?
     requirement = _estimate_aurora_requirement(instance, desires, db_type)
     rps = desires.query_pattern.estimated_read_per_second.mid
 

--- a/tests/netflix/test_aurora.py
+++ b/tests/netflix/test_aurora.py
@@ -24,7 +24,7 @@ tier_0 = CapacityDesires(
 small_footprint = CapacityDesires(
     service_tier=1,
     query_pattern=QueryPattern(
-        estimated_read_per_second=certain_int(200),
+        estimated_read_per_second=certain_int(100),
         estimated_write_per_second=certain_int(100),
         estimated_mean_read_latency_ms=certain_float(10),
         estimated_mean_write_latency_ms=certain_float(10),
@@ -112,7 +112,7 @@ def test_large_footprint():
         region="us-east-1",
         desires=large_footprint,
     )
-    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.8xlarge"
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.12xlarge"
 
 
 def test_tier_3():


### PR DESCRIPTION
1. Add platform info for db instances
2. Bug fixing in instance interface to support .deprecated instances
3. use postgres as the default Aurora engine