### PR TITLE
Update the AWS shapes using latest IPC scale

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws/auto_c7a.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/auto_c7a.json
@@ -5,7 +5,7 @@
       "cpu": 1,
       "cpu_cores": 1,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 1.91,
       "net_mbps": 390.0,
       "drive": null
@@ -15,7 +15,7 @@
       "cpu": 2,
       "cpu_cores": 2,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 3.81,
       "net_mbps": 781.0,
       "drive": null
@@ -25,7 +25,7 @@
       "cpu": 4,
       "cpu_cores": 4,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 7.63,
       "net_mbps": 1562.0,
       "drive": null
@@ -35,7 +35,7 @@
       "cpu": 8,
       "cpu_cores": 8,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 15.26,
       "net_mbps": 3125.0,
       "drive": null
@@ -45,7 +45,7 @@
       "cpu": 16,
       "cpu_cores": 16,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 30.52,
       "net_mbps": 6250.0,
       "drive": null
@@ -55,7 +55,7 @@
       "cpu": 32,
       "cpu_cores": 32,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 61.04,
       "net_mbps": 12500.0,
       "drive": null
@@ -65,7 +65,7 @@
       "cpu": 48,
       "cpu_cores": 48,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 91.55,
       "net_mbps": 18750.0,
       "drive": null
@@ -75,7 +75,7 @@
       "cpu": 64,
       "cpu_cores": 64,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 122.07,
       "net_mbps": 25000.0,
       "drive": null
@@ -85,7 +85,7 @@
       "cpu": 96,
       "cpu_cores": 96,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 183.11,
       "net_mbps": 37500.0,
       "drive": null
@@ -95,7 +95,7 @@
       "cpu": 128,
       "cpu_cores": 128,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 244.14,
       "net_mbps": 50000.0,
       "drive": null
@@ -105,7 +105,7 @@
       "cpu": 192,
       "cpu_cores": 192,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 366.21,
       "net_mbps": 50000.0,
       "drive": null

--- a/service_capacity_modeling/hardware/profiles/shapes/aws/auto_m6a.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/auto_m6a.json
@@ -5,7 +5,7 @@
       "cpu": 2,
       "cpu_cores": 1,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 7.63,
       "net_mbps": 781.0,
       "drive": null
@@ -15,7 +15,7 @@
       "cpu": 4,
       "cpu_cores": 2,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 15.26,
       "net_mbps": 1562.0,
       "drive": null
@@ -25,7 +25,7 @@
       "cpu": 8,
       "cpu_cores": 4,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 30.52,
       "net_mbps": 3125.0,
       "drive": null
@@ -35,7 +35,7 @@
       "cpu": 16,
       "cpu_cores": 8,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 61.04,
       "net_mbps": 6250.0,
       "drive": null
@@ -45,7 +45,7 @@
       "cpu": 32,
       "cpu_cores": 16,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 122.07,
       "net_mbps": 12500.0,
       "drive": null
@@ -55,7 +55,7 @@
       "cpu": 48,
       "cpu_cores": 24,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 183.11,
       "net_mbps": 18750.0,
       "drive": null
@@ -65,7 +65,7 @@
       "cpu": 64,
       "cpu_cores": 32,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 244.14,
       "net_mbps": 25000.0,
       "drive": null
@@ -75,7 +75,7 @@
       "cpu": 96,
       "cpu_cores": 48,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 366.21,
       "net_mbps": 37500.0,
       "drive": null
@@ -85,7 +85,7 @@
       "cpu": 128,
       "cpu_cores": 64,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 488.28,
       "net_mbps": 50000.0,
       "drive": null
@@ -95,7 +95,7 @@
       "cpu": 192,
       "cpu_cores": 96,
       "cpu_ghz": 3.6,
-      "cpu_ipc_scale": 1.0,
+      "cpu_ipc_scale": 1.15,
       "ram_gib": 732.42,
       "net_mbps": 50000.0,
       "drive": null

--- a/service_capacity_modeling/hardware/profiles/shapes/aws/auto_m7a.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/auto_m7a.json
@@ -5,7 +5,7 @@
       "cpu": 1,
       "cpu_cores": 1,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 3.81,
       "net_mbps": 390.0,
       "drive": null
