### PR TITLE
Add min parallelism and fix the build

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,15 +1,16 @@
 name: Build
 
-on: [push, pull_request]
-
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  pull_request:
 jobs:
   build:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-
-    runs-on: ubuntu-latest
-
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox and any other packages
       run: pip install tox
-    - name: Run Tox (pydantic v1)
+    - name: Run end-to-end test suite
       run: tox -e py
-    - name: Run Tox (full pre-commit check)
+    - name: Run linters via pre-commit
       run: tox -e pre-commit

--- a/service_capacity_modeling/hardware/profiles/__init__.py
+++ b/service_capacity_modeling/hardware/profiles/__init__.py
@@ -1,8 +1,8 @@
 try:
-    import importlib.resources as pkg_resources
+    from importlib import resources
     from importlib import import_module
 except ImportError:
-    import importlib_resources as pkg_resources  # type: ignore[no-redef]
+    import importlib_resources as resources  # type: ignore[no-redef]
 
     import_module = __import__  # type: ignore[assignment]
 
@@ -12,7 +12,7 @@ from pathlib import Path
 current_module = import_module(__name__)
 common_profiles = {}
 
-with pkg_resources.path(  # pylint: disable=deprecated-method
+with resources.path(  # pylint: disable=deprecated-method
     current_module, "profiles.txt"
 ) as shape_file:
     shapes = Path(shape_file.parent, "shapes")

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -560,6 +560,28 @@ class QueryPattern(ExcludeUnsetModel):
     estimated_mean_read_size_bytes: Interval = certain_int(AVG_ITEM_SIZE_BYTES)
     estimated_mean_write_size_bytes: Interval = certain_int(AVG_ITEM_SIZE_BYTES // 2)
 
+    # For workloads which have bursts of async work, what is the
+    # expected parallelism of those workloads. Note the summation of
+    # read and write parallelism will lower bound the number of cores.
+    estimated_read_parallelism: Interval = Field(
+        certain_int(1),
+        title="Estimated per instance parallelism on read operations",
+        description=(
+            "The estimated amount of parallel work streams on a single "
+            "host. For example a read triggers async callbacks that need "
+            "to be executed truly in parallel (not just concurrent)."
+        ),
+    )
+    estimated_write_parallelism: Interval = Field(
+        certain_int(1),
+        title="Estimated per instance parallelism on write operations",
+        description=(
+            "The estimated amount of parallel work streams on a single "
+            "host. For example a write triggers async fanouts that need "
+            "to be executed truly in parallel (not just concurrent)."
+        ),
+    )
+
     # The latencies at which oncall engineers get involved. We want
     # to provision such that we don't involve oncall
     # Note that these summary statistics will be used to create reasonable

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37, py38, py39
+envlist=py38, py39, py310
 
 [testenv]
 usedevelop = True
@@ -15,7 +15,7 @@ commands =
 
 [testenv:dev]
 envdir = .tox/dev
-basepython=python3.8
+basepython=python3.10
 passenv = *
 deps =
     ipython

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 
 [testenv:notebook]
 envdir = .tox/notebook
-basepython=python3.8
+basepython=python3.10
 passenv = *
 deps =
     matplotlib


### PR DESCRIPTION
There are workloads which require more vertical scaling due to required parallelism, so now the planner can take read and write parallelism into account.

For example, imagine that a Java process creates 4 concurrent futures in response to a read request, then it needs at least 4 cores for that workload to run in parallel (as opposed to concurrent). The defaults are 1+1 for read+write which means our minimum instance size is effectively 2 cores. Given that hyperthreading is the default for most AWS instances this is reasonable.

Python 3.7 is [EOL](https://devguide.python.org/versions/) so remove testing that and add in Python 3.10.

