### PR TITLE
Capacity planner for GraphKV abstraction

### DIFF
--- a/service_capacity_modeling/models/org/netflix/__init__.py
+++ b/service_capacity_modeling/models/org/netflix/__init__.py
@@ -9,6 +9,7 @@ from .elasticsearch import nflx_elasticsearch_master_capacity_model
 from .elasticsearch import nflx_elasticsearch_search_capacity_model
 from .entity import nflx_entity_capacity_model
 from .evcache import nflx_evcache_capacity_model
+from .graphkv import nflx_graphkv_capacity_model
 from .kafka import nflx_kafka_capacity_model
 from .key_value import nflx_key_value_capacity_model
 from .postgres import nflx_postgres_capacity_model
@@ -40,4 +41,5 @@ def models():
         "org.netflix.kafka": nflx_kafka_capacity_model,
         "org.netflix.dynamodb": nflx_ddb_capacity_model,
         "org.netflix.wal": nflx_wal_capacity_model,
+        "org.netflix.graphkv": nflx_graphkv_capacity_model,
     }

--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -1,0 +1,206 @@
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+from .stateless_java import nflx_java_app_capacity_model
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import FixedInterval
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.models import CapacityModel
+
+
+class NflxGraphKVCapacityModel(CapacityModel):
+    @staticmethod
+    def capacity_plan(
+        instance: Instance,
+        drive: Drive,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+    ) -> Optional[CapacityPlan]:
+
+        graphkv_app = nflx_java_app_capacity_model.capacity_plan(
+            instance=instance,
+            drive=drive,
+            context=context,
+            desires=desires,
+            extra_model_arguments=extra_model_arguments,
+        )
+        if graphkv_app is None:
+            return None
+
+        for cluster in graphkv_app.candidate_clusters.regional:
+            cluster.cluster_type = "dgwgraphkv"
+        return graphkv_app
+
+    @staticmethod
+    def description():
+        return "Netflix Streaming Graph Abstraction"
+
+    @staticmethod
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return nflx_java_app_capacity_model.extra_model_arguments_schema()
+
+    @staticmethod
+    def compose_with(
+        user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
+    ) -> Tuple[Tuple[str, Callable[[CapacityDesires], CapacityDesires]], ...]:
+        def _modify_kv_desires(
+            user_desires: CapacityDesires,
+        ) -> CapacityDesires:
+            relaxed = user_desires.model_copy(deep=True)
+
+            # TODO: introduce a custom config file for graphkv
+            default_amplification = 10
+            relaxed.query_pattern.estimated_read_per_second = (
+                user_desires.query_pattern.estimated_read_per_second.scale(
+                    default_amplification
+                )
+            )
+            relaxed.query_pattern.estimated_write_per_second = (
+                user_desires.query_pattern.estimated_write_per_second.scale(
+                    default_amplification
+                )
+            )
+
+            item_count = relaxed.data_shape.estimated_state_item_count
+            if item_count is None:
+                # assume 1 KB items
+                if (
+                    user_desires.query_pattern.estimated_mean_write_size_bytes
+                    is not None
+                ):
+                    item_size_gib = (
+                        user_desires.query_pattern.estimated_mean_write_size_bytes.mid
+                        / 1024**3
+                    )
+                else:
+                    item_size_gib = 1 / 1024**2
+                item_count = user_desires.data_shape.estimated_state_size_gib.scale(
+                    1 / item_size_gib
+                )
+            # assume 512 B to track the id and metadata write_ts of each item
+            relaxed.data_shape.estimated_state_size_gib = item_count.scale(
+                512 / 1024**3
+            )
+            return relaxed
+
+        return (("org.netflix.key-value", _modify_kv_desires),)
+
+    @staticmethod
+    def default_desires(user_desires, extra_model_arguments):
+        if user_desires.query_pattern.access_pattern == AccessPattern.latency:
+            return CapacityDesires(
+                query_pattern=QueryPattern(
+                    access_pattern=AccessPattern.latency,
+                    access_consistency=GlobalConsistency(
+                        same_region=Consistency(
+                            target_consistency=AccessConsistency.read_your_writes,
+                        ),
+                        cross_region=Consistency(
+                            target_consistency=AccessConsistency.eventual,
+                        ),
+                    ),
+                    estimated_mean_read_size_bytes=Interval(
+                        low=128, mid=1024, high=65536, confidence=0.95
+                    ),
+                    estimated_mean_write_size_bytes=Interval(
+                        low=64, mid=128, high=1024, confidence=0.95
+                    ),
+                    estimated_mean_read_latency_ms=Interval(
+                        low=0.2, mid=1, high=2, confidence=0.98
+                    ),
+                    estimated_mean_write_latency_ms=Interval(
+                        low=0.2, mid=1, high=2, confidence=0.98
+                    ),
+                    # "Single digit milliseconds SLO"
+                    read_latency_slo_ms=FixedInterval(
+                        minimum_value=0.2,
+                        maximum_value=10,
+                        low=1,
+                        mid=3,
+                        high=6,
+                        confidence=0.98,
+                    ),
+                    write_latency_slo_ms=FixedInterval(
+                        minimum_value=0.2,
+                        maximum_value=10,
+                        low=0.4,
+                        mid=2,
+                        high=5,
+                        confidence=0.98,
+                    ),
+                ),
+                data_shape=DataShape(
+                    estimated_state_size_gib=Interval(
+                        low=10, mid=50, high=200, confidence=0.98
+                    ),
+                    reserved_instance_app_mem_gib=8,
+                ),
+            )
+        else:
+            return CapacityDesires(
+                query_pattern=QueryPattern(
+                    access_pattern=AccessPattern.latency,
+                    access_consistency=GlobalConsistency(
+                        same_region=Consistency(
+                            target_consistency=AccessConsistency.read_your_writes,
+                        ),
+                        cross_region=Consistency(
+                            target_consistency=AccessConsistency.eventual,
+                        ),
+                    ),
+                    estimated_mean_read_size_bytes=Interval(
+                        low=128, mid=1024, high=65536, confidence=0.95
+                    ),
+                    estimated_mean_write_size_bytes=Interval(
+                        low=64, mid=128, high=1024, confidence=0.95
+                    ),
+                    estimated_mean_read_latency_ms=Interval(
+                        low=0.2, mid=4, high=6, confidence=0.98
+                    ),
+                    estimated_mean_write_latency_ms=Interval(
+                        low=0.2, mid=1, high=2, confidence=0.98
+                    ),
+                    # Assume they're doing GetItems scans -> slow reads
+                    read_latency_slo_ms=FixedInterval(
+                        minimum_value=1,
+                        maximum_value=100,
+                        low=1,
+                        mid=8,
+                        high=90,
+                        confidence=0.98,
+                    ),
+                    # Assume they're doing PutRecords (BATCH)
+                    write_latency_slo_ms=FixedInterval(
+                        minimum_value=1,
+                        maximum_value=20,
+                        low=2,
+                        mid=4,
+                        high=10,
+                        confidence=0.98,
+                    ),
+                ),
+                # Most throughput GraphKV clusters are large
+                data_shape=DataShape(
+                    estimated_state_size_gib=Interval(
+                        low=100, mid=1000, high=4000, confidence=0.98
+                    ),
+                    reserved_instance_app_mem_gib=8,
+                ),
+            )
+
+
+nflx_graphkv_capacity_model = NflxGraphKVCapacityModel()

