### PR TITLE
[Cassandra] Enforce `required cluster size` in the extra model args to always be an int

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -574,8 +574,10 @@ class NflxCassandraCapacityModel(CapacityModel):
         require_attached_disks: bool = extra_model_arguments.get(
             "require_attached_disks", False
         )
-        required_cluster_size: Optional[int] = extra_model_arguments.get(
-            "required_cluster_size", None
+        required_cluster_size: Optional[int] = (
+            math.ceil(extra_model_arguments["required_cluster_size"])
+            if "required_cluster_size" in extra_model_arguments
+            else None
         )
         max_rps_to_disk: int = extra_model_arguments.get("max_rps_to_disk", 500)
         max_regional_size: int = extra_model_arguments.get("max_regional_size", 192)


### PR DESCRIPTION
The `required_cluster_size` value is rounded up to the nearest integer if it is provided in the `extra_model_arguments`. The downstream base models requires that this value is an int otherwise it will throw a validation exception. And due to the type hinting, this value can propogate very deep in the stack before throwing an exception.

There are 2 things we can handle this:
1. Reject the request and throw an error
2. Take the ceiling of the cluster size and proceed with the computation.

Upstream apis don't have a good way of knowing the required value for these fields since this extra model args is typed extremely loosely.  So I'm open to option (2)