### PR TITLE
Add WAL to Capacity Planner

### DIFF
--- a/service_capacity_modeling/models/org/netflix/__init__.py
+++ b/service_capacity_modeling/models/org/netflix/__init__.py
@@ -15,6 +15,7 @@ from .postgres import nflx_postgres_capacity_model
 from .rds import nflx_rds_capacity_model
 from .stateless_java import nflx_java_app_capacity_model
 from .time_series import nflx_time_series_capacity_model
+from .wal import nflx_wal_capacity_model
 from .zookeeper import nflx_zookeeper_capacity_model
 
 
@@ -38,4 +39,5 @@ def models():
         "org.netflix.postgres": nflx_postgres_capacity_model,
         "org.netflix.kafka": nflx_kafka_capacity_model,
         "org.netflix.dynamodb": nflx_ddb_capacity_model,
+        "org.netflix.wal": nflx_wal_capacity_model,
     }

--- a/service_capacity_modeling/models/org/netflix/wal.py
+++ b/service_capacity_modeling/models/org/netflix/wal.py
@@ -1,0 +1,121 @@
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+from .stateless_java import nflx_java_app_capacity_model
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import FixedInterval
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.models import CapacityModel
+
+
+class NflxWALCapacityModel(CapacityModel):
+    @staticmethod
+    def capacity_plan(
+        instance: Instance,
+        drive: Drive,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+    ) -> Optional[CapacityPlan]:
+
+        wal_app = nflx_java_app_capacity_model.capacity_plan(
+            instance=instance,
+            drive=drive,
+            context=context,
+            desires=desires,
+            extra_model_arguments=extra_model_arguments,
+        )
+        if wal_app is None:
+            return None
+
+        for cluster in wal_app.candidate_clusters.regional:
+            cluster.cluster_type = "dgwwal"
+        return wal_app
+
+    @staticmethod
+    def description():
+        return "Netflix Streaming WAL Model"
+
+    @staticmethod
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return nflx_java_app_capacity_model.extra_model_arguments_schema()
+
+    @staticmethod
+    def compose_with(
+        user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
+    ) -> Tuple[Tuple[str, Callable[[CapacityDesires], CapacityDesires]], ...]:
+        provision_kv_shard = extra_model_arguments.get("wal.provisionkvshard", False)
+        if provision_kv_shard:
+            return (("org.netflix.key-value", lambda x: x),)
+        else:
+            return ()
+
+    @staticmethod
+    def default_desires(user_desires, extra_model_arguments):
+        return CapacityDesires(
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                access_consistency=GlobalConsistency(
+                    same_region=Consistency(
+                        target_consistency=AccessConsistency.read_your_writes,
+                    ),
+                    cross_region=Consistency(
+                        target_consistency=AccessConsistency.eventual,
+                    ),
+                ),
+                estimated_mean_read_size_bytes=Interval(
+                    low=128, mid=1024, high=65536, confidence=0.95
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=64, mid=128, high=1024, confidence=0.95
+                ),
+                # KV scan queries can be more expensive
+                estimated_mean_read_latency_ms=Interval(
+                    low=0.2, mid=4, high=6, confidence=0.98
+                ),
+                estimated_mean_write_latency_ms=Interval(
+                    low=0.2, mid=1, high=2, confidence=0.98
+                ),
+                # Assume they're doing GetItems scans -> slow reads
+                read_latency_slo_ms=FixedInterval(
+                    minimum_value=1,
+                    maximum_value=100,
+                    low=1,
+                    mid=8,
+                    high=90,
+                    confidence=0.98,
+                ),
+                # Assume they're doing PutRecords (BATCH)
+                write_latency_slo_ms=FixedInterval(
+                    minimum_value=1,
+                    maximum_value=20,
+                    low=2,
+                    mid=4,
+                    high=10,
+                    confidence=0.98,
+                ),
+            ),
+            # Most throughput KV clusters are large
+            data_shape=DataShape(
+                estimated_state_size_gib=Interval(
+                    low=100, mid=1000, high=4000, confidence=0.98
+                ),
+                reserved_instance_app_mem_gib=8,
+            ),
+        )
+
+
+nflx_wal_capacity_model = NflxWALCapacityModel()

--- a/service_capacity_modeling/models/org/netflix/wal.py
+++ b/service_capacity_modeling/models/org/netflix/wal.py
@@ -82,14 +82,12 @@ class NflxWALCapacityModel(CapacityModel):
                 estimated_mean_write_size_bytes=Interval(
                     low=64, mid=128, high=1024, confidence=0.95
                 ),
-                # KV scan queries can be more expensive
                 estimated_mean_read_latency_ms=Interval(
                     low=0.2, mid=4, high=6, confidence=0.98
                 ),
                 estimated_mean_write_latency_ms=Interval(
                     low=0.2, mid=1, high=2, confidence=0.98
                 ),
