### PR TITLE
Change minimum EBS step size to 100G instead of 200G

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -289,8 +289,8 @@ def compute_stateful_zone(
         total_ios = read_io + write_io
         io_gib = cloud_gib_for_io(drive, total_ios, space_gib)
 
-        # Provision EBS in increments of 200 GiB
-        ebs_gib = utils.next_n(max(1, io_gib, space_gib), n=200)
+        # Provision EBS in increments of 100 GiB
+        ebs_gib = utils.next_n(max(1, io_gib, space_gib), n=100)
 
         # When initially provisioniong we don't want to attach more than
         # 1/3 the maximum volume size in one node (preferring more nodes

--- a/tests/netflix/test_cassandra_uncertain.py
+++ b/tests/netflix/test_cassandra_uncertain.py
@@ -99,7 +99,7 @@ def test_increasing_qps_simple():
         ]
         lr_family = lr.instance.family
         if lr.instance.drive is None:
-            assert sum(dr.size_gib for dr in lr.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in lr.attached_drives) >= 100
         else:
             assert lr.instance.drive.size_gib >= 100
 

--- a/tests/netflix/test_counter.py
+++ b/tests/netflix/test_counter.py
@@ -45,7 +45,7 @@ def test_counter_increasing_qps_simple():
         zlr_cost = cap_plan.least_regret[0].candidate_clusters.total_annual_cost
         zlr_family = zlr.instance.family
         if zlr.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 100
         else:
             assert zlr.instance.drive.size_gib >= 70
 

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -51,7 +51,7 @@ def test_kv_increasing_qps_simple():
         zlr_cost = cap_plan.least_regret[0].candidate_clusters.total_annual_cost
         zlr_family = zlr.instance.family
         if zlr.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 100
         else:
             assert zlr.instance.drive.size_gib >= 100
 
@@ -238,7 +238,7 @@ def test_kv_plus_evcache_rps_exceeding_250k():
             if cluster.cluster_type == "cassandra"
         )
         if zlr_cass.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 100
         else:
             assert zlr_cass.instance.drive.size_gib >= 100
 
@@ -341,7 +341,7 @@ def test_kv_plus_evcache_rps_exceeding_100k_and_sufficient_read_write_ratio():
             if cluster.cluster_type == "cassandra"
         )
         if zlr_cass.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 100
         else:
             assert zlr_cass.instance.drive.size_gib >= 100
 
@@ -441,7 +441,7 @@ def test_kv_rps_exceeding_100k_but_insufficient_read_write_ratio():
             if cluster.cluster_type == "cassandra"
         )
         if zlr_cass.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 100
         else:
             assert zlr_cass.instance.drive.size_gib >= 100
 
@@ -521,7 +521,7 @@ def test_kv_plus_evcache_configured_read_write_ratio_threshold():
             if cluster.cluster_type == "cassandra"
         )
         if zlr_cass.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr_cass.attached_drives) >= 100
         else:
             assert zlr_cass.instance.drive.size_gib >= 100
 

--- a/tests/netflix/test_time_series.py
+++ b/tests/netflix/test_time_series.py
@@ -106,7 +106,7 @@ def test_timeseries_increasing_qps_simple():
         zlr_cost = cap_plan.least_regret[0].candidate_clusters.total_annual_cost
         zlr_family = zlr.instance.family
         if zlr.instance.drive is None:
-            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 200
+            assert sum(dr.size_gib for dr in zlr.attached_drives) >= 100
         else:
             assert zlr.instance.drive.size_gib >= 100
 


### PR DESCRIPTION
Change default EBS provisioning increments from 200G to 100G