### PR TITLE
Support reference_shape based on current cluster instance

### DIFF
--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -876,13 +876,22 @@ class CapacityDesires(ExcludeUnsetModel):
 
     @property
     def reference_shape(self) -> Instance:
-        if (
-            self.current_clusters
-            and self.current_clusters.zonal
-            and self.current_clusters.zonal[0].cluster_instance
-        ):
-            return self.current_clusters.zonal[0].cluster_instance
-        # TODO: Support regional reference shapes from the current cluster
+        if not self.current_clusters:
+            return default_reference_shape
+
+        zonal, regional = (self.current_clusters.zonal, self.current_clusters.regional)
+        if zonal and regional:
+            raise ValueError(
+                "The current cluster should not have both "
+                "zonal and regional instances. They're mutually exclusive."
+            )
+
+        if zonal and zonal[0].cluster_instance:
+            return zonal[0].cluster_instance
+
+        if regional and regional[0].cluster_instance:
+            return regional[0].cluster_instance
+
         return default_reference_shape
 
     def merge_with(self, defaults: "CapacityDesires") -> "CapacityDesires":

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -876,7 +876,13 @@ class CapacityDesires(ExcludeUnsetModel):
 
     @property
     def reference_shape(self) -> Instance:
-        # TODO: this should use the shape from current clusters if it is there
+        if (
+            self.current_clusters
+            and self.current_clusters.zonal
+            and self.current_clusters.zonal[0].cluster_instance
+        ):
+            return self.current_clusters.zonal[0].cluster_instance
+        # TODO: Support regional reference shapes from the current cluster
         return default_reference_shape
 
     def merge_with(self, defaults: "CapacityDesires") -> "CapacityDesires":

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -900,7 +900,7 @@ def zonal_requirements_from_current(
             mem_gib=certain_float(needed_memory_gib),
             disk_gib=certain_float(needed_disk_gib),
             network_mbps=certain_float(needed_network_mbps),
-            reference_shape=current_capacity.cluster_instance,
+            reference_shape=reference_shape,
         )
     else:
         raise ValueError("Please check if current_cluster is populated correctly.")

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -164,7 +164,6 @@ def _estimate_cassandra_requirement(  # pylint: disable=too-many-positional-argu
         capacity_requirement = zonal_requirements_from_current(
             desires.current_clusters, desires.buffers, instance, reference_shape
         )
-        reference_shape = capacity_requirement.reference_shape
         disk_scale, _ = derived_buffer_for_component(
             desires.buffers.derived, ["storage", "disk"]
         )


### PR DESCRIPTION
This was a missing feature that causes the requirements for current clusters to provision less cores than expected because it would convert the number of cores based on the reference shape

Anytime we do a right-sizing (i.e. we know the current cluster instance), we should be normalizing requirements know that the usage is based on the current instance type and not the nameless default reference instance.

Here's what happens in practice:
```
default_reference_shape = Instance(
    name="default_reference_shape",
    cpu=4,
    # Much of our benchmarking was carried out in the 5th gen i2 shape, can
    # adjust this up once we go through and fix all the latency distributions
    cpu_ghz=2.3,
    cpu_ipc_scale=1.0,
    ram_gib=8.0,
    net_mbps=1000,
)

==> CPU utilization = 25%
```

Implicitly, we are using 1 core of this 2.3 ghz 1.0 ipc scale instance.

But what if the node that this is running on is actually larger? Then the actual load we are receiving 

Let's take an extreme example:
```
i4i.4xlarge
16 CPU
3.1 GHZ
1.0 IPC scale
```

25% of this CPU represents a significantly larger load so we will be under provisioning load when right-sizing.