### PR TITLE
Bug fix: Handle node density with buffer via min count

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -69,7 +69,7 @@ def _sqrt_staffed_cores(rps: float, latency_s: float, qos: float) -> int:
     return math.ceil((rps * latency_s) + qos * math.sqrt(rps * latency_s))
 
 
-def compute_density_gib(
+def compute_max_data_per_node(
     instance: Instance,
     drive: Drive,
     disk_buffer_ratio: float,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -33,7 +33,7 @@ from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models.common import buffer_for_components
-from service_capacity_modeling.models.common import compute_density_gib
+from service_capacity_modeling.models.common import compute_max_data_per_node
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import derived_buffer_for_component
 from service_capacity_modeling.models.common import network_services
@@ -104,6 +104,50 @@ def _get_disk_from_desires(desires, copies_per_region):
         * desires.data_shape.estimated_state_size_gib.mid
         * copies_per_region
         * disk_buffer.ratio
+    )
+
+
+def _get_min_count(
+    tier: int,
+    required_cluster_size: Optional[int],
+    needed_disk_gib: float,
+    max_data_per_node_gib: float,
+):
+    """
+    Compute the minimum number of nodes required for a zone.
+
+    This function is used to prevent the planner from allocating clusters that
+    would exceed the max data per node or under the required cluster size for
+    a tier or existing cluster
+    """
+
+    # Cassandra clusters should aim to be at least 2 nodes per zone to start
+    # out with for tier 0 or tier 1. This gives us more room to "up-color"]
+    # clusters.
+    min_nodes_for_tier = 2 if tier in CRITICAL_TIERS else 0
+
+    # Prevent allocating clusters that exceed the max data per node.
+    min_nodes_for_disk = math.ceil(needed_disk_gib / max_data_per_node_gib)
+
+    # Take the max of the following in order to avoid:
+    # (1) if `required_cluster_size` < `min_nodes_for_disk`, don't let the planner
+    #     pick a shape that would exceed the max data per node
+    #
+    #     For example, if we need 4TiB of disk, and the max data per node is 1TiB,
+    #     Regardless of the `required_cluster_size`, we cannot allocate less than 4
+    #     nodes because that would exceed the max data per node.
+    #
+    # (2) if `required_cluster_size` > `min_nodes_for_disk`, don't let the
+    #     node density requirement affect the min count because the required
+    #     cluster size already meets the node density requirement.
+    #
+    #     For example, if we need 4TiB of disk, and the max data per node is 1TiB,
+    #     and the upstream requires >= 8 nodes, we can allocate 8 nodes because
+    #     each node would only have 500GB of data.
+    return max(
+        min_nodes_for_tier,
+        required_cluster_size or 0,
+        min_nodes_for_disk,
     )
 
 
@@ -362,24 +406,22 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         copies_per_region=copies_per_region,
     )
 
-    # Cassandra clusters should aim to be at least 2 nodes per zone to start
-    # out with for tier 0 or tier 1. This gives us more room to "up-color"]
-    # clusters.
-    min_count = 2 if desires.service_tier in CRITICAL_TIERS else 0
+    # Adjust the min count to adjust to prevent too much data on a single
     needed_disk_gib = int(requirement.disk_gib.mid)
     disk_buffer_ratio = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     ).ratio
