### PR TITLE
Fixing non-ebs cluster planning

### DIFF
--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -246,7 +246,7 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     require_attached_disks: bool = False,
     required_zone_size: Optional[int] = None,
     max_regional_size: int = 150,
-    max_local_disk_gib: int = 1024 * 16,  # i3en.6xl has 15TB disk
+    max_local_disk_gib: int = 1024 * 8,
     min_instance_cpu: int = 2,
     min_instance_memory_gib: int = 12,
     require_same_instance_family: bool = True,
@@ -494,7 +494,7 @@ class NflxKafkaCapacityModel(CapacityModel):
         max_regional_size: int = extra_model_arguments.get("max_regional_size", 150)
         # Very large nodes are hard to cache warm
         max_local_disk_gib: int = extra_model_arguments.get(
-            "max_local_disk_gib", 1024 * 16  # i3en.6xlarge can use up to 15TB
+            "max_local_disk_gib", 1024 * 8
         )
         min_instance_cpu: int = extra_model_arguments.get("min_instance_cpu", 2)
         min_instance_memory_gib: int = extra_model_arguments.get(

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -247,7 +247,7 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     require_attached_disks: bool = False,
     required_zone_size: Optional[int] = None,
     max_regional_size: int = 150,
-    max_local_disk_gib: int = 1024 * 8,
+    max_local_disk_gib: int = 1024 * 5,
     min_instance_cpu: int = 2,
     min_instance_memory_gib: int = 12,
     require_same_instance_family: bool = True,
@@ -495,7 +495,7 @@ class NflxKafkaCapacityModel(CapacityModel):
         max_regional_size: int = extra_model_arguments.get("max_regional_size", 150)
         # Very large nodes are hard to cache warm
         max_local_disk_gib: int = extra_model_arguments.get(
-            "max_local_disk_gib", 1024 * 8
+            "max_local_disk_gib", 1024 * 5
         )
         min_instance_cpu: int = extra_model_arguments.get("min_instance_cpu", 2)
         min_instance_memory_gib: int = extra_model_arguments.get(

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -188,7 +188,8 @@ def _estimate_kafka_requirement(  # pylint: disable=too-many-positional-argument
     ) // zones_per_region
 
     logger.debug(
-        "Need (cpu, mem, disk) = (%s, %s, %s)",
+        "Need (instance, cpu, mem, disk) = (%s, %s, %s, %s)",
+        instance.name,
         needed_cores,
         needed_memory,
         needed_disk,

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -363,11 +363,12 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
         ebs_gib = utils.next_n(space_gib, n=100)
 
         # Max allowed disk size in `compute_stateful_zone`
-        max_size = drive.max_size_gib / 3
         if instance.drive is not None and instance.drive.size_gib > 0:
             max_size = min(max_local_disk_gib, instance.drive.size_gib)
         elif max_attached_disk_gib is not None:
             max_size = max_attached_disk_gib
+        else:
+            max_size = drive.max_size_gib / 3
 
         # Capacity planner only allows ~ 5TB disk (max_size) for gp3 drives
         # or max_attached_disk_gib if provided.

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -894,9 +894,9 @@ def test_non_ebs():
             confidence=1.0,
         ),
         disk_utilization_gib=Interval(
-            low=311.24108505249023,
-            mid=1413.8721423142003,
-            high=2350.127197265625,
+            low=500.24108505249023,
+            mid=750.8721423142003,
+            high=1300.127197265625,
             confidence=1.0,
         ),
     )

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+import logging
+
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
@@ -17,6 +19,16 @@ from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.org.netflix.kafka import ClusterType
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(
+    level=logging.WARNING,  # Set to DEBUG for detailed capacity planner reasoning
+    format="%(name)s - %(levelname)s - %(message)s",
+    force=True,
+)
+
+logger.setLevel(logging.DEBUG)
 
 
 def test_kafka_basic():
@@ -144,7 +156,7 @@ def test_kafka_high_throughput():
     )
 
     for lr in plan.least_regret:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])
         assert 50_000 < lr.candidate_clusters.total_annual_cost < 200_000
         clstr = lr.candidate_clusters.zonal[0]
         if clstr.instance.drive is None:
@@ -351,7 +363,7 @@ def test_plan_certain():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
     assert lr_clusters[0].count == cluster_capacity.cluster_instance_count.high
 
 
