### PR TITLE
Flesh out CurrentClusters in CapacityDesires input.

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -642,12 +642,6 @@ class CapacityPlanner:
             num_regions=num_regions,
         )
 
-        # We should not even bother with shapes that don't meet the minimums
-        (
-            per_instance_cores,
-            per_instance_mem,
-        ) = self._per_instance_requirements(desires)
-
         allowed_platforms: Set[Platform] = set(model.allowed_platforms())
         allowed_drives: Set[str] = set(drives or [])
         for drive_name in model.allowed_cloud_drives():
@@ -660,6 +654,12 @@ class CapacityPlanner:
 
         # Set current instance object if exists
         _set_instance_objects(desires, hardware)
+
+        # We should not even bother with shapes that don't meet the minimums
+        (
+            per_instance_cores,
+            per_instance_mem,
+        ) = self._per_instance_requirements(desires)
 
         if model.run_hardware_simulation():
             for instance in hardware.instances.values():

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -606,16 +606,8 @@ class CapacityPlanner:
         if current_capacity is None or current_capacity.cluster_instance is None:
             return (per_instance_cores, per_instance_mem)
 
-        # Calculate CPU requirements based on current capacity
-        current_cpu_utilization = current_capacity.cpu_utilization.high / 100.0
-        current_instance_cpus = current_capacity.cluster_instance.cpu
-        required_cores = math.ceil(current_cpu_utilization * current_instance_cpus)
-        per_instance_cores = max(per_instance_cores, required_cores)
-
         # Calculate memory requirements based on current capacity
-        current_memory_utilization_gib = (
-            current_capacity.memory_utilization_mib.high / 1024
-        )
+        current_memory_utilization_gib = current_capacity.memory_utilization_gib.high
         per_instance_mem = max(per_instance_mem, current_memory_utilization_gib)
 
         return (per_instance_cores, per_instance_mem)

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -679,7 +679,12 @@ class CurrentClusterCapacity(ExcludeUnsetModel):
     cluster_instance_name: str
     cluster_instance: Optional[Instance] = None
     cluster_instance_count: Interval
+    # The distribution cpu utilization in the cluster.
     cpu_utilization: Interval
+    # The per node distribution of memory used in mib.
+    memory_utilization_mib: Interval
+    # The per node distribution of network used in mbps.
+    network_utilization_mbps: Interval
 
 
 # For services that are provisioned by zone (e.g. Cassandra, EVCache)

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -681,8 +681,8 @@ class CurrentClusterCapacity(ExcludeUnsetModel):
     cluster_instance_count: Interval
     # The distribution cpu utilization in the cluster.
     cpu_utilization: Interval
-    # The per node distribution of memory used in mib.
-    memory_utilization_mib: Interval
+    # The per node distribution of memory used in gib.
+    memory_utilization_gib: Interval
     # The per node distribution of network used in mbps.
     network_utilization_mbps: Interval
 

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -361,6 +361,8 @@ def test_plan_certain():
         cpu_utilization=Interval(
             low=10.12, mid=13.2, high=14.194801291058118, confidence=1
         ),
+        memory_utilization_mib=certain_float(32.0),
+        network_utilization_mbps=certain_float(128.0),
     )
 
     worn_desire = CapacityDesires(

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -361,7 +361,7 @@ def test_plan_certain():
         cpu_utilization=Interval(
             low=10.12, mid=13.2, high=14.194801291058118, confidence=1
         ),
-        memory_utilization_mib=certain_float(32.0),
+        memory_utilization_gib=certain_float(32.0),
         network_utilization_mbps=certain_float(128.0),
     )
 

--- a/tests/test_generate_scenarios.py
+++ b/tests/test_generate_scenarios.py
@@ -7,7 +7,6 @@ from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentRegionClusterCapacity
-from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import Lifecycle
 from service_capacity_modeling.interface import Platform
 
