### PR TITLE
Pydantic V2 ensure compatibility

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -18,5 +18,5 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox and any other packages
       run: pip install tox
-    - name: Run Tox
+    - name: Run Tox (pydantic v1)
       run: tox -e py

--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -254,7 +254,7 @@
       "ram_gib": 15.48,
       "net_mbps": 781,
       "drive": {
-        "name": "ephem", "size_gib": 436.5,
+        "name": "ephem", "size_gib": 436,
         "read_io_latency_ms": {
             "minimum_value":0.05,
             "low":0.10, "mid":0.125, "high":0.17,
@@ -271,7 +271,7 @@
       "ram_gib": 30.955,
       "net_mbps": 1875,
       "drive": {
-        "name": "ephem", "size_gib": 873.0,
+        "name": "ephem", "size_gib": 873,
         "read_io_latency_ms": {
             "minimum_value": 0.05,
             "low": 0.10, "mid": 0.125, "high": 0.17,

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -155,13 +155,6 @@ def interval(samples: Sequence[float], low_p: int = 5, high_p: int = 95) -> Inte
     )
 
 
-def interval_percentile(
-    samples: Sequence[float], percentiles: Sequence[int]
-) -> Sequence[Interval]:
-    p = np.percentile(samples, percentiles)
-    return [certain_float(i) for i in p]
-
-
 ###############################################################################
 #              Models (structs) for how we describe hardware                  #
 ###############################################################################
@@ -555,11 +548,11 @@ class DataShape(ExcludeUnsetModel):
 
     # How much fixed memory must be provisioned per instance for the
     # application (e.g. for process heap memory)
-    reserved_instance_app_mem_gib: int = 2
+    reserved_instance_app_mem_gib: float = 2
 
     # How much fixed memory must be provisioned per instance for the
     # system (e.g. for kernel and other system processes)
-    reserved_instance_system_mem_gib: int = 1
+    reserved_instance_system_mem_gib: float = 1
 
     # How durable does this dataset need to be. We want to provision
     # sufficient replication and backups of data to achieve the target

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="Contains utilities for modeling database capacity on a cloud",
     packages=setuptools.find_packages(exclude=("tests*", "notebooks*")),
     install_requires=[
-        "pydantic",
+        "pydantic<2.0",
         "scipy",
         "numpy",
         'importlib_resources; python_version < "3.7"',


### PR DESCRIPTION
Fixed up compatibility with `pydantic` V2, mostly stricter validations on data (e.g. ints can't be floats, providing superclass instead of subclass, etc ...).

Note that there are a _ton_ of deprecation warnings in V2 since we still use V1 APIs like `__fields__`, but most of the replacement methods aren't available in V1 so we can't use those either. I resolved the issues that were throwing active type exceptions, but left the use of V1 apis for now since that works in both V1 and V2 at least. The internal app that includes this library is pinned to <V2 for now, once that upgrades we can upgrade this to use v2 and just hope nobody uses this library inside a V1 app (which would promptly explode).

Also adds to the matrix to run the unit test suite against both v1 and v2 pydantic and adds two more python versions while I'm there. 