@@ -441,10 +453,10 @@ def test_plan_certain_data_shape():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
     assert lr_clusters[0].count == cluster_capacity.cluster_instance_count.high
     for lr in cap_plan:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])
     families = set(
         map(
             lambda curr_plan: curr_plan.candidate_clusters.zonal[0].instance.family,
@@ -545,7 +557,7 @@ def test_plan_certain_data_shape_same_instance_type():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
     assert lr_clusters[0].count == cluster_capacity.cluster_instance_count.high
 
     families = set(
@@ -562,7 +574,7 @@ def test_plan_certain_data_shape_same_instance_type():
     assert lr_clusters[0].count == cluster_capacity.cluster_instance_count.high
 
     for lr in cap_plan:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])
 
 
 def test_scale_up_using_buffers():
@@ -679,7 +691,7 @@ def test_scale_up_using_buffers():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
     assert lr_clusters[0].count == cluster_capacity.cluster_instance_count.high
 
     families = set(
@@ -713,7 +725,7 @@ def test_scale_up_using_buffers():
     )
 
     for lr in cap_plan:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])
 
 
 def test_scale_up_using_buffers_high_disk_change_instance_count():
@@ -828,7 +840,7 @@ def test_scale_up_using_buffers_high_disk_change_instance_count():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
 
     families = set(
         map(
@@ -859,7 +871,7 @@ def test_scale_up_using_buffers_high_disk_change_instance_count():
     )
 
     for lr in cap_plan:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])
 
 
 def test_non_ebs():
@@ -986,7 +998,7 @@ def test_non_ebs():
     assert len(cap_plan) >= 1
     lr_clusters = cap_plan[0].candidate_clusters.zonal
     assert len(lr_clusters) >= 1
