### PR TITLE
Generate i4i.12xlarge manual instance using auto_shape script

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws/manual_instances.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/manual_instances.json
@@ -145,6 +145,30 @@
         "block_size_kib": 4, "single_tenant": true
       }
     },
+    "i4i.12xlarge": {
+      "name": "i4i.12xlarge",
+      "cpu": 48,
+      "cpu_cores": 24,
+      "cpu_ghz": 3.5,
+      "cpu_ipc_scale": 1.0,
+      "ram_gib": 366.21,
+      "net_mbps": 28125.0,
+      "drive": {
+        "name": "ephem",
+        "size_gib": 10477,
+        "read_io_per_s": 1200000,
+        "write_io_per_s": 660000,
+        "single_tenant": true,
+        "read_io_latency_ms": {
+          "low": 0.1,
+          "mid": 0.125,
+          "high": 0.17,
+          "confidence": 0.9,
+          "minimum_value": 0.05,
+          "maximum_value": 2.0
+        }
+      }
+    },
     "i4i.16xlarge": {
       "name": "i4i.16xlarge",
       "cpu": 64,


### PR DESCRIPTION
Seems like for i4i the auto_shape / generate_missing does not support `i4i.12xlarge`. Since I do not have the context on why i4i is missing from the auto generate, I've chosen to take the output of the script and add it directly to the manual_instances.json

Interestingly, the auto generated payload adds support for `cpu_cores` and has some slightly different ram / net_mbps values. It also removes the `block_size_kib` value

<img width="1045" height="561" alt="image" src="https://github.com/user-attachments/assets/84fe106c-8477-4621-8672-a24c23fe4af4" />

```
(py310) 21:44:18 ~/repos/service-capacity-modeling mho/scale-buffer-intents $ python3 service_capacity_modeling/tools/auto_shape.py i4i
[i4i] Hardware Shapes
{
  "instances": {
    "i4i.large": {
      "name": "i4i.large",
      "cpu": 2,
      "cpu_cores": 1,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 15.26,
      "net_mbps": 781.0,
      "drive": {
        "name": "ephem",
        "size_gib": 436,
        "read_io_per_s": 50000,
        "write_io_per_s": 27500,
        "single_tenant": false,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.xlarge": {
      "name": "i4i.xlarge",
      "cpu": 4,
      "cpu_cores": 2,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 30.52,
      "net_mbps": 1875.0,
      "drive": {
        "name": "ephem",
        "size_gib": 873,
        "read_io_per_s": 100000,
        "write_io_per_s": 55000,
        "single_tenant": false,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.2xlarge": {
      "name": "i4i.2xlarge",
      "cpu": 8,
      "cpu_cores": 4,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 61.04,
      "net_mbps": 4687.0,
      "drive": {
        "name": "ephem",
        "size_gib": 1746,
        "read_io_per_s": 200000,
        "write_io_per_s": 110000,
        "single_tenant": false,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.4xlarge": {
      "name": "i4i.4xlarge",
      "cpu": 16,
      "cpu_cores": 8,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 122.07,
      "net_mbps": 9375.0,
      "drive": {
        "name": "ephem",
        "size_gib": 3492,
        "read_io_per_s": 400000,
        "write_io_per_s": 220000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.8xlarge": {
      "name": "i4i.8xlarge",
      "cpu": 32,
      "cpu_cores": 16,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 244.14,
      "net_mbps": 18750.0,
      "drive": {
        "name": "ephem",
        "size_gib": 6985,
        "read_io_per_s": 800000,
        "write_io_per_s": 440000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.12xlarge": {
      "name": "i4i.12xlarge",
      "cpu": 48,
      "cpu_cores": 24,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 366.21,
      "net_mbps": 28125.0,
      "drive": {
        "name": "ephem",
        "size_gib": 10477,
        "read_io_per_s": 1200000,
        "write_io_per_s": 660000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.16xlarge": {
      "name": "i4i.16xlarge",
      "cpu": 64,
      "cpu_cores": 32,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 488.28,
      "net_mbps": 37500.0,
      "drive": {
        "name": "ephem",
        "size_gib": 13970,
        "read_io_per_s": 1600000,
        "write_io_per_s": 880000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.24xlarge": {
      "name": "i4i.24xlarge",
      "cpu": 96,
      "cpu_cores": 48,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 732.42,
      "net_mbps": 56250.0,
      "drive": {
        "name": "ephem",
        "size_gib": 20955,
        "read_io_per_s": 2400000,
        "write_io_per_s": 1320000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    },
    "i4i.32xlarge": {
      "name": "i4i.32xlarge",
      "cpu": 128,
      "cpu_cores": 64,
      "cpu_ghz": 3.5,
      "cpu_ipc_scale": 1.0,
      "ram_gib": 976.56,
      "net_mbps": 75000.0,
      "drive": {
        "name": "ephem",
        "size_gib": 27940,
        "read_io_per_s": 3200000,
        "write_io_per_s": 1760000,
        "single_tenant": true,
        "read_io_latency_ms": {
          "low": 0.1,
          "mid": 0.125,
          "high": 0.17,
          "confidence": 0.9,
          "minimum_value": 0.05,
          "maximum_value": 2.0
        }
      }
    }
  }
}
```