### PR TITLE
Adjust Aurora model based on AWS feedback

### DIFF
--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -321,13 +321,14 @@ class NflxAuroraCapacityModel(CapacityModel):
                 estimated_mean_write_size_bytes=Interval(
                     low=64, mid=512, high=2048, confidence=0.90
                 ),
-                # probably closer to CRDB than Cassandra. Query by PK in MySQL takes
-                # total of ~300 ms end to end
+                # probably closer to CRDB than Cassandra. Query by PK in MySQL
+                # theoretically takes total of ~300 us end to end, but
+                # PostgreSQL is usually slower ...
                 estimated_mean_read_latency_ms=Interval(
-                    low=5, mid=30, high=150, confidence=0.90
+                    low=1, mid=4, high=100, confidence=0.90
                 ),
                 estimated_mean_write_latency_ms=Interval(
-                    low=5, mid=30, high=150, confidence=0.90
+                    low=1, mid=6, high=200, confidence=0.90
                 ),
                 # Single row fetch by PK in MySQL takes total of ~300 ms end to end
                 read_latency_slo_ms=FixedInterval(
@@ -347,9 +348,10 @@ class NflxAuroraCapacityModel(CapacityModel):
                     confidence=0.90,
                 ),
             ),
+            # Assume that the working set is between 20% by default
             data_shape=DataShape(
                 estimated_working_set_percent=Interval(
-                    low=0.05, mid=0.50, high=0.70, confidence=0.8
+                    low=0.05, mid=0.10, high=0.20, confidence=0.8
                 )
             ),
         )

--- a/tests/netflix/test_aurora.py
+++ b/tests/netflix/test_aurora.py
@@ -96,14 +96,20 @@ def test_small_footprint():
     assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.xlarge"
 
     # two instance plus storage and io
-    assert (3500 < cap_plan[0].candidate_clusters.annual_costs["aurora-cluster.regional-clusters"] < 4500)
+    assert (
+        3500
+        < cap_plan[0].candidate_clusters.annual_costs[
+            "aurora-cluster.regional-clusters"
+        ]
+        < 4500
+    )
 
 
 def test_medium_footprint():
     cap_plan = planner.plan_certain(
         model_name="org.netflix.aurora", region="us-east-1", desires=mid_footprint
     )
-    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.8xlarge"
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.4xlarge"
 
 
 def test_large_footprint():
@@ -121,7 +127,7 @@ def test_tier_3():
         region="us-east-1",
         desires=tier_3,
     )
-    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.4xlarge"
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.2xlarge"
 
 
 def test_cap_plan():
@@ -222,4 +228,4 @@ def test_cap_plan():
         region="us-east-1",
         desires=my_desire,
     )
-    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.8xlarge"
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.2xlarge"


### PR DESCRIPTION
We are reducing the on-cpu-time or reads/write by 10x and reducing cache sizes by 4x based on feedback from AWS Aurora teams.