-    density_gib = compute_density_gib(
+    max_data_per_node_gib = compute_max_data_per_node(
         instance,
         drive,
         disk_buffer_ratio,
         max_local_disk_gib=max_local_disk_gib,
     )
-    min_count = max(
-        min_count,
-        required_cluster_size or 0,
-        math.ceil(needed_disk_gib / density_gib),
+    min_count = _get_min_count(
+        tier=desires.service_tier,
+        required_cluster_size=required_cluster_size,
+        needed_disk_gib=needed_disk_gib,
+        max_data_per_node_gib=max_data_per_node_gib,
     )
 
     base_mem = _get_base_memory(desires)
@@ -689,6 +731,26 @@ class NflxCassandraCapacityModel(CapacityModel):
         return NflxCassandraArguments.model_json_schema()
 
     @staticmethod
+    def default_buffers() -> Buffers:
+        return Buffers(
+            default=Buffer(ratio=1.5),
+            desired={
+                "compute": Buffer(ratio=1.5, components=[BufferComponent.compute]),
+                "storage": Buffer(ratio=4.0, components=[BufferComponent.storage]),
+                # Cassandra reserves headroom in both cpu and network for background
+                # work and tasks
+                "background": Buffer(
+                    ratio=2.0,
+                    components=[
+                        BufferComponent.cpu,
+                        BufferComponent.network,
+                        BACKGROUND_BUFFER,
+                    ],
+                ),
+            },
+        )
+
+    @staticmethod
     def default_desires(user_desires, extra_model_arguments: Dict[str, Any]):
         acceptable_consistency = {
             None,
@@ -715,24 +777,7 @@ class NflxCassandraCapacityModel(CapacityModel):
 
         # By supplying these buffers we can deconstruct observed utilization into
         # load versus buffer.
-        buffers = Buffers(
-            default=Buffer(ratio=1.5),
-            desired={
-                "compute": Buffer(ratio=1.5, components=[BufferComponent.compute]),
-                "storage": Buffer(ratio=4.0, components=[BufferComponent.storage]),
-                # Cassandra reserves headroom in both cpu and network for background
-                # work and tasks
-                "background": Buffer(
-                    ratio=2.0,
-                    components=[
-                        BufferComponent.cpu,
-                        BufferComponent.network,
-                        BACKGROUND_BUFFER,
-                    ],
-                ),
-            },
-        )
-
+        buffers = NflxCassandraCapacityModel.default_buffers()
         if user_desires.query_pattern.access_pattern == AccessPattern.latency:
             return CapacityDesires(
                 query_pattern=QueryPattern(

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -43,6 +43,7 @@ from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import working_set_from_drive_and_slo
 from service_capacity_modeling.models.common import zonal_requirements_from_current
+from service_capacity_modeling.models.utils import is_power_of_2
 from service_capacity_modeling.models.utils import next_doubling
 from service_capacity_modeling.models.utils import next_power_of_2
 from service_capacity_modeling.stats import dist_for_interval
@@ -352,7 +353,7 @@ def _get_cluster_size_lambda(
 ) -> Callable[[int], int]:
     if required_cluster_size:
         return lambda x: next_doubling(x, base=required_cluster_size)
-    elif current_cluster_size:
+    elif current_cluster_size and not is_power_of_2(current_cluster_size):
         return lambda x: next_doubling(x, base=current_cluster_size)
     else:  # New provisionings
         return next_power_of_2

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -31,7 +31,7 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.models import CapacityModel
-from service_capacity_modeling.models.common import compute_density_gib
+from service_capacity_modeling.models.common import compute_max_data_per_node
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import get_cores_from_current_capacity
 from service_capacity_modeling.models.common import get_disk_from_current_capacity
@@ -299,13 +299,13 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         read_write_ratio = reads_per_sec / (reads_per_sec + writes_per_sec)
 
     needed_disk_gib = int(requirement.disk_gib.mid)
-    density_gib = compute_density_gib(
+    max_data_per_node_gib = compute_max_data_per_node(
         instance,
         drive,
         1,
         max_local_disk_gib=max_local_disk_gib,
     )
-    min_count = math.ceil(needed_disk_gib / density_gib)
+    min_count = math.ceil(needed_disk_gib / max_data_per_node_gib)
     cluster = compute_stateful_zone(
         instance=instance,
         drive=drive,

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -36,8 +36,8 @@ from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import utils
 from service_capacity_modeling.models.common import buffer_for_components
-from service_capacity_modeling.models.common import compute_max_data_per_node
 from service_capacity_modeling.models.common import compute_stateful_zone
+from service_capacity_modeling.models.common import get_effective_disk_per_node_gib
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import zonal_requirements_from_current
@@ -321,12 +321,12 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     disk_buffer_ratio = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     ).ratio
-    max_data_per_node_gib = compute_max_data_per_node(
+    max_data_per_node_gib = get_effective_disk_per_node_gib(
         instance,
         drive,
         disk_buffer_ratio,
-        max_local_disk_gib=max_local_disk_gib,
-        max_attached_disk_gib=max_attached_disk_gib,
+        max_local_data_per_node_gib=max_local_disk_gib,
+        max_attached_data_per_node_gib=max_attached_disk_gib,
     )
     min_count = math.ceil(needed_disk_gib / max_data_per_node_gib)
     cluster = compute_stateful_zone(

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -36,7 +36,7 @@ from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import utils
 from service_capacity_modeling.models.common import buffer_for_components
-from service_capacity_modeling.models.common import compute_density_gib
+from service_capacity_modeling.models.common import compute_max_data_per_node
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -321,14 +321,14 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     disk_buffer_ratio = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     ).ratio
-    density_gib = compute_density_gib(
+    max_data_per_node_gib = compute_max_data_per_node(
         instance,
         drive,
         disk_buffer_ratio,
         max_local_disk_gib=max_local_disk_gib,
         max_attached_disk_gib=max_attached_disk_gib,
     )
-    min_count = math.ceil(needed_disk_gib / density_gib)
+    min_count = math.ceil(needed_disk_gib / max_data_per_node_gib)
     cluster = compute_stateful_zone(
         instance=instance,
         drive=drive,

--- a/service_capacity_modeling/models/utils.py
+++ b/service_capacity_modeling/models/utils.py
@@ -62,5 +62,21 @@ def next_power_of_2(y: float) -> int:
     return 1 if x == 0 else 2 ** (x - 1).bit_length()
 
 
+def is_power_of_2(y: float) -> bool:
+    """Check if x is a power of 2 or 1"""
+    return y == next_power_of_2(y)
+
+
+def next_doubling(x: float, base: int) -> int:
+    # Some clusters were provisioned as non powers of (e.g. 12)
+    # And so if a requirement cannot be satisifed by a cluster
+    # we would want to round up to the next doubling
+    # E.g. 12 -> 24 -> 48
+    # e.g. 3 -> 6 -> 12
+    if x <= base:
+        return int(base)
+    return int(base * (2 ** math.ceil(math.log(x / base, 2))))
+
+
 def next_n(x: float, n: float) -> int:
     return int(math.ceil(x / n)) * int(n)

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -157,7 +157,9 @@ def test_kafka_high_throughput():
 
     for lr in plan.least_regret:
         logger.debug(lr.candidate_clusters.zonal[0])
-        assert 50_000 < lr.candidate_clusters.total_annual_cost < 200_000
+        # 37 i3en.xlarge 166k
+        # 18 i3en.2xlarge 162k
+        assert 50_000 < lr.candidate_clusters.total_annual_cost < 205_000
         clstr = lr.candidate_clusters.zonal[0]
         if clstr.instance.drive is None:
             assert clstr.attached_drives[0].name == "gp3"

--- a/tests/netflix/test_kafka.py
+++ b/tests/netflix/test_kafka.py
@@ -193,7 +193,7 @@ def test_kafka_high_throughput_ebs():
             "cluster_type": ClusterType.ha,
             "retention": "PT3H",
             # Force to attached drives
-            "max_local_disk_gib": 500,
+            "max_local_disk_gib": 125,
         },
         num_results=3,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,9 @@ from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ZoneClusterCapacity
+from service_capacity_modeling.models.utils import is_power_of_2
+from service_capacity_modeling.models.utils import next_doubling
+from service_capacity_modeling.models.utils import next_power_of_2
 from service_capacity_modeling.models.utils import reduce_by_family
 
 
@@ -173,3 +176,39 @@ def test_reduce_by_family_unlimited():
 
     # Should return all 5 plans since we have 3 from family_a and 2 from family_b
     assert len(result) == 5
+
+
+def test_power_of_2_functions():
+    """Test both next_power_of_2 and is_power_of_2 functions comprehensively."""
+    # Edge cases: 0 → 1, False; 1 → 1, True
+    assert next_power_of_2(0) == 1
+    assert not is_power_of_2(0)
+    assert next_power_of_2(1) == 1
+    assert is_power_of_2(1)
+
+    powers_of_2 = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+
+    # Test each power and range between powers
+    for i, current_power in enumerate(powers_of_2):
+        range_start = 0 if i == 0 else powers_of_2[i - 1] + 1
+
+        # Non-powers should round up to current_power
+        for test_value in range(range_start, current_power):
+            assert not is_power_of_2(test_value)
+            assert next_power_of_2(test_value) == current_power
+
+        # Current power should return itself
+        assert is_power_of_2(current_power)
+        assert next_power_of_2(current_power) == current_power
+
+
+def test_next_doubling():
+    # Case 1: prime (3)
+    for i in range(0, 4):
+        assert next_doubling(i, 3) == 3
+    for i in range(4, 7):
+        assert next_doubling(i, 3) == 6
+    for i in range(7, 13):
+        assert next_doubling(i, 3) == 12
+    for i in range(13, 25):
+        assert next_doubling(i, 3) == 24


### PR DESCRIPTION
**What changed:**
- Added `compute_max_data_per_node()` function to enforce per-node data limits
- Replaced hardcoded buffer ratios with configurable `default_buffers()` per model
- Models now respect `max_local_disk_gib` constraints when sizing clusters. In the past many clusters were over provisioned and allocating much less than this amount because buffer was never applied
- Added helper functions to centralize min node count logic

**Why:**
- Prevents overloading individual nodes with too much data
- Makes buffer ratios configurable instead of magic numbers
- Ensures cluster sizing considers both capacity needs and node density limits