### PR TITLE
Allowing multiple capacity plans for the same family

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -577,7 +577,10 @@ class CapacityPlanner:
         plans.sort(key=lambda p: (p.rank, p.candidate_clusters.total_annual_cost))
 
         num_results = num_results or self._default_num_results
-        return reduce_by_family(plans)[:num_results]
+        max_per_family = extra_model_arguments.get("max_results_per_family", 1)
+        return reduce_by_family(plans, max_results_per_family=max_per_family)[
+            :num_results
+        ]
 
     # Calculates the minimum cpu, memory, and network requirements based on desires.
     def _per_instance_requirements(self, desires) -> Tuple[int, float]:

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -511,6 +511,7 @@ class CapacityPlanner:
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
+        max_results_per_family: int = 1,
     ) -> Sequence[CapacityPlan]:
         if model_name not in self._models:
             raise ValueError(
@@ -538,6 +539,7 @@ class CapacityPlanner:
                 lifecycles=lifecycles,
                 instance_families=instance_families,
                 drives=drives,
+                max_results_per_family=max_results_per_family,
             )
             if sub_plan:
                 results.append(sub_plan)
@@ -555,6 +557,7 @@ class CapacityPlanner:
         instance_families: Optional[Sequence[str]] = None,
         drives: Optional[Sequence[str]] = None,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
+        max_results_per_family: int = 1,
     ) -> Sequence[CapacityPlan]:
         extra_model_arguments = extra_model_arguments or {}
         model = self._models[model_name]
@@ -577,8 +580,7 @@ class CapacityPlanner:
         plans.sort(key=lambda p: (p.rank, p.candidate_clusters.total_annual_cost))
 
         num_results = num_results or self._default_num_results
-        max_per_family = extra_model_arguments.get("max_results_per_family", 1)
-        return reduce_by_family(plans, max_results_per_family=max_per_family)[
+        return reduce_by_family(plans, max_results_per_family=max_results_per_family)[
             :num_results
         ]
 
@@ -699,6 +701,7 @@ class CapacityPlanner:
         regret_params: Optional[CapacityRegretParameters] = None,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         explain: bool = False,
+        max_results_per_family: int = 1,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
 
@@ -744,6 +747,7 @@ class CapacityPlanner:
                             lifecycles=lifecycles,
                             instance_families=instance_families,
                             drives=drives,
+                            max_results_per_family=max_results_per_family,
                         ),
                     )
                 )
@@ -766,7 +770,8 @@ class CapacityPlanner:
                 ],
                 zonal_requirements,
                 regional_requirements,
-            )
+            ),
+            max_results_per_family=max_results_per_family,
         )[:num_results]
 
         low_p, high_p = sorted(percentiles)[0], sorted(percentiles)[-1]

--- a/service_capacity_modeling/models/utils.py
+++ b/service_capacity_modeling/models/utils.py
@@ -8,7 +8,7 @@ from service_capacity_modeling.models import CapacityPlan
 
 
 def reduce_by_family(
-    plans: Iterable[CapacityPlan], max_per_family: int = 1
+    plans: Iterable[CapacityPlan], max_results_per_family: int = 1
 ) -> List[CapacityPlan]:
     """Groups a potential set of clusters by hardware family sorted by cost.
 
@@ -16,7 +16,8 @@ def reduce_by_family(
 
     Args:
         plans: Iterable of CapacityPlan objects to filter
-        max_per_family: Maximum number of results to return per family combination
+        max_results_per_family: Maximum number of results to return per
+            family combination
     """
     zonal_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
     regional_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