-    print(lr_clusters[0].instance.name)
+    logger.debug(lr_clusters[0].instance.name)
 
     families = set(
         map(
@@ -1014,4 +1026,4 @@ def test_non_ebs():
     )
 
     for lr in cap_plan:
-        print(lr.candidate_clusters.zonal[0])
+        logger.debug(lr.candidate_clusters.zonal[0])

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -1008,7 +1008,8 @@ def test_non_ebs():
         * scale_ratio
     )
     assert (
-        lr_clusters[0].instance.drive.size_gib * lr_clusters[0].count
+        lr_clusters[0].instance.drive is not None
+        and lr_clusters[0].instance.drive.size_gib * lr_clusters[0].count
         >= minimum_provisioned_disk
     )
 

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
@@ -854,6 +855,164 @@ def test_scale_up_using_buffers_high_disk_change_instance_count():
     )
     assert (
         lr_clusters[0].attached_drives[0].size_gib * lr_clusters[0].count
+        >= minimum_provisioned_disk
+    )
+
+    for lr in cap_plan:
+        print(lr.candidate_clusters.zonal[0])
+
+
+def test_non_ebs():
+    cluster_capacity = CurrentZoneClusterCapacity(
+        cluster_instance_name="i3en.2xlarge",
+        cluster_instance=None,
+        cluster_drive=None,
+        cluster_instance_count=Interval(low=44.0, mid=44.0, high=44.0, confidence=1.0),
+        cpu_utilization=Interval(
+            low=3.0162736316287893,
+            mid=17.47713213503852,
+            high=28.850521087646484,
+            confidence=1.0,
+        ),
+        memory_utilization_gib=Interval(low=0.0, mid=0.0, high=0.0, confidence=1.0),
+        network_utilization_mbps=Interval(
+            low=18.110018933333333,
+            mid=908.3751514114257,
+            high=2515.735296,
+            confidence=1.0,
+        ),
+        disk_utilization_gib=Interval(
+            low=311.24108505249023,
+            mid=1413.8721423142003,
+            high=2350.127197265625,
+            confidence=1.0,
+        ),
+    )
+
+    scale_ratio = 1.47
+    buffer_ratio = 2.5
+    buffers = Buffers(
+        default=Buffer(ratio=1.5, intent=BufferIntent.desired, components=["compute"]),
+        desired={
+            "compute": Buffer(
+                ratio=buffer_ratio, intent=BufferIntent.desired, components=["compute"]
+            ),
+            "storage": Buffer(
+                ratio=buffer_ratio, intent=BufferIntent.desired, components=["storage"]
+            ),
+        },
+        derived={
+            "compute": Buffer(
+                ratio=scale_ratio, intent=BufferIntent.scale, components=["compute"]
+            ),
+            "storage": Buffer(
+                ratio=scale_ratio, intent=BufferIntent.scale, components=["storage"]
+            ),
+        },
+    )
+
+    desires = CapacityDesires(
+        service_tier=1,
+        buffers=buffers,
+        current_clusters=CurrentClusters(zonal=[cluster_capacity]),
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=Interval(
+                low=4.0, mid=4.0, high=4.0, confidence=1.0
+            ),
+            estimated_write_per_second=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=0.98
+            ),
+            estimated_mean_read_latency_ms=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_mean_write_latency_ms=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_mean_read_size_bytes=Interval(
+                low=1024.0, mid=1024.0, high=1024.0, confidence=1.0
+            ),
+            estimated_mean_write_size_bytes=Interval(
+                low=45934839.712777786,
+                mid=2832737185.7793183,
+                high=5291668222.459846,
+                confidence=0.98,
+            ),
+            estimated_read_parallelism=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_write_parallelism=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            read_latency_slo_ms=FixedInterval(
+                low=0.4, mid=4.0, high=10.0, confidence=0.98
+            ),
+            write_latency_slo_ms=FixedInterval(
+                low=0.4, mid=4.0, high=10.0, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=35428.05778477986,
+                mid=209861.32096354378,
+                high=294807.85949808755,
+                confidence=1.0,
+            ),
+            reserved_instance_app_mem_gib=2,
+            reserved_instance_system_mem_gib=1,
+            estimated_compression_ratio=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+        ),
+    )
+
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.kafka",
+        region="us-east-1",
+        num_results=3,
+        num_regions=1,
+        desires=desires,
+        extra_model_arguments={
+            "cluster_type": ClusterType.ha,
+            "retention": "PT8H",
+            "context": "fleet analysis from AG.kafka",
+            "context-memo": "fleet analysis from AG.kafka",
+            "nflx-sensitivedata": False,
+            "required_zone_size": 44.0,
+            "require_local_disks": True,
+        },
+    )
+
+    assert len(cap_plan) >= 1
+    lr_clusters = cap_plan[0].candidate_clusters.zonal
+    assert len(lr_clusters) >= 1
+    print(lr_clusters[0].instance.name)
+
+    families = set(
+        map(
+            lambda curr_plan: curr_plan.candidate_clusters.zonal[0].instance.family,
+            cap_plan,
+        )
+    )
+    # check that we restricted the instance family to only i3en
+    assert families == {"i3en"}
+
+    # check that we have at least as many instances as the current cluster
+    assert lr_clusters[0].count >= cluster_capacity.cluster_instance_count.high
+
+    # Since the disk required per instance is > 5TB allowed by cap planner, we
+    # allow higher instance count. This means we may not have vertically scaled
+    # the instance type up since a lower instance type may be ok with the higher count
+
+    # Check that we provisioned enough storage
+    minimum_provisioned_disk = (
+        cluster_capacity.disk_utilization_gib.high
+        * cluster_capacity.cluster_instance_count.mid
+        * buffer_ratio
+        * scale_ratio
+    )
+    assert (
+        lr_clusters[0].instance.drive.size_gib * lr_clusters[0].count
         >= minimum_provisioned_disk
     )
 

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -1000,10 +1000,6 @@ def test_non_ebs():
     # check that we have at least as many instances as the current cluster
     assert lr_clusters[0].count >= cluster_capacity.cluster_instance_count.high
 
