### PR TITLE
Update aurora capacity planner to provision reader instances

### DIFF
--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -187,9 +187,16 @@ def _compute_aurora_region(  # pylint: disable=too-many-positional-arguments
         total_annual_cost,
     )
 
+    # TODO (ramsrivatsak): In future we need to leverage read traffic and model the
+    # number of reader instances based on the number of read IOPS.
+    # We add a reader instance if we are deploying a tier 0 and tier 1 service.
+    # Writer instance + Reader instance = 2. For other service tiers the writer instance
+    # is enough.
+    cluster_count = 2 if desires.service_tier <= 1 else 1
+
     return RegionClusterCapacity(
         cluster_type="aurora-cluster",
-        count=1,
+        count=cluster_count,
         instance=instance,
         attached_drives=attached_drives,
         annual_cost=total_annual_cost,

--- a/tests/netflix/test_aurora.py
+++ b/tests/netflix/test_aurora.py
@@ -143,6 +143,22 @@ def test_tier_3():
     assert_similar_compute(expected_shape=expected, actual_shape=leader)
 
 
+def test_cluster_count():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.aurora",
+        region="us-east-1",
+        desires=tier_3,
+    )
+    assert cap_plan[0].candidate_clusters.regional[0].count == 1
+
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.aurora",
+        region="us-east-1",
+        desires=large_footprint,
+    )
+    assert cap_plan[0].candidate_clusters.regional[0].count == 2
+
+
 def test_cap_plan():
     desire_json = """{
       "deploy_desires": {


### PR DESCRIPTION
Update aurora capacity planner to provision reader instances for tier 0 and tier 1 services.