--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -63,15 +63,18 @@ class NflxGraphKVCapacityModel(CapacityModel):
             relaxed = user_desires.model_copy(deep=True)
 
             # TODO: introduce a custom config file for graphkv
-            default_amplification = 10
+            # forward edge, reverse edge, properties
+            avg_write_amplification = 3
+            average_node_fanout = 10
+            average_edge_mappings = 5
             relaxed.query_pattern.estimated_read_per_second = (
                 user_desires.query_pattern.estimated_read_per_second.scale(
-                    default_amplification
+                    average_node_fanout * average_edge_mappings
                 )
             )
             relaxed.query_pattern.estimated_write_per_second = (
                 user_desires.query_pattern.estimated_write_per_second.scale(
-                    default_amplification
+                    avg_write_amplification
                 )
             )
 

--- a/tests/netflix/test_graphkv.py
+++ b/tests/netflix/test_graphkv.py
@@ -1,0 +1,111 @@
+import pytest
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
+
+def create_interval(low, mid, high, confidence=0.98):
+    return Interval(low=low, mid=mid, high=high, confidence=confidence)
+
+
+def get_cluster_plan(cap_plan, cluster_type):
+    return next(
+        filter(
+            lambda c: c.cluster_type == cluster_type,
+            cap_plan.least_regret[0].candidate_clusters.regional,
+        )
+    )
+
+
+def create_capacity_desires(qps, data_shape_fn):
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=create_interval(qps // 10, qps, qps * 10),
+            estimated_write_per_second=create_interval(qps // 10, qps, qps * 10),
+            estimated_mean_write_size_bytes=create_interval(
+                1024, 1024 * 10, 1024 * 100
+            ),
+        ),
+        data_shape=data_shape_fn(qps),
+    )
+
+
+class TestGraphKVIncreasingQPS:
+    QPS_VALUES = (100, 1000, 10_000, 100_000)
+
+    @pytest.fixture(
+        params=[
+            pytest.param(
+                (
+                    "simple",
+                    lambda qps: DataShape(
+                        estimated_state_item_count=create_interval(
+                            1000000, 10000000, 100000000
+                        )
+                    ),
+                ),
+                id="with_item_count",
+            ),
+            pytest.param(
+                (
+                    "item_count_unset",
+                    lambda qps: DataShape(
+                        estimated_state_size_gib=create_interval(10, 100, 1000)
+                    ),
+                ),
+                id="with_state_size",
+            ),
+        ]
+    )
+    def data_shape_config(self, request):
+        return request.param
+
+    def test_graphkv_increasing_qps(self, data_shape_config):
+        _, data_shape_fn = data_shape_config
+        graphkv_results_trend = []
+        kv_results_trend = []
+
+        for qps in self.QPS_VALUES:
+            cap_plan = planner.plan(
+                model_name="org.netflix.graphkv",
+                region="us-east-1",
+                desires=create_capacity_desires(qps, data_shape_fn),
+                simulations=256,
+            )
+
+            # Verify cluster types
+            types = {
+                c.cluster_type
+                for c in list(cap_plan.least_regret[0].candidate_clusters.regional)
+                + list(cap_plan.least_regret[0].candidate_clusters.zonal)
+            }
+            assert sorted(types) == ["cassandra", "dgwgraphkv", "dgwkv"]
+
+            graphkv_plan = get_cluster_plan(cap_plan, "dgwgraphkv")
+            kv_plan = get_cluster_plan(cap_plan, "dgwkv")
+
+            # TODO: Add a comprehensive check based on request amplification
+            # Account for resource amplification
+            assert (
+                kv_plan.count > graphkv_plan.count
+                or kv_plan.instance.cpu > graphkv_plan.instance.cpu
+            )
+
+            kv_results_trend.append((kv_plan.count * kv_plan.instance.cpu,))
+            graphkv_results_trend.append(
+                (graphkv_plan.count * graphkv_plan.instance.cpu,)
+            )
+
+            for plan in (graphkv_plan, kv_plan):
+                assert plan.instance.family[0] in ("m", "r")
+                assert plan.instance.drive is None
+
+        # Verify capacity increases
+        for results in (graphkv_results_trend, kv_results_trend):
+            x = [r[0] for r in results]
+            assert x[0] < x[-1]
+            assert sorted(x) == x

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     isodate
     setuptools
     boto3
+    pytest
 commands =
     pre-commit run --all-files
 


### PR DESCRIPTION
This PR adds a simple capacity model for GraphKV, KV and Cassandra. In this V1 version, we add a custom hardcoded amplification factor read and write requests per second for KV. In the following versions, we will focus on building custom graphkv configs that we can leverage for deriving a better estimate of the amplification factor.