-                # Assume they're doing GetItems scans -> slow reads
                 read_latency_slo_ms=FixedInterval(
                     minimum_value=1,
                     maximum_value=100,
@@ -98,7 +96,6 @@ class NflxWALCapacityModel(CapacityModel):
                     high=90,
                     confidence=0.98,
                 ),
-                # Assume they're doing PutRecords (BATCH)
                 write_latency_slo_ms=FixedInterval(
                     minimum_value=1,
                     maximum_value=20,
@@ -108,7 +105,7 @@ class NflxWALCapacityModel(CapacityModel):
                     confidence=0.98,
                 ),
             ),
-            # Most throughput KV clusters are large
+            # Most throughput WAL clusters are large
             data_shape=DataShape(
                 estimated_state_size_gib=Interval(
                     low=100, mid=1000, high=4000, confidence=0.98

--- a/tests/netflix/test_wal.py
+++ b/tests/netflix/test_wal.py
@@ -1,5 +1,3 @@
-from inspect import walktree
-
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import DataShape
@@ -36,7 +34,7 @@ def test_wal_increasing_qps_simple():
             region="us-east-1",
             desires=simple,
             simulations=256,
-            extra_model_arguments={"wal.provisionkvshard": False}
+            extra_model_arguments={"wal.provisionkvshard": False},
         )
 
         # the set of cluster types the planner chose
@@ -97,7 +95,7 @@ def test_wal_increasing_qps_item_count_unset():
             region="us-east-1",
             desires=simple,
             simulations=256,
-            extra_model_arguments={"wal.provisionkvshard": False}
+            extra_model_arguments={"wal.provisionkvshard": False},
         )
 
         # the set of cluster types the planner chose
@@ -158,7 +156,7 @@ def test_wal_increasing_qps_simple_with_kv_shard():
             region="us-east-1",
             desires=simple,
             simulations=256,
-            extra_model_arguments={"wal.provisionkvshard": True}
+            extra_model_arguments={"wal.provisionkvshard": True},
         )
 
         # the set of cluster types the planner chose
@@ -221,7 +219,7 @@ def test_wal_increasing_qps_item_count_unset_with_kv_shard():
             region="us-east-1",
             desires=simple,
             simulations=256,
-            extra_model_arguments={"wal.provisionkvshard": True}
+            extra_model_arguments={"wal.provisionkvshard": True},
         )
 
         # the set of cluster types the planner chose

