### PR TITLE
Fix ZeroDivisionError from weighted_latency calculation

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -91,9 +91,11 @@ def sqrt_staffed_cores(desires: CapacityDesires) -> int:
     )
 
     total_rate = read_rps + write_rps
-    weighted_latency = (read_rps / total_rate) * read_lat + (
-        write_rps / total_rate
-    ) * write_lat
+    weighted_latency = (
+        (read_rps / total_rate) * read_lat + (write_rps / total_rate) * write_lat
+        if total_rate > 0
+        else 0
+    )
     # The alternative is to staff each workload separately, but that over
     # provisions cores as f(x) + f(y) > f(x+y) (sqrt staffing isn't linear)
     # read_cores = _sqrt_staffed_cores(read_rps, read_lat, qos)


### PR DESCRIPTION
`weighted_latency` calculation was dividing by 0 when `total_rate = 0`. This is was causing 500 errors in cdeselfservice for elasticsearch because we provision only on disk size

This defaults the weighted latency to 0 in this case which should result in the same behavior as before