### PR TITLE
Rename buffer_for_components to desired_buffer_for_components

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -168,7 +168,7 @@ def cpu_headroom_target(instance: Instance, buffers: Optional[Buffers] = None) -
     cpu_boost = 1.0 if instance.cores < instance.cpu else 1.0 / 0.6
     reserved_headroom = _reserved_headroom(instance.cpu, cpu_boost)
     if buffers is not None:
-        cpu_ratio = buffer_for_components(
+        cpu_ratio = desired_buffer_for_components(
             buffers=buffers, components=[BufferComponent.cpu]
         ).ratio
         buffer_adjusted_headroom = (1.0 - reserved_headroom) / cpu_ratio
@@ -190,7 +190,7 @@ _default_buffer_fallbacks: Dict[str, List[str]] = {
 }
 
 
-def buffer_for_components(
+def desired_buffer_for_components(
     buffers: Buffers,
     components: List[str],
     current_capacity: Optional[CurrentClusterCapacity] = None,
@@ -765,7 +765,7 @@ def get_memory_from_current_capacity(
     )
 
     # These are the desired buffers
-    memory_buffer = buffer_for_components(
+    memory_buffer = desired_buffer_for_components(
         buffers=buffers, components=[BufferComponent.memory]
     )
 
@@ -807,7 +807,7 @@ def get_network_from_current_capacity(
     )
 
     # These are the desired buffers
-    network_buffer = buffer_for_components(
+    network_buffer = desired_buffer_for_components(
         buffers=buffers, components=[BufferComponent.network]
     )
 
@@ -855,7 +855,7 @@ def get_disk_from_current_capacity(
     )
 
     # These are the desired buffers
-    disk_buffer = buffer_for_components(
+    disk_buffer = desired_buffer_for_components(
         buffers=buffers, components=[BufferComponent.disk]
     )
 

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -32,9 +32,9 @@ from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
-from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import derived_buffer_for_component
+from service_capacity_modeling.models.common import desired_buffer_for_components
 from service_capacity_modeling.models.common import network_services
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import simple_network_mbps
@@ -76,7 +76,7 @@ def _write_buffer_gib_zone(
 
 
 def _get_cores_from_desires(desires, instance):
-    cpu_buffer = buffer_for_components(
+    cpu_buffer = desired_buffer_for_components(
         buffers=desires.buffers, components=[BACKGROUND_BUFFER]
     )
 
@@ -94,7 +94,7 @@ def _get_cores_from_desires(desires, instance):
 
 
 def _get_disk_from_desires(desires, copies_per_region):
-    disk_buffer = buffer_for_components(
+    disk_buffer = desired_buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
     # Do not add disk buffers now as memory calculation is done on the disk usage
@@ -113,7 +113,7 @@ def _zonal_requirement_for_new_cluster(
     needed_disk = _get_disk_from_desires(desires, copies_per_region)
 
     # Keep some of the bandwidth available for backup and repair streaming
-    network_buffer = buffer_for_components(
+    network_buffer = desired_buffer_for_components(
         buffers=desires.buffers, components=[BACKGROUND_BUFFER]
     )
     needed_network_mbps = simple_network_mbps(desires) * network_buffer.ratio
@@ -144,7 +144,7 @@ def _estimate_cassandra_requirement(  # pylint: disable=too-many-positional-argu
     The input desires should be the **regional** desire, and this function will
     return the zonal capacity requirement
     """
-    disk_buffer = buffer_for_components(
+    disk_buffer = desired_buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
     memory_preserve = False

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -5,8 +5,8 @@ from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import Buffers
-from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import cpu_headroom_target
+from service_capacity_modeling.models.common import desired_buffer_for_components
 
 
 def test_m5_same_headroom_as_r5():
@@ -84,7 +84,7 @@ def test_2xl_headroom_with_buffer_no_hyperthreading():
 def test_default_buffer():
     buffers = Buffers(default=Buffer(ratio=4, sources={"default": Buffer(ratio=4)}))
     for component in BufferComponent:
-        result = buffer_for_components(buffers, [component])
+        result = desired_buffer_for_components(buffers, [component])
         assert result.ratio == 4
         assert component in result.components
         assert not result.sources
@@ -98,25 +98,25 @@ def test_common_buffer_fallbacks():
         }
     )
 
-    assert buffer_for_components(buffers, [BufferComponent.cpu]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.cpu]) == Buffer(
         ratio=2.0,
         components=["compute", "cpu"],
         sources={"compute": buffers.desired["compute"]},
     )
 
-    assert buffer_for_components(buffers, [BufferComponent.network]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.network]) == Buffer(
         ratio=2.0,
         components=["compute", "network"],
         sources={"compute": buffers.desired["compute"]},
     )
 
-    assert buffer_for_components(buffers, [BufferComponent.disk]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.disk]) == Buffer(
         ratio=3.2,
         components=["disk", "storage"],
         sources={"storage": buffers.desired["storage"]},
     )
 
-    assert buffer_for_components(buffers, [BufferComponent.memory]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.memory]) == Buffer(
         ratio=3.2,
         components=["memory", "storage"],
         sources={"storage": buffers.desired["storage"]},
@@ -133,22 +133,22 @@ def test_precise_buffers():
         }
     )
 
-    assert buffer_for_components(buffers, [BufferComponent.cpu]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.cpu]) == Buffer(
         ratio=2.0,
         components=["compute", "cpu"],
         sources={"custom-cpu": buffers.desired["custom-cpu"]},
     )
-    assert buffer_for_components(buffers, [BufferComponent.network]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.network]) == Buffer(
         ratio=2.5,
         components=["compute", "network"],
         sources={"custom-network": buffers.desired["custom-network"]},
     )
-    assert buffer_for_components(buffers, [BufferComponent.disk]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.disk]) == Buffer(
         ratio=3.0,
         components=["disk", "storage"],
         sources={"custom-disk": buffers.desired["custom-disk"]},
     )
-    assert buffer_for_components(buffers, [BufferComponent.memory]) == Buffer(
+    assert desired_buffer_for_components(buffers, [BufferComponent.memory]) == Buffer(
         ratio=3.5,
         components=["memory", "storage"],
         sources={"custom-memory": buffers.desired["custom-memory"]},

--- a/tests/test_desire_merge.py
+++ b/tests/test_desire_merge.py
@@ -8,7 +8,7 @@ from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
-from service_capacity_modeling.models.common import buffer_for_components
+from service_capacity_modeling.models.common import desired_buffer_for_components
 
 user_desires = CapacityDesires(
     service_tier=0,
@@ -66,27 +66,29 @@ def test_cassandra_merge():
     # Buffer tests
     # The custom component should just be itself
     assert (
-        buffer_for_components(buffers=merged.buffers, components=["custom"]).ratio
+        desired_buffer_for_components(
+            buffers=merged.buffers, components=["custom"]
+        ).ratio
         == 3.8
     )
     # The custom cpu buffer should multiply with the default 1.5 compute buffer
     # AND the 2.0 background buffer
     assert (
-        buffer_for_components(
+        desired_buffer_for_components(
             buffers=merged.buffers, components=[BufferComponent.cpu]
         ).ratio
         == 3.0 * 1.5 * 2.0
     )
     # The network should just have the default 1.5 compute and 2.0 background
     assert (
-        buffer_for_components(
+        desired_buffer_for_components(
             buffers=merged.buffers, components=[BufferComponent.network]
         ).ratio
         == 1.5 * 2.0
     )
     # Disk should just come from the default storage
     assert (
-        buffer_for_components(
+        desired_buffer_for_components(
             buffers=merged.buffers, components=[BufferComponent.disk]
         ).ratio
         == 4.0


### PR DESCRIPTION
The derived_buffer_for_components is unclear to read when next to this "buffer_for_components" method. They seem to do similar or overlapping things until you read that the buffer_for_components only handles desired buffers. So it should be renamed