--- a/tests/netflix/test_wal.py
+++ b/tests/netflix/test_wal.py
@@ -1,0 +1,255 @@
+from inspect import walktree
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
+
+def test_wal_increasing_qps_simple():
+    qps_values = (100, 1000, 10_000, 100_000)
+    wal_results_trend = []
+    for qps in qps_values:
+        simple = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_write_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=1024, mid=1024 * 10, high=1024 * 100, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                estimated_state_item_count=Interval(
+                    low=1000000, mid=10000000, high=100000000, confidence=0.98
+                ),
+            ),
+        )
+
+        cap_plan = planner.plan(
+            model_name="org.netflix.wal",
+            region="us-east-1",
+            desires=simple,
+            simulations=256,
+            extra_model_arguments={"wal.provisionkvshard": False}
+        )
+
+        # the set of cluster types the planner chose
+        types = {
+            c.cluster_type
+            for c in list(cap_plan.least_regret[0].candidate_clusters.regional)
+            + list(cap_plan.least_regret[0].candidate_clusters.zonal)
+        }
+        assert sorted(types) == [
+            "dgwwal",
+        ]
+
+        # Check the Java cluster
+        wal_plan = next(
+            filter(
+                lambda c: c.cluster_type == "dgwwal",
+                cap_plan.least_regret[0].candidate_clusters.regional,
+            )
+        )
+        wal_results_trend.append((wal_plan.count * wal_plan.instance.cpu,))
+        # We just want ram and cpus for a java app
+        assert wal_plan.instance.family[0] in ("m", "r")
+        # We should never be paying for ephemeral drives
+        assert wal_plan.instance.drive is None
+
+    # Should have more capacity as requirement increases
+    x = [r[0] for r in wal_results_trend]
+    assert x[0] < x[-1]
+    assert sorted(x) == x
+
+
+def test_wal_increasing_qps_item_count_unset():
+    qps_values = (100, 1000, 10_000, 100_000)
+    wal_results_trend = []
+    for qps in qps_values:
+        simple = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_write_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=1024, mid=1024 * 10, high=1024 * 100, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=Interval(
+                    low=10, mid=100, high=1000, confidence=0.98
+                ),
+            ),
+        )
+
+        cap_plan = planner.plan(
+            model_name="org.netflix.wal",
+            region="us-east-1",
+            desires=simple,
+            simulations=256,
+            extra_model_arguments={"wal.provisionkvshard": False}
+        )
+
+        # the set of cluster types the planner chose
+        types = {
+            c.cluster_type
+            for c in list(cap_plan.least_regret[0].candidate_clusters.regional)
+            + list(cap_plan.least_regret[0].candidate_clusters.zonal)
+        }
+        assert sorted(types) == [
+            "dgwwal",
+        ]
+
+        # Check the Java cluster
+        wal_plan = next(
+            filter(
+                lambda c: c.cluster_type == "dgwwal",
+                cap_plan.least_regret[0].candidate_clusters.regional,
+            )
+        )
+        wal_results_trend.append((wal_plan.count * wal_plan.instance.cpu,))
+        # We just want ram and cpus for a java app
+        assert wal_plan.instance.family[0] in ("m", "r")
+        # We should never be paying for ephemeral drives
+        assert wal_plan.instance.drive is None
+
+    # Should have more capacity as requirement increases
+    x = [r[0] for r in wal_results_trend]
+    assert x[0] < x[-1]
+    assert sorted(x) == x
+
+
+def test_wal_increasing_qps_simple_with_kv_shard():
+    qps_values = (100, 1000, 10_000, 100_000)
+    wal_results_trend = []
+    for qps in qps_values:
+        simple = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_write_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=1024, mid=1024 * 10, high=1024 * 100, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                estimated_state_item_count=Interval(
+                    low=1000000, mid=10000000, high=100000000, confidence=0.98
+                ),
+            ),
+        )
+
+        cap_plan = planner.plan(
+            model_name="org.netflix.wal",
+            region="us-east-1",
+            desires=simple,
+            simulations=256,
+            extra_model_arguments={"wal.provisionkvshard": True}
+        )
+
+        # the set of cluster types the planner chose
+        types = {
+            c.cluster_type
+            for c in list(cap_plan.least_regret[0].candidate_clusters.regional)
+            + list(cap_plan.least_regret[0].candidate_clusters.zonal)
+        }
+        assert sorted(types) == [
+            "cassandra",
+            "dgwkv",
+            "dgwwal",
+        ]
+
+        # Check the Java cluster
+        wal_plan = next(
+            filter(
+                lambda c: c.cluster_type == "dgwwal",
+                cap_plan.least_regret[0].candidate_clusters.regional,
+            )
+        )
+        wal_results_trend.append((wal_plan.count * wal_plan.instance.cpu,))
+        # We just want ram and cpus for a java app
+        assert wal_plan.instance.family[0] in ("m", "r")
+        # We should never be paying for ephemeral drives
+        assert wal_plan.instance.drive is None
+
+    # Should have more capacity as requirement increases
+    x = [r[0] for r in wal_results_trend]
+    assert x[0] < x[-1]
+    assert sorted(x) == x
+
+
+def test_wal_increasing_qps_item_count_unset_with_kv_shard():
+    qps_values = (100, 1000, 10_000, 100_000)
+    wal_results_trend = []
+    for qps in qps_values:
+        simple = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_write_per_second=Interval(
+                    low=qps // 10, mid=qps, high=qps * 10, confidence=0.98
+                ),
+                estimated_mean_write_size_bytes=Interval(
+                    low=1024, mid=1024 * 10, high=1024 * 100, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=Interval(
+                    low=10, mid=100, high=1000, confidence=0.98
+                ),
+            ),
+        )
+
+        cap_plan = planner.plan(
+            model_name="org.netflix.wal",
+            region="us-east-1",
+            desires=simple,
+            simulations=256,
+            extra_model_arguments={"wal.provisionkvshard": True}
+        )
+
+        # the set of cluster types the planner chose
+        types = {
+            c.cluster_type
+            for c in list(cap_plan.least_regret[0].candidate_clusters.regional)
+            + list(cap_plan.least_regret[0].candidate_clusters.zonal)
+        }
+        assert sorted(types) == [
+            "cassandra",
+            "dgwkv",
+            "dgwwal",
+        ]
+
+        # Check the Java cluster
+        wal_plan = next(
+            filter(
+                lambda c: c.cluster_type == "dgwwal",
+                cap_plan.least_regret[0].candidate_clusters.regional,
+            )
+        )
+        wal_results_trend.append((wal_plan.count * wal_plan.instance.cpu,))
+        # We just want ram and cpus for a java app
+        assert wal_plan.instance.family[0] in ("m", "r")
+        # We should never be paying for ephemeral drives
+        assert wal_plan.instance.drive is None
+
+    # Should have more capacity as requirement increases
+    x = [r[0] for r in wal_results_trend]
+    assert x[0] < x[-1]
+    assert sorted(x) == x


### PR DESCRIPTION
Normally WAL will provision as normal as a stateless Java app.

If `wal.provisionkvshard` is true (multi partition mutations are required), WAL will also provision KV with the same desires.