### PR TITLE
Add org.netflix.postgres model with plan rank

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -436,7 +436,7 @@ class CapacityPlanner:
                     plans.append(plan)
 
         # lowest cost first
-        plans.sort(key=lambda plan: plan.candidate_clusters.total_annual_cost)
+        plans.sort(key=lambda plan: (plan.rank, plan.candidate_clusters.total_annual_cost))
 
         return reduce_by_family(plans)[:num_results]
 

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -725,6 +725,7 @@ class Clusters(ExcludeUnsetModel):
 class CapacityPlan(ExcludeUnsetModel):
     requirements: Requirements
     candidate_clusters: Clusters
+    rank: int = 0
 
 
 # Parameters to cost functions of the form

--- a/service_capacity_modeling/models/org/netflix/__init__.py
+++ b/service_capacity_modeling/models/org/netflix/__init__.py
@@ -7,6 +7,7 @@ from .elasticsearch import nflx_elasticsearch_master_capacity_model
 from .entity import nflx_entity_capacity_model
 from .evcache import nflx_evcache_capacity_model
 from .key_value import nflx_key_value_capacity_model
+from .postgres import nflx_postgres_capacity_model
 from .rds import nflx_rds_capacity_model
 from .stateless_java import nflx_java_app_capacity_model
 from .time_series import nflx_time_series_capacity_model
@@ -31,5 +32,6 @@ def models():
         "org.netflix.entity": nflx_entity_capacity_model,
         "org.netflix.cockroachdb": nflx_cockroachdb_capacity_model,
         "org.netflix.aurora": nflx_aurora_capacity_model,
+        "org.netflix.postgres": nflx_postgres_capacity_model,
         "org.netflix.kafka": nflx_kafka_capacity_model,
     }

--- a/service_capacity_modeling/models/org/netflix/postgres.py
+++ b/service_capacity_modeling/models/org/netflix/postgres.py
@@ -1,0 +1,125 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+from service_capacity_modeling.interface import AccessConsistency, Platform
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import FixedInterval
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.models import CapacityModel
+from . import nflx_aurora_capacity_model, nflx_cockroachdb_capacity_model
+
+
+class NflxPostgresCapacityModel(CapacityModel):
+    @staticmethod
+    def capacity_plan(
+        instance: Instance,
+        drive: Drive,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+    ) -> Optional[CapacityPlan]:
+        if desires.service_tier == 0:
+            return None
+
+        require_multi_region: bool = extra_model_arguments.get("require_multi_region", False)
+        plan = None
+        if Platform.aurora_postgres in instance.platforms and not require_multi_region:
+            plan = nflx_aurora_capacity_model.capacity_plan(
+                instance=instance,
+                drive=drive,
+                context=context,
+                desires=desires,
+                extra_model_arguments=extra_model_arguments,
+            )
+
+        if plan is not None:
+            return plan
+
+        if set(nflx_cockroachdb_capacity_model.allowed_platforms()).intersection(instance.platforms):
+            plan = nflx_cockroachdb_capacity_model.capacity_plan(
+                instance=instance,
+                drive=drive,
+                context=context,
+                desires=desires,
+                extra_model_arguments=extra_model_arguments,
+            )
+        if plan is not None:
+            # We want to lower the rank so this plan will only be chosen when no other workaround
+            plan.rank = 1
+
+        return plan
+
+    @staticmethod
+    def description():
+        return "Netflix Postgres Model"
+
+    @staticmethod
+    def allowed_platforms() -> Tuple[Platform, ...]:
+        return Platform.aurora_postgres, Platform.amd64
+
+    @staticmethod
+    def default_desires(user_desires, extra_model_arguments):
+        return CapacityDesires(
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                access_consistency=GlobalConsistency(
+                    same_region=Consistency(
+                        target_consistency=AccessConsistency.serializable_stale,
+                    ),
+                    cross_region=Consistency(
+                        target_consistency=AccessConsistency.never,
+                    ),
+                ),
+                # can't really make latency/throughput trade-offs with RDS
+                estimated_mean_read_size_bytes=Interval(
+                    low=128, mid=1024, high=65536, confidence=0.90
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=64, mid=512, high=2048, confidence=0.90
+                ),
+
+                estimated_mean_read_latency_ms=Interval(
+                    low=1, mid=4, high=100, confidence=0.90
+                ),
+                estimated_mean_write_latency_ms=Interval(
+                    low=1, mid=6, high=200, confidence=0.90
+                ),
+
+                read_latency_slo_ms=FixedInterval(
+                    minimum_value=1,
+                    maximum_value=100,
+                    low=1,
+                    mid=10,
+                    high=20,
+                    confidence=0.98,
+                ),
+                write_latency_slo_ms=FixedInterval(
+                    minimum_value=1,
+                    maximum_value=100,
+                    low=1,
+                    mid=10,
+                    high=20,
+                    confidence=0.98,
+                ),
+            ),
+            # Assume that the working set is between 20% by default
+            data_shape=DataShape(
+                estimated_working_set_percent=Interval(
+                    low=0.05, mid=0.10, high=0.20, confidence=0.8
+                )
+            ),
+        )
+
+
+nflx_postgres_capacity_model = NflxPostgresCapacityModel()