@@ -133,13 +132,6 @@ def test_generate_scenarios_current_resources():
     desires.current_clusters.regional = [
         CurrentRegionClusterCapacity(
             cluster_instance_name="m5.12xlarge",
-            cluster_instance=Instance(
-                name="m5.12xlarge",
-                cpu=48,
-                cpu_ghz=3.1,
-                ram_gib=192,
-                net_mbps=10000,
-            ),
             cluster_instance_count=certain_int(5),
             cpu_utilization=certain_float(16.0),
             memory_utilization_mib=certain_float(32 * 1024),

--- a/tests/test_generate_scenarios.py
+++ b/tests/test_generate_scenarios.py
@@ -1,0 +1,163 @@
+from typing import List
+from unittest.mock import Mock
+
+from service_capacity_modeling.capacity_planner import CapacityPlanner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentRegionClusterCapacity
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Lifecycle
+from service_capacity_modeling.interface import Platform
+
+
+def test_generate_scenarios():
+    # Create a CapacityPlanner instance
+    planner = CapacityPlanner()
+
+    # Mock the model
+    model = Mock()
+    model.allowed_platforms.return_value = {Platform.amd64}
+    model.allowed_cloud_drives.return_value = {}
+    model.run_hardware_simulation.return_value = True
+
+    region = "us-east-1"
+    desires = CapacityDesires()
+    num_regions = 3
+    lifecycles = [Lifecycle.stable]
+    instance_families: List[str] = []
+    drives: List[str] = []
+
+    # Call generate_scenarios
+    scenarios = list(
+        planner.generate_scenarios(
+            model, region, desires, num_regions, lifecycles, instance_families, drives
+        )
+    )
+
+    # Check we got some instances
+    assert len(scenarios) > 0
+
+
+def test_generate_scenarios_limit_family():
+    # Create a CapacityPlanner instance
+    planner = CapacityPlanner()
+
+    # Mock the model
+    model = Mock()
+    model.allowed_platforms.return_value = {Platform.amd64}
+    model.allowed_cloud_drives.return_value = {}
+    model.run_hardware_simulation.return_value = True
+
+    region = "us-east-1"
+    desires = CapacityDesires()
+    num_regions = 3
+    lifecycles = [Lifecycle.stable]
+    # Limit to m5 family
+    instance_families = ["m5"]
+    drives: List[str] = []
+
+    # Call generate_scenarios
+    scenarios = list(
+        planner.generate_scenarios(
+            model, region, desires, num_regions, lifecycles, instance_families, drives
+        )
+    )
+
+    # Check we got m5s
+    assert len(scenarios) > 0
+    for instance, _, _ in scenarios:
+        assert instance.family == "m5"
+
+
+def test_generate_scenarios_desire_resources():
+    # Create a CapacityPlanner instance
+    planner = CapacityPlanner()
+
+    # Mock the model
+    model = Mock()
+    model.allowed_platforms.return_value = {Platform.amd64}
+    model.allowed_cloud_drives.return_value = {}
+    model.run_hardware_simulation.return_value = True
+
+    region = "us-east-1"
+    num_regions = 3
+    lifecycles = [Lifecycle.stable]
+    # Limit to m5 family
+    instance_families = ["m5"]
+    drives: List[str] = []
+
+    desires = CapacityDesires()
+    # Set cpu and memory requirements via application desires
+    desires.data_shape.reserved_instance_app_mem_gib = 64
+    desires.data_shape.reserved_instance_system_mem_gib = 0
+    desires.query_pattern.estimated_read_parallelism = certain_int(16)
+    desires.query_pattern.estimated_write_parallelism = certain_int(0)
+
+    # Call generate_scenarios
+    scenarios = list(
+        planner.generate_scenarios(
+            model, region, desires, num_regions, lifecycles, instance_families, drives
+        )
+    )
+
+    # Check we got m5s
+    assert len(scenarios) > 0
+    for instance, _, _ in scenarios:
+        assert instance.family == "m5"
+        assert instance.cpu >= 16
+        assert instance.ram_gib >= 64
+
+
+def test_generate_scenarios_current_resources():
+    # Create a CapacityPlanner instance
+    planner = CapacityPlanner()
+
+    # Mock the model
+    model = Mock()
+    model.allowed_platforms.return_value = {Platform.amd64}
+    model.allowed_cloud_drives.return_value = {}
+    model.run_hardware_simulation.return_value = True
+
+    region = "us-east-1"
+    num_regions = 3
+    lifecycles = [Lifecycle.stable]
+    # Limit to m5 family
+    instance_families = ["m5"]
+    drives: List[str] = []
+
+    desires = CapacityDesires()
+    # Set cpu and memory requirements via current capacity
+    desires.current_clusters = CurrentClusters()
+    desires.current_clusters.regional = [
+        CurrentRegionClusterCapacity(
+            cluster_instance_name="m5.12xlarge",
+            cluster_instance=Instance(
+                name="m5.12xlarge",
+                cpu=48,
+                cpu_ghz=3.1,
+                ram_gib=192,
+                net_mbps=10000,
+            ),
+            cluster_instance_count=certain_int(5),
+            cpu_utilization=certain_float(16.0),
+            memory_utilization_mib=certain_float(32 * 1024),
+            network_utilization_mbps=certain_float(128.0),
+        )
+    ]
+
+    # Call generate_scenarios
+    scenarios = list(
+        planner.generate_scenarios(
+            model, region, desires, num_regions, lifecycles, instance_families, drives
+        )
+    )
+
+    # Check we got m5s
+    assert len(scenarios) > 0
+    for instance, _, _ in scenarios:
+        assert instance.family == "m5"
+        assert instance.cpu >= 48 * 0.16
+        assert instance.ram_gib >= 32
+        assert instance.net_mbps >= 128

--- a/tests/test_generate_scenarios.py
+++ b/tests/test_generate_scenarios.py
@@ -133,8 +133,8 @@ def test_generate_scenarios_current_resources():
         CurrentRegionClusterCapacity(
             cluster_instance_name="m5.12xlarge",
             cluster_instance_count=certain_int(5),
-            cpu_utilization=certain_float(16.0),
-            memory_utilization_mib=certain_float(32 * 1024),
+            cpu_utilization=certain_float(100.0),
+            memory_utilization_gib=certain_float(16),
             network_utilization_mbps=certain_float(128.0),
         )
     ]
@@ -150,6 +150,4 @@ def test_generate_scenarios_current_resources():
     assert len(scenarios) > 0
     for instance, _, _ in scenarios:
         assert instance.family == "m5"
-        assert instance.cpu >= 48 * 0.16
-        assert instance.ram_gib >= 32
-        assert instance.net_mbps >= 128
+        assert instance.ram_gib >= 16


### PR DESCRIPTION
We now have cpu, memory, and network utilization in the CurrentCapacity section of the CapacityDesires input. Furthermore the generate_scenarios() call which filters out instances now takes that shape into account.

This allows for callers of the plan api to (optionally) input the current cluster capacity and use that to inform instance selection. Models can furthermore use this to determine cluster size based on current utilziation.