-    # Since the disk required per instance is > 5TB allowed by cap planner, we
-    # allow higher instance count. This means we may not have vertically scaled
-    # the instance type up since a lower instance type may be ok with the higher count
-
     # Check that we provisioned enough storage
     minimum_provisioned_disk = (
         cluster_capacity.disk_utilization_gib.high

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -1027,3 +1027,158 @@ def test_non_ebs():
 
     for lr in cap_plan:
         logger.debug(lr.candidate_clusters.zonal[0])
+
+
+def test_non_ebs_force_horizontal():
+    cluster_capacity = CurrentZoneClusterCapacity(
+        cluster_instance_name="i3en.2xlarge",
+        cluster_instance=None,
+        cluster_drive=None,
+        cluster_instance_count=Interval(low=34.0, mid=34.0, high=34.0, confidence=1.0),
+        cpu_utilization=Interval(
+            low=7.976402722859067,
+            mid=23.6481902437047,
+            high=32.95874639028172,
+            confidence=1.0,
+        ),
+        memory_utilization_gib=Interval(low=0.0, mid=0.0, high=0.0, confidence=1.0),
+        network_utilization_mbps=Interval(
+            low=261.2259746737884,
+            mid=1400.0759607382988,
+            high=2102.2521095975226,
+            confidence=1.0,
+        ),
+        disk_utilization_gib=Interval(
+            low=568.1681300331992,
+            mid=1265.9443437846992,
+            high=1631.3559736741358,
+            confidence=1.0,
+        ),
+    )
+
+    scale_ratio = 1.47
+    buffer_ratio = 2.5
+    buffers = Buffers(
+        default=Buffer(ratio=1.5, intent=BufferIntent.desired, components=["compute"]),
+        desired={
+            "compute": Buffer(
+                ratio=buffer_ratio, intent=BufferIntent.desired, components=["compute"]
+            ),
+            "storage": Buffer(
+                ratio=buffer_ratio, intent=BufferIntent.desired, components=["storage"]
+            ),
+        },
+        derived={
+            "compute": Buffer(
+                ratio=scale_ratio, intent=BufferIntent.scale, components=["compute"]
+            ),
+            "storage": Buffer(
+                ratio=scale_ratio, intent=BufferIntent.scale, components=["storage"]
+            ),
+        },
+    )
+
+    desires = CapacityDesires(
+        service_tier=1,
+        buffers=buffers,
+        current_clusters=CurrentClusters(zonal=[cluster_capacity]),
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=Interval(
+                low=4.0, mid=4.0, high=4.0, confidence=1.0
+            ),
+            estimated_write_per_second=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=0.98
+            ),
+            estimated_mean_read_latency_ms=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_mean_write_latency_ms=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_mean_read_size_bytes=Interval(
+                low=1024.0, mid=1024.0, high=1024.0, confidence=1.0
+            ),
+            estimated_mean_write_size_bytes=Interval(
+                low=176860051.61423847,
+                mid=2124963552.9652083,
+                high=3525502574.7887697,
+                confidence=0.98,
+            ),
+            estimated_read_parallelism=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            estimated_write_parallelism=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+            read_latency_slo_ms=FixedInterval(
+                low=0.4, mid=4.0, high=10.0, confidence=0.98
+            ),
+            write_latency_slo_ms=FixedInterval(
+                low=0.4, mid=4.0, high=10.0, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=30065.005002339683,
+                mid=147923.7993778993,
+                high=166897.69089864095,
+                confidence=1.0,
+            ),
+            reserved_instance_app_mem_gib=2,
+            reserved_instance_system_mem_gib=1,
+            estimated_compression_ratio=Interval(
+                low=1.0, mid=1.0, high=1.0, confidence=1.0
+            ),
+        ),
+    )
+
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.kafka",
+        region="us-east-1",
+        num_results=3,
+        num_regions=1,
+        desires=desires,
+        extra_model_arguments={
+            "cluster_type": ClusterType.ha,
+            "retention": "PT8H",
+            "context": "fleet analysis from AG.kafka",
+            "context-memo": "fleet analysis from AG.kafka",
+            "nflx-sensitivedata": False,
+            "required_zone_size": cluster_capacity.cluster_instance_count.mid,
+            "require_local_disks": True,
+        },
+    )
+
+    assert len(cap_plan) >= 1
+    lr_clusters = cap_plan[0].candidate_clusters.zonal
+    assert len(lr_clusters) >= 1
+    print(lr_clusters[0].instance.name)
+
+    families = set(
+        map(
+            lambda curr_plan: curr_plan.candidate_clusters.zonal[0].instance.family,
+            cap_plan,
+        )
+    )
+    # check that we restricted the instance family to only i3en
+    assert families == {"i3en"}
+
+    # check that we have at least as many instances as the current cluster
+    assert lr_clusters[0].count >= cluster_capacity.cluster_instance_count.high
+
+    # Check that we provisioned enough storage
+    minimum_provisioned_disk = (
+        cluster_capacity.disk_utilization_gib.high
+        * cluster_capacity.cluster_instance_count.mid
+        * buffer_ratio
+        * scale_ratio
+    )
+    assert (
+        lr_clusters[0].instance.drive is not None
+        and lr_clusters[0].instance.drive.size_gib * lr_clusters[0].count
+        >= minimum_provisioned_disk
+    )
+
+    for lr in cap_plan:
+        print(lr.candidate_clusters.zonal[0])


### PR DESCRIPTION
Kafka planner was not accounting for the local disk size for non-ebs clusters compared to attached disks for ebs clusters. This PR adjusts the validation in the Kafka specific planner to check the correct value before returning a plan.