### PR TITLE
Promotes gp3 to be GA and properly does IO calcs

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -797,13 +797,15 @@
       "name": "gp2",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16
+      "max_scale_size_gib": 16384, "block_size_kib": 16,
+      "max_scale_io_per_s": 16000
     },
     "io2": {
       "name": "io2",
       "read_io_latency_ms": {"low": 0.5, "mid": 0.8, "high": 1.2, "maximum_value": 2, "confidence": 0.90},
       "write_io_latency_ms": {"low": 0.9, "mid": 1.2, "high": 2, "maximum_value": 4, "confidence": 0.90},
       "max_scale_size_gib": 16384, "block_size_kib": 16,
+      "max_scale_io_per_s": 64000,
       "lifecycle": "alpha"
     },
     "gp3": {
@@ -811,7 +813,8 @@
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
       "max_scale_size_gib": 16384, "block_size_kib": 16,
-      "lifecycle": "alpha"
+      "max_scale_io_per_s": 16000,
+      "lifecycle": "stable"
     },
     "aurora": {
       "name": "aurora",

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from decimal import Decimal
 from enum import Enum
 from functools import lru_cache
@@ -199,6 +200,8 @@ class Drive(ExcludeUnsetModel):
     single_tenant: bool = True
     # If this drive can scale, how large can it scale to
     max_scale_size_gib: int = 0
+    # If this drive can scale IO, how large can it scale to
+    max_scale_io_per_s: int = 0
 
     lifecycle: Lifecycle = Lifecycle.stable
     compatible_families: List[str] = []
@@ -224,6 +227,13 @@ class Drive(ExcludeUnsetModel):
             return self.max_scale_size_gib
         else:
             return self.size_gib
+
+    @property
+    def max_io_per_s(self):
+        if self.max_scale_io_per_s != 0:
+            return self.max_scale_io_per_s
+        else:
+            return sys.maxsize
 
     @property
     def annual_cost(self):

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -162,7 +162,7 @@ def test_worn_dataset():
     assert lr_cluster.instance.name.startswith(
         "m5."
     ) or lr_cluster.instance.name.startswith("r5.")
-    assert lr_cluster.attached_drives[0].name == "gp2"
+    assert lr_cluster.attached_drives[0].name == "gp3"
     # gp2 should not provision massive drives, prefer to upcolor
     assert lr_cluster.attached_drives[0].size_gib < 9000
     assert lr_cluster.attached_drives[0].size_gib * lr_cluster.count * 3 > 204800


### PR DESCRIPTION
Now that Cassandra can provision with gp3, let's start recommending it from models.