### PR TITLE
Create Cassandra clusters of non power of 2

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -394,7 +394,9 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         # want to avoid clusters with more than 1 TiB of local state
         max_local_disk_gib=max_local_disk_gib,
         # C* clusters provision in powers of 2 because doubling
-        cluster_size=next_power_of_2,
+        # But if the required cluster size is specified, we want to strictly
+        # honor it as-is until we have horizontal scaling
+        cluster_size=(lambda n: n) if required_cluster_size else next_power_of_2,
         min_count=max(min_count, required_cluster_size or 0),
         # TODO: Take reserve memory calculation into account during buffer calculation
         # C* heap usage takes away from OS page cache memory

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -255,6 +255,22 @@ def test_high_write_throughput_ebs():
     assert high_writes_result.cluster_params["cassandra.compaction.min_threshold"] > 4
 
 
+def test_capacity_non_power_of_two():
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=large_footprint,
+        extra_model_arguments={
+            "require_local_disks": True,
+            "required_cluster_size": 12,
+        },
+    )[0]
+
+    result = cap_plan.candidate_clusters.zonal[0]
+    assert result.count == 12
+    assert result.instance.name.startswith("i")
+
+
 def test_capacity_large_footprint():
     cap_plan = planner.plan_certain(
         model_name="org.netflix.cassandra",


### PR DESCRIPTION
C* supports arbitrary node counts but the capacity planner forces them to be a power of 2.  In general, it's easiest to only support doubling due to operations. 

A longer term vision is for the non power of 2 restriction to be removed but the token algorithm would need to be revised and there are edge cases with off by 1 token issues that will make maintenance tasks take longer