### PR TITLE
Run linters before end-to-end test suite for faster build result

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox and any other packages
       run: pip install tox
-    - name: Run end-to-end test suite
-      run: tox -e py
     - name: Run linters via pre-commit
       run: tox -e pre-commit
+    - name: Run end-to-end test suite
+      run: tox -e py
   release:
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Currently, the linter runs as the last step in the build. This results in builds failing for lint issues (if not checked locally) after 30-40 mins after the end-to-end test suite finishes running. Instead we can move it up before the tests so it can fail faster and PR submitter can fix sooner rather than waiting another 30 mins.