@@ -15,7 +15,7 @@
       "cpu": 2,
       "cpu_cores": 2,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 7.63,
       "net_mbps": 781.0,
       "drive": null
@@ -25,7 +25,7 @@
       "cpu": 4,
       "cpu_cores": 4,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 15.26,
       "net_mbps": 1562.0,
       "drive": null
@@ -35,7 +35,7 @@
       "cpu": 8,
       "cpu_cores": 8,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 30.52,
       "net_mbps": 3125.0,
       "drive": null
@@ -45,7 +45,7 @@
       "cpu": 16,
       "cpu_cores": 16,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 61.04,
       "net_mbps": 6250.0,
       "drive": null
@@ -55,7 +55,7 @@
       "cpu": 32,
       "cpu_cores": 32,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 122.07,
       "net_mbps": 12500.0,
       "drive": null
@@ -65,7 +65,7 @@
       "cpu": 48,
       "cpu_cores": 48,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 183.11,
       "net_mbps": 18750.0,
       "drive": null
@@ -75,7 +75,7 @@
       "cpu": 64,
       "cpu_cores": 64,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 244.14,
       "net_mbps": 25000.0,
       "drive": null
@@ -85,7 +85,7 @@
       "cpu": 96,
       "cpu_cores": 96,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 366.21,
       "net_mbps": 37500.0,
       "drive": null
@@ -95,7 +95,7 @@
       "cpu": 128,
       "cpu_cores": 128,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 488.28,
       "net_mbps": 50000.0,
       "drive": null
@@ -105,7 +105,7 @@
       "cpu": 192,
       "cpu_cores": 192,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 732.42,
       "net_mbps": 50000.0,
       "drive": null

--- a/service_capacity_modeling/hardware/profiles/shapes/aws/auto_r7a.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/auto_r7a.json
@@ -5,7 +5,7 @@
       "cpu": 1,
       "cpu_cores": 1,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 7.63,
       "net_mbps": 390.0,
       "drive": null
@@ -15,7 +15,7 @@
       "cpu": 2,
       "cpu_cores": 2,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 15.26,
       "net_mbps": 781.0,
       "drive": null
@@ -25,7 +25,7 @@
       "cpu": 4,
       "cpu_cores": 4,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 30.52,
       "net_mbps": 1562.0,
       "drive": null
@@ -35,7 +35,7 @@
       "cpu": 8,
       "cpu_cores": 8,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 61.04,
       "net_mbps": 3125.0,
       "drive": null
@@ -45,7 +45,7 @@
       "cpu": 16,
       "cpu_cores": 16,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 122.07,
       "net_mbps": 6250.0,
       "drive": null
@@ -55,7 +55,7 @@
       "cpu": 32,
       "cpu_cores": 32,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 244.14,
       "net_mbps": 12500.0,
       "drive": null
@@ -65,7 +65,7 @@
       "cpu": 48,
       "cpu_cores": 48,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 366.21,
       "net_mbps": 18750.0,
       "drive": null
@@ -75,7 +75,7 @@
       "cpu": 64,
       "cpu_cores": 64,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 488.28,
       "net_mbps": 25000.0,
       "drive": null
@@ -85,7 +85,7 @@
       "cpu": 96,
       "cpu_cores": 96,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 732.42,
       "net_mbps": 37500.0,
       "drive": null
@@ -95,7 +95,7 @@
       "cpu": 128,
       "cpu_cores": 128,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 976.56,
       "net_mbps": 50000.0,
       "drive": null
@@ -105,7 +105,7 @@
       "cpu": 192,
       "cpu_cores": 192,
       "cpu_ghz": 3.7,
-      "cpu_ipc_scale": 1.5,
+      "cpu_ipc_scale": 1.2994999999999999,
       "ram_gib": 1464.84,
       "net_mbps": 50000.0,
       "drive": null


### PR DESCRIPTION
These files are out of date from the latest ipc scale defined in the code. Although, this is a potential issue because these new values may make gen6 preferable over gen 7. 