### PR TITLE
Adding max_attached_disk_gib parameter to allow provisioning higher EBS

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -465,7 +465,7 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
         # with smaller volumes)
         max_size = drive.max_size_gib / 3
         if max_attached_disk_gib is not None:
-            max_size = max(max_size, max_attached_disk_gib)
+            max_size = max_attached_disk_gib
 
         if ebs_gib > max_size > 0:
             ratio = ebs_gib / max_size

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -374,6 +374,9 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
     min_count: int = 0,
     adjusted_disk_io_needed: float = 0.0,
     read_write_ratio: float = 0.0,
+    # Max attached EBS volume size per node. Higher value here could allow
+    # for a lower instance count (allows more vertical scaling vs forcing horizontal)
+    max_attached_disk_gib: Optional[float] = None,
 ) -> ZoneClusterCapacity:
     # Datastores often require disk headroom for e.g. compaction and such
     if instance.drive is not None:
@@ -461,6 +464,9 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
         # 1/3 the maximum volume size in one node (preferring more nodes
         # with smaller volumes)
         max_size = drive.max_size_gib / 3
+        if max_attached_disk_gib is not None:
+            max_size = max(max_size, max_attached_disk_gib)
+
         if ebs_gib > max_size > 0:
             ratio = ebs_gib / max_size
             count = max(cluster_size(math.ceil(count * ratio)), min_count)

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -337,6 +337,8 @@ def _estimate_kafka_cluster_zonal(  # pylint: disable=too-many-positional-argume
         # Sidecars and Variable OS Memory
         # Kafka currently uses 8GiB fixed, might want to change to min(30, x // 2)
         reserve_memory=lambda instance_mem_gib: base_mem + 8,
+        # allow up to 8TiB of attached EBS
+        max_attached_disk_gib=8 * 1024,
     )
 
     # Communicate to the actual provision that if we want reduced RF


### PR DESCRIPTION
Adding a parameter to allow specifying the max attached disk (EBS) size.

For existing deployed clusters, it may be preferable to scale to a higher EBS disk size when requiring more disk rather than adding more nodes (horizontal scaling). The planner currently caps the EBS size to 1/3 of the maximum drive capacity. This may be acceptable for new clusters but for existing clusters, this may be too conservative. This results in forcing horizontal scaling for higher scale factors that require more disk. For short term events, we would prefer to vertically scale the instances and scale the disks up/back down instead as horizontal scaling is not reversible for all cases (Kafka).