@@ -42,7 +43,10 @@ def reduce_by_family(
         regional_count = regional_families.get(regional_type, 0)
 
         # Add the plan if we haven't reached the maximum for either family type
-        if zonal_count < max_per_family or regional_count < max_per_family:
+        if (
+            zonal_count < max_results_per_family
+            or regional_count < max_results_per_family
+        ):
             result.append(plan)
 
             # Update counters

--- a/service_capacity_modeling/models/utils.py
+++ b/service_capacity_modeling/models/utils.py
@@ -1,19 +1,25 @@
 import math
+from typing import Dict
 from typing import Iterable
 from typing import List
-from typing import Set
 from typing import Tuple
 
 from service_capacity_modeling.models import CapacityPlan
 
 
-def reduce_by_family(plans: Iterable[CapacityPlan]) -> List[CapacityPlan]:
+def reduce_by_family(
+    plans: Iterable[CapacityPlan], max_per_family: int = 1
+) -> List[CapacityPlan]:
     """Groups a potential set of clusters by hardware family sorted by cost.
 
     Useful for showing different family options.
+
+    Args:
+        plans: Iterable of CapacityPlan objects to filter
+        max_per_family: Maximum number of results to return per family combination
     """
-    zonal_families: Set[Tuple[Tuple[str, str], ...]] = set()
-    regional_families: Set[Tuple[Tuple[str, str], ...]] = set()
+    zonal_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
+    regional_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
 
     result: List[CapacityPlan] = []
     for plan in plans:
@@ -31,11 +37,17 @@ def reduce_by_family(plans: Iterable[CapacityPlan]) -> List[CapacityPlan]:
                 sorted({(c.cluster_type, c.instance.family) for c in topo.zonal})
             )
 
-        if not (zonal_type in zonal_families and regional_type in regional_families):
+        # Count how many of each family combination we've seen
+        zonal_count = zonal_families.get(zonal_type, 0)
+        regional_count = regional_families.get(regional_type, 0)
+
+        # Add the plan if we haven't reached the maximum for either family type
+        if zonal_count < max_per_family or regional_count < max_per_family:
             result.append(plan)
 
-        regional_families.add(regional_type)
-        zonal_families.add(zonal_type)
+            # Update counters
+            zonal_families[zonal_type] = zonal_count + 1
+            regional_families[regional_type] = regional_count + 1
 
     return result
 

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -526,7 +526,6 @@ def test_plan_certain_data_shape_same_instance_type():
             "require_attached_disks": True,
             "required_zone_size": cluster_capacity.cluster_instance_count.mid,
             "require_same_instance_family": True,
-            "max_results_per_family": 4,
         },
     )
 

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -526,6 +526,7 @@ def test_plan_certain_data_shape_same_instance_type():
             "require_attached_disks": True,
             "required_zone_size": cluster_capacity.cluster_instance_count.mid,
             "require_same_instance_family": True,