--- a/tests/netflix/test_postgres.py
+++ b/tests/netflix/test_postgres.py
@@ -1,0 +1,154 @@
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+
+tier_0 = CapacityDesires(
+    service_tier=0,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=certain_int(200),
+        estimated_write_per_second=certain_int(100),
+        estimated_mean_read_latency_ms=certain_float(20),
+        estimated_mean_write_latency_ms=certain_float(20),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=certain_int(200),
+    ),
+)
+
+small_footprint = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=certain_int(100),
+        estimated_write_per_second=certain_int(100),
+        estimated_mean_read_latency_ms=certain_float(1),
+        estimated_mean_write_latency_ms=certain_float(1),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=certain_int(50),
+    ),
+)
+
+large_footprint = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=certain_int(2000),
+        estimated_write_per_second=certain_int(3000),
+        estimated_mean_read_latency_ms=certain_float(20),
+        estimated_mean_write_latency_ms=certain_float(20),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=certain_int(10000),
+        estimated_working_set_percent=Interval(
+            low=0.05, mid=0.30, high=0.50, confidence=0.8
+        ),
+    ),
+)
+
+tier_3 = CapacityDesires(
+    service_tier=3,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=certain_int(200),
+        estimated_write_per_second=certain_int(100),
+        estimated_mean_read_latency_ms=certain_float(20),
+        estimated_mean_write_latency_ms=certain_float(20),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=certain_int(200),
+    ),
+)
+
+
+def test_tier_0_not_supported():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=tier_0,
+    )
+    # Aurora can't support tier 0 service
+    assert len(cap_plan) == 0
+
+
+def test_small_footprint():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=small_footprint,
+    )
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.large"
+
+    # two instance plus storage and io
+    assert (
+        2000
+        < cap_plan[0].candidate_clusters.annual_costs[
+            "aurora-cluster.regional-clusters"
+        ]
+        < 4500
+    )
+
+
+def test_small_footprint_multi_region():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=small_footprint,
+        extra_model_arguments={"require_multi_region": True}
+    )
+    assert cap_plan[0].candidate_clusters.zonal[0].instance.name == "m5d.xlarge"
+
+    assert (
+        2000
+        < cap_plan[0].candidate_clusters.total_annual_cost
+        < 4000
+    )
+
+    planner.plan(model_name="org.netflix.postgres", region="us-east-1", desires=small_footprint,
+                 extra_model_arguments={"require_multi_region": False})
+
+
+def test_small_footprint_plan_uncertain():
+    cap_plan = planner.plan(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=small_footprint,
+        extra_model_arguments={"require_multi_region": False},
+        simulations=256
+    )
+    plan_a = cap_plan.least_regret[0]
+
+    assert plan_a.candidate_clusters.regional[0].instance.name == "db.r5.large"
+
+    assert (
+        2000
+        < plan_a.candidate_clusters.total_annual_cost
+        < 4000
+    )
+
+
+def test_large_footprint():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=large_footprint,
+    )
+    # Aurora cannot handle the scale, so pick crdb
+    assert cap_plan[0].candidate_clusters.zonal[0].instance.name == "i3.xlarge"
+    assert cap_plan[0].candidate_clusters.zonal[0].count == 41
+
+    assert (
+        100_000
+        < cap_plan[0].candidate_clusters.total_annual_cost
+        < 150_000
+    )
+
+
+def test_tier_3():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.postgres",
+        region="us-east-1",
+        desires=tier_3,
+    )
+    assert cap_plan[0].candidate_clusters.regional[0].instance.name == "db.r5.2xlarge"


### PR DESCRIPTION
* This model need "require_multi_region" to decide whether to use Aurora, in the future, this condition can be changed.
* The capacity plan was evaluated per instance, so I introduce the **rank** in the plan itself for us to set preference regardless of cost. 