### PR TITLE
Tune memory on kafka clusters

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -191,7 +191,8 @@ def _allow_instance(
     # of all lifecycles filter based on that
     if allowed_names:
         if instance.name not in allowed_names:
-            return False
+            if instance.family not in allowed_names:
+                return False
     # Otherwise consider lifecycle (default) and platform
     else:
         if instance.lifecycle not in allowed_lifecycles:
@@ -330,8 +331,8 @@ class CapacityPlanner:
         region: str,
         desires: CapacityDesires,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
-        instance_families: Optional[List[str]] = None,
-        drives: Optional[List[str]] = None,
+        instance_families: Optional[Sequence[str]] = None,
+        drives: Optional[Sequence[str]] = None,
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
@@ -436,7 +437,9 @@ class CapacityPlanner:
                     plans.append(plan)
 
         # lowest cost first
-        plans.sort(key=lambda plan: (plan.rank, plan.candidate_clusters.total_annual_cost))
+        plans.sort(
+            key=lambda plan: (plan.rank, plan.candidate_clusters.total_annual_cost)
+        )
 
         return reduce_by_family(plans)[:num_results]
 
@@ -564,6 +567,7 @@ class CapacityPlanner:
                 desires=percentile_inputs[index],
                 extra_model_arguments=extra_model_arguments,
                 num_regions=num_regions,
+                instance_families=instance_families,
             )
 
         result = UncertainCapacityPlan(
@@ -575,6 +579,7 @@ class CapacityPlanner:
                 desires=mean_desires,
                 extra_model_arguments=extra_model_arguments,
                 num_regions=num_regions,
+                instance_families=instance_families,
             ),
             percentiles=percentile_plans,
             explanation=PlanExplanation(

--- a/service_capacity_modeling/hardware/profiles/shapes/aws.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws.json
@@ -797,7 +797,9 @@
       "name": "gp2",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16,
+      "max_scale_size_gib": 16384,
+      "block_size_kib": 16,
+      "group_size_kib": 256,
       "max_scale_io_per_s": 16000,
       "lifecycle": "stable",
       "drive_type": "attached-ssd"
@@ -806,7 +808,9 @@
       "name": "io2",
       "read_io_latency_ms": {"low": 0.5, "mid": 0.8, "high": 1.2, "maximum_value": 2, "confidence": 0.90},
       "write_io_latency_ms": {"low": 0.9, "mid": 1.2, "high": 2, "maximum_value": 4, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16,
+      "max_scale_size_gib": 16384,
+      "block_size_kib": 16,
+      "group_size_kib": 256,
       "max_scale_io_per_s": 64000,
       "lifecycle": "alpha",
       "drive_type": "attached-ssd"
@@ -815,7 +819,9 @@
       "name": "gp3",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16,
+      "max_scale_size_gib": 16384,
+      "block_size_kib": 16,
+      "group_size_kib": 256,
       "max_scale_io_per_s": 16000,
       "lifecycle": "stable",
       "drive_type": "attached-ssd"
@@ -824,7 +830,9 @@
       "name": "aurora",
       "read_io_latency_ms": {"low": 0.8, "mid": 1.05, "high": 1.8, "maximum_value": 10, "confidence": 0.90},
       "write_io_latency_ms": {"low": 1.2, "mid": 2, "high": 4, "maximum_value": 20, "confidence": 0.90},
-      "max_scale_size_gib": 16384, "block_size_kib": 16
+      "max_scale_size_gib": 16384,
+      "block_size_kib": 16,
+      "group_size_kib": 256
     }
   },
   "services": {

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -137,8 +137,8 @@ def test_ebs_high_writes():
 
     # 10TiB ~= 4 IO/read -> 3.3k r/zone/s -> 12k /s
     assert 20_000 < read_ios < 60_000
-    # 33k wps * 8KiB  / 16KiB write IO size = 16.5k / s * 4 for compaction = 64k
-    assert 60_000 < write_ios < 100_000
+    # 33k wps * 8KiB  / 256KiB write IO size = 16.5k / s * 4 for compaction = 6.4k
+    assert 4_000 < write_ios < 7_000
 
 
 def test_capacity_high_writes():

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -70,3 +70,141 @@ def test_kafka_large_scale():
 
     assert lr.candidate_clusters.total_annual_cost < 200_000
     assert lr_cluster[0].instance.family in ("i3en", "i4i", "r5")
+
+
+def test_kafka_high_throughput():
+    # 2.8 GiB / second
+    throughput = 2.8 * 1024 * 1024 * 1024
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            # 2 consumers
+            estimated_read_per_second=Interval(low=1, mid=2, high=2, confidence=0.98),
+            # 1 producer
+            estimated_write_per_second=Interval(low=1, mid=1, high=1, confidence=0.98),
+            # Write throughput of 100 MiB/s
+            estimated_mean_write_size_bytes=Interval(
+                low=throughput, mid=throughput, high=throughput * 2, confidence=0.98
+            ),
+        ),
+    )
+
+    plan = planner.plan(
+        model_name="org.netflix.kafka",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={
+            "cluster_type": "ha",
+            "retention": "PT3H",
+        },
+        num_results=3,
+    )
+
+    lr = plan.least_regret[0]
+    lr_zone_requirements = lr.requirements.zonal[0]
+    # This should be doable with ~136 cpu cores @3.1 = 182 cores,
+    # ~1TiB RAM, and 25Gbps networking
+    # Note that network reserves 40% headroom for streaming.
+    expected_cpu = (120, 200)
+    expected_ram = (400, 1200)
+    expected_net = (20_000 * 1.4, 28_000 * 1.4)
+    expected_disk = (22000, 25400)
+
+    assert expected_cpu[0] < lr_zone_requirements.cpu_cores.mid < expected_cpu[1]
+    assert expected_ram[0] < lr_zone_requirements.mem_gib.mid < expected_ram[1]
+    assert expected_net[0] < lr_zone_requirements.network_mbps.mid < expected_net[1]
+    assert expected_disk[0] < lr_zone_requirements.disk_gib.mid < expected_disk[1]
+
+    lr_zone_cluster = lr.candidate_clusters.zonal[0]
+    # 17 r5.2xlarge is this much memory
+    expected_memory = 17 * 62
+    # subtract out the 8G heaps + system
+    expected_cache = 17 * 52
+
+    assert expected_cache * 0.5 < lr.requirements.zonal[0].mem_gib.mid < expected_cache
+    assert (
+        expected_memory * 0.5
+        < lr_zone_cluster.instance.ram_gib * lr_zone_cluster.count
+        < expected_memory * 2
+    )
+
+    for lr in plan.least_regret:
+        assert lr.candidate_clusters.total_annual_cost < 200_000
+        clstr = lr.candidate_clusters.zonal[0]
+        if clstr.instance.drive is None:
+            assert clstr.instance.family in ("r5", "m6i")
+            assert clstr.attached_drives[0].name == "gp3"
+            disk = clstr.attached_drives[0].size_gib * clstr.count
+            assert expected_disk[0] < disk < expected_disk[1] * 2.5
+        else:
+            assert clstr.instance.family in ("i3en", "i4i")
+            disk = clstr.instance.drive.size_gib * clstr.count
+            assert expected_disk[0] < disk
+
+
+def test_kafka_high_throughput_ebs():
+    # 2.8 GiB / second
+    throughput = 2.8 * 1024 * 1024 * 1024
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            # 2 consumers
+            estimated_read_per_second=Interval(low=1, mid=2, high=2, confidence=0.98),
+            # 1 producer
+            estimated_write_per_second=Interval(low=1, mid=1, high=1, confidence=0.98),
+            # Write throughput of 100 MiB/s
+            estimated_mean_write_size_bytes=Interval(
+                low=throughput, mid=throughput, high=throughput * 2, confidence=0.98
+            ),
+        ),
+    )
+
+    plan = planner.plan(
+        model_name="org.netflix.kafka",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={
+            "cluster_type": "ha",
+            "retention": "PT3H",
+            # Force to attached drives
+            "max_local_disk_gib": 500,
+        },
+        num_results=3,
+    )
+
+    lr = plan.least_regret[0]
+    lr_zone_requirements = lr.requirements.zonal[0]
+    # This should be doable with ~136 cpu cores @3.1 = 182 cores,
+    # ~1TiB RAM, and 25Gbps networking
+    # Note that network reserves 40% headroom for streaming.
+    expected_cpu = (120, 200)
+    expected_ram = (400, 1200)
+    expected_net = (20_000 * 1.4, 28_000 * 1.4)
+    expected_disk = (22000, 25400)
+    assert expected_cpu[0] < lr_zone_requirements.cpu_cores.mid < expected_cpu[1]
+    assert expected_ram[0] < lr_zone_requirements.mem_gib.mid < expected_ram[1]
+    assert expected_net[0] < lr_zone_requirements.network_mbps.mid < expected_net[1]
+    assert expected_disk[0] < lr_zone_requirements.disk_gib.mid < expected_disk[1]
+
+    lr_zone_cluster = lr.candidate_clusters.zonal[0]
+    # 17 r5.2xlarge is this much memory
+    expected_memory = 17 * 62
+    # subtract out the 8G heaps + system
+    expected_cache = 17 * 52
+
+    assert expected_cache * 0.5 < lr.requirements.zonal[0].mem_gib.mid < expected_cache
+    assert (
+        expected_memory * 0.5
+        < lr_zone_cluster.instance.ram_gib * lr_zone_cluster.count
+        < expected_memory * 2
+    )
+    assert lr.candidate_clusters.total_annual_cost < 250_000
+
+    for lr in plan.least_regret:
+        assert lr.candidate_clusters.total_annual_cost < 250_000
+        clstr = lr.candidate_clusters.zonal[0]
+        if clstr.instance.drive is None:
+            assert clstr.instance.family in ("r5", "r5n", "m5", "m6i")
+            assert clstr.attached_drives[0].name == "gp3"
+            disk = clstr.attached_drives[0].size_gib * clstr.count
+            assert expected_disk[0] < disk < expected_disk[1] * 2.5

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 [testenv:mypy]
 skip_install = true
 deps =
+    pydantic
     mypy
 commands =
     mypy --ignore-missing-imports --check-untyped-defs --show-error-codes --follow-imports silent service_capacity_modeling tests


### PR DESCRIPTION
Keep the last 10 minutes of data hot in RAM for consumers, and don't worry about the rest