+            "max_results_per_family": 4,
         },
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,168 @@
+import unittest
+from decimal import Decimal
+from typing import Dict
+from typing import List
+
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import Clusters
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Requirements
+from service_capacity_modeling.interface import ZoneClusterCapacity
+from service_capacity_modeling.models.utils import reduce_by_family
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        # Create mock hardware instances with different families
+        self.shape_family_a1 = Instance(
+            name="family_a.a1",
+            family_separator=".",
+            cpu=2,
+            cpu_ghz=2.4,
+            ram_gib=8,
+            net_mbps=1000,
+        )
+        self.shape_family_a2 = Instance(
+            name="family_a.a2",
+            family_separator=".",
+            cpu=4,
+            cpu_ghz=2.4,
+            ram_gib=16,
+            net_mbps=2000,
+        )
+        self.shape_family_a3 = Instance(
+            name="family_a.a3",
+            family_separator=".",
+            cpu=8,
+            cpu_ghz=2.4,
+            ram_gib=32,
+            net_mbps=4000,
+        )
+
+        self.shape_family_b1 = Instance(
+            name="family_b.b1",
+            family_separator=".",
+            cpu=2,
+            cpu_ghz=2.4,
+            ram_gib=8,
+            net_mbps=1000,
+        )
+        self.shape_family_b2 = Instance(
+            name="family_b.b2",
+            family_separator=".",
+            cpu=4,
+            cpu_ghz=2.4,
+            ram_gib=16,
+            net_mbps=2000,
+        )
+
+        # Create capacity plans with different combinations of families
+        self.plans = self._create_test_capacity_plans()
+
+    def _create_test_capacity_plans(self) -> List[CapacityPlan]:
+        # Create 5 plans - 3 with family_a and 2 with family_b
+        plans = []
+
+        # Family A plans
+        for i, shape in enumerate(
+            [self.shape_family_a1, self.shape_family_a2, self.shape_family_a3]
+        ):
+            annual_cost = (i + 1) * 100.0  # Different costs
+
+            cluster = ZoneClusterCapacity(
+                cluster_type="test_cluster",
+                count=i + 1,
+                instance=shape,
+                annual_cost=annual_cost,
+            )
+
+            annual_costs_a: Dict[str, Decimal] = {
+                "test_cluster": Decimal(str(annual_cost))
+            }
+
+            plans.append(
+                CapacityPlan(
+                    requirements=Requirements(),
+                    candidate_clusters=Clusters(
+                        annual_costs=annual_costs_a, zonal=[cluster], regional=[]
+                    ),
+                    cost=annual_cost,  # Different costs
+                    efficiency=1.0,
+                )
+            )
+
+        # Family B plans
+        for i, shape in enumerate([self.shape_family_b1, self.shape_family_b2]):
+            annual_cost = (i + 1) * 200.0  # Different costs
+
+            cluster = ZoneClusterCapacity(
+                cluster_type="test_cluster",
+                count=i + 1,
+                instance=shape,
+                annual_cost=annual_cost,
+            )
+
+            annual_costs_b: Dict[str, Decimal] = {
+                "test_cluster": Decimal(str(annual_cost))
+            }
+
+            plans.append(
+                CapacityPlan(
+                    requirements=Requirements(),
+                    candidate_clusters=Clusters(
+                        annual_costs=annual_costs_b, zonal=[cluster], regional=[]
+                    ),
+                    cost=annual_cost,  # Different costs
+                    efficiency=1.0,
+                )
+            )
+
+        return plans
+
+    def test_reduce_by_family_default(self):
+        """Test that reduce_by_family with default parameter
+        returns one plan per family."""
+        result = reduce_by_family(self.plans)
+
+        # Should return only 2 plans - one from family_a and
+        # one from family_b
+        self.assertEqual(len(result), 2)
+
+        # Verify we have one from each family
+        families = set()
+        for plan in result:
+            for cluster in plan.candidate_clusters.zonal:
+                families.add(cluster.instance.family)
+
+        self.assertEqual(families, {"family_a", "family_b"})
+
+    def test_reduce_by_family_multiple(self):
+        """Test that reduce_by_family with max_per_family > 1
+        returns multiple plans per family."""
+        result = reduce_by_family(self.plans, max_per_family=2)
+
+        # Should return 4 plans - two from family_a and two from family_b
+        self.assertEqual(len(result), 4)
+
+        # Count plans per family
+        family_counts = {"family_a": 0, "family_b": 0}
+        for plan in result:
+            for cluster in plan.candidate_clusters.zonal:
+                family_counts[cluster.instance.family] += 1
+
+        # Verify we have exactly 2 from each family
+        self.assertEqual(family_counts["family_a"], 2)
+        self.assertEqual(family_counts["family_b"], 2)
+
+    def test_reduce_by_family_unlimited(self):
+        """Test that reduce_by_family with max_per_family > available plans
+        returns all plans."""
+        # Set max_per_family higher than the number of plans we have
+        result = reduce_by_family(self.plans, max_per_family=10)
+
+        # Should return all 5 plans since we have 3 from family_a and 2 from family_b
+        self.assertEqual(len(result), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import unittest
 from decimal import Decimal
 from typing import Dict
 from typing import List
@@ -11,158 +10,166 @@ from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models.utils import reduce_by_family
 
 
-class TestUtils(unittest.TestCase):
-    def setUp(self):
-        # Create mock hardware instances with different families
-        self.shape_family_a1 = Instance(
-            name="family_a.a1",
-            family_separator=".",
-            cpu=2,
-            cpu_ghz=2.4,
-            ram_gib=8,
-            net_mbps=1000,
-        )
-        self.shape_family_a2 = Instance(
-            name="family_a.a2",
-            family_separator=".",
-            cpu=4,
-            cpu_ghz=2.4,
-            ram_gib=16,
-            net_mbps=2000,
-        )
-        self.shape_family_a3 = Instance(
-            name="family_a.a3",
-            family_separator=".",
-            cpu=8,
-            cpu_ghz=2.4,
-            ram_gib=32,
-            net_mbps=4000,
+# Create mock hardware instances with different families for all tests
+def get_test_instances():
+    shape_family_a1 = Instance(
+        name="family_a.a1",
+        family_separator=".",
+        cpu=2,
+        cpu_ghz=2.4,
+        ram_gib=8,
+        net_mbps=1000,
+    )
+    shape_family_a2 = Instance(
+        name="family_a.a2",
+        family_separator=".",
+        cpu=4,
+        cpu_ghz=2.4,
+        ram_gib=16,
+        net_mbps=2000,
+    )
+    shape_family_a3 = Instance(
+        name="family_a.a3",
+        family_separator=".",
+        cpu=8,
+        cpu_ghz=2.4,
+        ram_gib=32,
+        net_mbps=4000,
+    )
+
+    shape_family_b1 = Instance(
+        name="family_b.b1",
+        family_separator=".",
+        cpu=2,
+        cpu_ghz=2.4,
+        ram_gib=8,
+        net_mbps=1000,
+    )
+    shape_family_b2 = Instance(
+        name="family_b.b2",
+        family_separator=".",
+        cpu=4,
+        cpu_ghz=2.4,
+        ram_gib=16,
+        net_mbps=2000,
+    )
+
+    return (
+        shape_family_a1,
+        shape_family_a2,
+        shape_family_a3,
+        shape_family_b1,
+        shape_family_b2,
+    )
+
+
+def create_test_capacity_plans() -> List[CapacityPlan]:
+    """Create test capacity plans with different hardware families for testing."""
+    shapes = get_test_instances()
+    (
+        shape_family_a1,
+        shape_family_a2,
+        shape_family_a3,
+        shape_family_b1,
+        shape_family_b2,
+    ) = shapes
+
+    plans = []
+
+    # Family A plans
+    for i, shape in enumerate([shape_family_a1, shape_family_a2, shape_family_a3]):
+        annual_cost = (i + 1) * 100.0  # Different costs
+
+        cluster = ZoneClusterCapacity(
+            cluster_type="test_cluster",
+            count=i + 1,
+            instance=shape,
+            annual_cost=annual_cost,
         )
 
-        self.shape_family_b1 = Instance(
-            name="family_b.b1",
-            family_separator=".",
-            cpu=2,
-            cpu_ghz=2.4,
-            ram_gib=8,
-            net_mbps=1000,
-        )
-        self.shape_family_b2 = Instance(
-            name="family_b.b2",
-            family_separator=".",
-            cpu=4,
-            cpu_ghz=2.4,
-            ram_gib=16,
-            net_mbps=2000,
-        )
+        annual_costs_a: Dict[str, Decimal] = {"test_cluster": Decimal(str(annual_cost))}
 
-        # Create capacity plans with different combinations of families
-        self.plans = self._create_test_capacity_plans()
-
-    def _create_test_capacity_plans(self) -> List[CapacityPlan]:
-        # Create 5 plans - 3 with family_a and 2 with family_b
-        plans = []
-
-        # Family A plans
-        for i, shape in enumerate(
-            [self.shape_family_a1, self.shape_family_a2, self.shape_family_a3]
-        ):
-            annual_cost = (i + 1) * 100.0  # Different costs
-
-            cluster = ZoneClusterCapacity(
-                cluster_type="test_cluster",
-                count=i + 1,
-                instance=shape,
-                annual_cost=annual_cost,
+        plans.append(
+            CapacityPlan(
+                requirements=Requirements(),
+                candidate_clusters=Clusters(
+                    annual_costs=annual_costs_a, zonal=[cluster], regional=[]
+                ),
+                cost=annual_cost,
+                efficiency=1.0,
             )
+        )
 
-            annual_costs_a: Dict[str, Decimal] = {
-                "test_cluster": Decimal(str(annual_cost))
-            }
+    # Family B plans
+    for i, shape in enumerate([shape_family_b1, shape_family_b2]):
+        annual_cost = (i + 1) * 200.0  # Different costs
 
-            plans.append(
-                CapacityPlan(
-                    requirements=Requirements(),
-                    candidate_clusters=Clusters(
-                        annual_costs=annual_costs_a, zonal=[cluster], regional=[]
-                    ),
-                    cost=annual_cost,  # Different costs
-                    efficiency=1.0,
-                )
+        cluster = ZoneClusterCapacity(
+            cluster_type="test_cluster",
+            count=i + 1,
+            instance=shape,
+            annual_cost=annual_cost,
+        )
+
+        annual_costs_b: Dict[str, Decimal] = {"test_cluster": Decimal(str(annual_cost))}
+
+        plans.append(
+            CapacityPlan(
+                requirements=Requirements(),
+                candidate_clusters=Clusters(
+                    annual_costs=annual_costs_b, zonal=[cluster], regional=[]
+                ),
+                cost=annual_cost,
+                efficiency=1.0,
             )
+        )
 
-        # Family B plans
-        for i, shape in enumerate([self.shape_family_b1, self.shape_family_b2]):
-            annual_cost = (i + 1) * 200.0  # Different costs
-
-            cluster = ZoneClusterCapacity(
-                cluster_type="test_cluster",
-                count=i + 1,
-                instance=shape,
-                annual_cost=annual_cost,
-            )
-
-            annual_costs_b: Dict[str, Decimal] = {
-                "test_cluster": Decimal(str(annual_cost))
-            }
-
-            plans.append(
-                CapacityPlan(
-                    requirements=Requirements(),
-                    candidate_clusters=Clusters(
-                        annual_costs=annual_costs_b, zonal=[cluster], regional=[]
-                    ),
-                    cost=annual_cost,  # Different costs
-                    efficiency=1.0,
-                )
-            )
-
-        return plans
-
-    def test_reduce_by_family_default(self):
-        """Test that reduce_by_family with default parameter
-        returns one plan per family."""
-        result = reduce_by_family(self.plans)
-
-        # Should return only 2 plans - one from family_a and
-        # one from family_b
-        self.assertEqual(len(result), 2)
-
-        # Verify we have one from each family
-        families = set()
-        for plan in result:
-            for cluster in plan.candidate_clusters.zonal:
-                families.add(cluster.instance.family)
-
-        self.assertEqual(families, {"family_a", "family_b"})
-
-    def test_reduce_by_family_multiple(self):
-        """Test that reduce_by_family with max_per_family > 1
-        returns multiple plans per family."""
-        result = reduce_by_family(self.plans, max_results_per_family=2)
-
-        # Should return 4 plans - two from family_a and two from family_b
-        self.assertEqual(len(result), 4)
-
-        # Count plans per family
-        family_counts = {"family_a": 0, "family_b": 0}
-        for plan in result:
-            for cluster in plan.candidate_clusters.zonal:
-                family_counts[cluster.instance.family] += 1
-
-        # Verify we have exactly 2 from each family
-        self.assertEqual(family_counts["family_a"], 2)
-        self.assertEqual(family_counts["family_b"], 2)
-
-    def test_reduce_by_family_unlimited(self):
-        """Test that reduce_by_family with max_per_family > available plans
-        returns all plans."""
-        # Set max_per_family higher than the number of plans we have
-        result = reduce_by_family(self.plans, max_results_per_family=10)
-
-        # Should return all 5 plans since we have 3 from family_a and 2 from family_b
-        self.assertEqual(len(result), 5)
+    return plans
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_reduce_by_family_default():
+    """Test that reduce_by_family with default parameter returns one plan per family."""
+    plans = create_test_capacity_plans()
+    result = reduce_by_family(plans)
+
+    # Should return only 2 plans - one from family_a and one from family_b
+    assert len(result) == 2
+
+    # Verify we have one from each family
+    families = set()
+    for plan in result:
+        for cluster in plan.candidate_clusters.zonal:
+            families.add(cluster.instance.family)
+
+    assert families == {"family_a", "family_b"}
+
+
+def test_reduce_by_family_multiple():
+    """Test that reduce_by_family with max_results_per_family > 1
+    returns multiple plans per family."""
+    plans = create_test_capacity_plans()
+    result = reduce_by_family(plans, max_results_per_family=2)
+
+    # Should return 4 plans - two from family_a and two from family_b
+    assert len(result) == 4
+
+    # Count plans per family
+    family_counts = {"family_a": 0, "family_b": 0}
+    for plan in result:
+        for cluster in plan.candidate_clusters.zonal:
+            family_counts[cluster.instance.family] += 1
+
+    # Verify we have exactly 2 from each family
+    assert family_counts["family_a"] == 2
+    assert family_counts["family_b"] == 2
+
+
+def test_reduce_by_family_unlimited():
+    """Test that reduce_by_family with max_results_per_family > available plans
+    returns all plans."""
+    plans = create_test_capacity_plans()
+    # Set max_results_per_family higher than the number of plans we have
+    result = reduce_by_family(plans, max_results_per_family=10)
+
+    # Should return all 5 plans since we have 3 from family_a and 2 from family_b
+    assert len(result) == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -139,7 +139,7 @@ class TestUtils(unittest.TestCase):
     def test_reduce_by_family_multiple(self):
         """Test that reduce_by_family with max_per_family > 1
         returns multiple plans per family."""
-        result = reduce_by_family(self.plans, max_per_family=2)
+        result = reduce_by_family(self.plans, max_results_per_family=2)
 
         # Should return 4 plans - two from family_a and two from family_b
         self.assertEqual(len(result), 4)
@@ -158,7 +158,7 @@ class TestUtils(unittest.TestCase):
         """Test that reduce_by_family with max_per_family > available plans
         returns all plans."""
         # Set max_per_family higher than the number of plans we have
-        result = reduce_by_family(self.plans, max_per_family=10)
+        result = reduce_by_family(self.plans, max_results_per_family=10)
 
         # Should return all 5 plans since we have 3 from family_a and 2 from family_b
         self.assertEqual(len(result), 5)


### PR DESCRIPTION
Currently, the capacity planner reduces the possible plans to allow at most 1 plan per instance family. This may not always be ideal in cases where the capacity planner may recommend a lower instance type with a higher count in certain cases due to disk requirements. i.e. `20x r5.2xl instances with 1TB disk` vs. `10x r5.4xl instances with 2TB disk` where the higher count ends up costing less and is the top recommendation by the planner but it is more inconvenient from a scaling perspective as we would rather stay closer to the current instance count and vertically scale instead. In such cases, the operator could benefit from examining multiple options before making a decision.

This PR aims to allow multiple results for the same family to help the above issue. By default this will be 1 so the behavior is the same for anyone not using this feature (backwards compatible). Central scaling workflow may not use this feature as it likely will require one final recommendation.

Ideally the planner itself should converge to the most ideal plan in general but this can also help the operator debug/example the planner results more easily.