### PR TITLE
Revert "allow other types of intervals"

### DIFF
--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -248,8 +248,10 @@ class Drive(ExcludeUnsetModel):
 
     # These defaults are assuming a cloud SSD like a gp2 volume
     # If you disagree please change them in your hardware description
-    read_io_latency_ms: Interval = FixedInterval(low=0.8, mid=1, high=2, confidence=0.9)
-    write_io_latency_ms: Interval = FixedInterval(
+    read_io_latency_ms: FixedInterval = FixedInterval(
+        low=0.8, mid=1, high=2, confidence=0.9
+    )
+    write_io_latency_ms: FixedInterval = FixedInterval(
         low=0.6, mid=2, high=3, confidence=0.9
     )
 
@@ -447,8 +449,10 @@ class Service(ExcludeUnsetModel):
     annual_cost_per_core: float = 0
 
     # These defaults assume a cloud blob storage like S3
-    read_io_latency_ms: Interval = FixedInterval(low=1, mid=5, high=50, confidence=0.9)
-    write_io_latency_ms: Interval = FixedInterval(
+    read_io_latency_ms: FixedInterval = FixedInterval(
+        low=1, mid=5, high=50, confidence=0.9
+    )
+    write_io_latency_ms: FixedInterval = FixedInterval(
         low=1, mid=10, high=50, confidence=0.9
     )
 
@@ -604,7 +608,7 @@ class Consistency(ExcludeUnsetModel):
             " consistency models: https://jepsen.io/consistency"
         ),
     )
-    staleness_slo_sec: Interval = Field(
+    staleness_slo_sec: FixedInterval = Field(
         FixedInterval(low=0, mid=10, high=60),
         title="When stale reads are permitted what is the staleness requirement",
         description=(
@@ -676,10 +680,10 @@ class QueryPattern(ExcludeUnsetModel):
     # to provision such that we don't involve oncall
     # Note that these summary statistics will be used to create reasonable
     # distribution approximations of these operations (yielding p25, p99, etc)
-    read_latency_slo_ms: Interval = FixedInterval(
+    read_latency_slo_ms: FixedInterval = FixedInterval(
         low=0.4, mid=4, high=10, confidence=0.98
     )
-    write_latency_slo_ms: Interval = FixedInterval(
+    write_latency_slo_ms: FixedInterval = FixedInterval(
         low=0.4, mid=4, high=10, confidence=0.98
     )
 
@@ -727,7 +731,7 @@ class DataShape(ExcludeUnsetModel):
     # This is measured in orders of magnitude. So
     #   1000   = 1 - (1/1000) = 0.999
     #   10000  = 1 - (1/10000) = 0.9999
-    durability_slo_order: Interval = FixedInterval(
+    durability_slo_order: FixedInterval = FixedInterval(
         low=1000, mid=10000, high=100000, confidence=0.98
     )
 


### PR DESCRIPTION
Currently, if a user does not pass in `read_latency_slo_ms` or `write_latency_slo_ms` to `desires`, the following chain of events will occur in plan uncertain

1. `read/write_latency_slo_ms` will be set to `FixedInterval(low=0.4, mid=4, high=10, confidence=0.98)` from the `QueryPattern` defaults
2. The `read/write_latency_slo_ms` fields will then be filtered out when `desires_dict.model_dump()` is called during [`merge_with`](https://github.com/Netflix-Skunkworks/service-capacity-modeling/blob/7f4d537a9167940ad7ee4b16ffacf176d7477d45/service_capacity_modeling/capacity_planner.py#L843) and then replaced with the default desires from [models/org/netflix/rds.py](https://github.com/Netflix-Skunkworks/service-capacity-modeling/blob/b5ef07b5e6206a517373ac6a62edc3982775bea6/service_capacity_modeling/models/org/netflix/rds.py#L278) below
    - `read_latency_slo_ms=FixedInterval(
                    minimum_value=10,
                    maximum_value=2000,
                    low=300,
                    mid=800,
                    high=2000,
                    confidence=0.90
                ),`
3. The combination of defaults above then leads to `high` being set to 1 in `_beta_dist_from_interval` and therefore an [assertion error](https://github.com/Netflix-Skunkworks/service-capacity-modeling/blob/5d0368a607577430b9cef12ad4326f62916ad03d/service_capacity_modeling/stats.py#L93) in `_beta_cost_fn_from_params`


The only changes I made here was swapping the type of `read_latency_slo_ms`/`write_latency_slo_ms` back to `FixedInterval` which changes it back to the previous functionality of the QueryPattern defaults being used and therefore no error

However, I feel like the previous behavior of `QueryPattern` defaults being used instead of the `netflix/rds.py` was probably not correct and that @abersnaze change may have uncovered this silent bug. If it is the case that `netflix/rds.py` is what should be defaulted to when no `read`/`write_latency_slo_ms` is passed into desires, then this code should be left as is and `netflix/rds.py` should be updated with defaults that don't trigger the `AssertionError`

But to be clear a have incredibly little context on this code and all of these points could be wildly off 😅