### PR TITLE
feat: add node-count bottleneck breakdown to compute_stateful_zone

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -191,8 +191,12 @@ def _attached_drive_plan(
     if (read_io + write_io) > drive.max_io_per_s:
         ratio = (read_io + write_io) / drive.max_io_per_s
         count_disk_iops = math.ceil(effective_count * ratio)
-        read_io = utils.next_n(read_io * ratio, n=200)
-        write_io = utils.next_n(write_io * ratio, n=200)
+        iops_count = max(cluster_size(count_disk_iops), min_count)
+        read_io, write_io = required_disk_ios(space_gib, iops_count)
+        read_io, write_io = (
+            utils.next_n(read_io, n=200),
+            utils.next_n(write_io, n=200),
+        )
 
     attached_drive = drive.model_copy()
     attached_drive.size_gib = ebs_gib

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -50,6 +50,155 @@ logger = logging.getLogger(__name__)
 SECONDS_IN_YEAR = 31556926
 
 EFFECTIVE_DISK_PER_NODE_GIB = "effective_disk_per_node_gib"
+REQUIRED_NODES_BY_TYPE = "required_nodes_by_type"
+COUNT_BOTTLENECK = "count_bottleneck"
+
+
+def _select_count_bottleneck(
+    resource_counts: Dict[str, int],
+    cluster_size_count: int,
+    min_count: int,
+) -> Optional[str]:
+    if not resource_counts:
+        return None
+
+    resource_bottleneck = max(
+        resource_counts, key=lambda constraint: resource_counts[constraint]
+    )
+    resource_count = resource_counts[resource_bottleneck]
+    cluster_size_added = max(0, cluster_size_count - resource_count)
+    min_count_added = max(0, min_count - max(resource_count, cluster_size_count))
+
+    if min_count_added > 0:
+        return "min_count"
+    if cluster_size_added > 0:
+        return "cluster_size"
+    return resource_bottleneck
+
+
+def _count_breakdown(
+    *,
+    count_cpu: int,
+    count_memory: int,
+    count_network: int,
+    count_disk_capacity: int,
+    count_disk_iops: int,
+    cluster_size_count: int,
+    min_count: int,
+) -> Dict[str, Any]:
+    resource_counts = {
+        "cpu": count_cpu,
+        "memory": count_memory,
+        "network": count_network,
+        "disk_capacity": count_disk_capacity,
+        "disk_iops": count_disk_iops,
+    }
+    return {
+        REQUIRED_NODES_BY_TYPE: {
+            **resource_counts,
+            "cluster_size": cluster_size_count,
+            "min_count": min_count,
+        },
+        COUNT_BOTTLENECK: _select_count_bottleneck(
+            resource_counts=resource_counts,
+            cluster_size_count=cluster_size_count,
+            min_count=min_count,
+        ),
+    }
+
+
+def _local_disk_node_counts(
+    *,
+    instance: Instance,
+    needed_disk_gib: float,
+    adjusted_disk_io_needed: float,
+    read_write_ratio: float,
+) -> Tuple[int, int]:
+    assert instance.drive is not None
+    count_disk_capacity = math.ceil(needed_disk_gib / instance.drive.size_gib)
+    count_disk_iops = 0
+    if adjusted_disk_io_needed != 0.0:
+        instance_read_iops = (
+            instance.drive.read_io_per_s
+            if instance.drive.read_io_per_s is not None
+            else 0
+        )
+        assert isinstance(instance_read_iops, int)
+        instance_write_iops = (
+            instance.drive.write_io_per_s
+            if instance.drive.write_io_per_s is not None
+            else 0
+        )
+        assert isinstance(instance_write_iops, int)
+        instance_adjusted_io = (
+            (
+                read_write_ratio * float(instance_read_iops)
+                + (1.0 - read_write_ratio) * float(instance_write_iops)
+            )
+            * instance.drive.block_size_kib
+            * 1024.0
+        )
+        if instance_adjusted_io != 0.0:
+            count_disk_iops = math.ceil(adjusted_disk_io_needed / instance_adjusted_io)
+    return count_disk_capacity, count_disk_iops
+
+
+def _attached_drive_plan(
+    *,
+    drive: Drive,
+    needed_disk_gib: float,
+    count_cpu: int,
+    count_memory: int,
+    count_network: int,
+    cluster_size: Callable[[int], int],
+    min_count: int,
+    required_disk_ios: Callable[[float, int], Tuple[float, float]],
+    max_node_disk_gib: Callable[[Drive], int],
+) -> Tuple[int, int, List[Drive]]:
+    preliminary_resource_count = max(count_cpu, count_memory, count_network)
+    preliminary_count = max(cluster_size(preliminary_resource_count), min_count)
+
+    space_gib = max(1, math.ceil(needed_disk_gib / preliminary_count))
+    read_io, write_io = required_disk_ios(space_gib, preliminary_count)
+    read_io, write_io = (
+        utils.next_n(read_io, n=200),
+        utils.next_n(write_io, n=200),
+    )
+    io_gib = cloud_gib_for_io(drive, read_io + write_io, space_gib)
+    ebs_gib = utils.next_n(max(1, io_gib, space_gib), n=100)
+
+    count_disk_capacity = 0
+    max_size = max_node_disk_gib(drive)
+    if max_size > 0:
+        count_disk_capacity = math.ceil(needed_disk_gib / max_size)
+    if ebs_gib > max_size > 0:
+        count_disk_capacity = max(
+            count_disk_capacity,
+            math.ceil(preliminary_count * ebs_gib / max_size),
+        )
+        ebs_gib = int(max_size)
+
+    effective_count = max(
+        cluster_size(max(preliminary_count, count_disk_capacity)), min_count
+    )
+    read_io, write_io = required_disk_ios(space_gib, effective_count)
+    read_io, write_io = (
+        utils.next_n(read_io, n=200),
+        utils.next_n(write_io, n=200),
+    )
+
+    count_disk_iops = 0
+    if (read_io + write_io) > drive.max_io_per_s:
+        ratio = (read_io + write_io) / drive.max_io_per_s
+        count_disk_iops = math.ceil(effective_count * ratio)
+        read_io = utils.next_n(read_io * ratio, n=200)
+        write_io = utils.next_n(write_io * ratio, n=200)
+
+    attached_drive = drive.model_copy()
+    attached_drive.size_gib = ebs_gib
+    attached_drive.read_io_per_s = int(round(read_io, 2))
+    attached_drive.write_io_per_s = int(round(write_io, 2))
+    return count_disk_capacity, count_disk_iops, [attached_drive]
 
 
 def upsert_params(cluster: ClusterCapacity, params: Dict[str, Any]) -> None:
@@ -538,109 +687,55 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
     # Maximum EBS volume size per node. Default caps at 1/3 max to leave
     # growth headroom. Models can override for clusters with known disk needs.
     max_node_disk_gib: Callable[[Drive], int] = lambda d: math.ceil(d.max_size_gib / 3),
+    include_node_count_breakdown: bool = False,
 ) -> ZoneClusterCapacity:
-    # How many instances do we need for the CPU
-    count = math.ceil(needed_cores / instance.cpu)
+    count_cpu = math.ceil(needed_cores / instance.cpu)
 
-    # How many instances do we need for the ram, taking into account
-    # reserved memory for the application and system
-    count = max(
-        count,
-        math.ceil(
-            needed_memory_gib / (instance.ram_gib - reserve_memory(instance.ram_gib))
-        ),
+    # RAM: max of page cache/working set and write buffer (both consume RAM)
+    count_memory = math.ceil(
+        needed_memory_gib / (instance.ram_gib - reserve_memory(instance.ram_gib))
     )
-    # Account for if the stateful service needs a certain amount of reserved
-    # memory for a given throughput.
     if write_buffer(instance.ram_gib) > 0:
-        count = max(
-            count,
+        count_memory = max(
+            count_memory,
             math.ceil(required_write_buffer_gib / (write_buffer(instance.ram_gib))),
         )
 
-    # How many instances do we need for the network
-    count = max(count, math.ceil(needed_network_mbps / instance.net_mbps))
+    count_network = math.ceil(needed_network_mbps / instance.net_mbps)
 
-    # How many instances do we need for the disk
+    count_disk_capacity = 0
+    count_disk_iops = 0
+
     if instance.drive is not None and instance.drive.size_gib > 0:
-        disk_per_node = instance.drive.size_gib
-        count = max(count, math.ceil(needed_disk_gib / disk_per_node))
-        if adjusted_disk_io_needed != 0.0:
-            instance_read_iops = (
-                instance.drive.read_io_per_s
-                if instance.drive.read_io_per_s is not None
-                else 0
-            )
-            assert isinstance(instance_read_iops, int)
-            instance_write_iops = (
-                instance.drive.write_io_per_s
-                if instance.drive.write_io_per_s is not None
-                else 0
-            )
-            assert isinstance(instance_write_iops, int)
-            instance_adjusted_io = (
-                (
-                    read_write_ratio * float(instance_read_iops)
-                    + (1.0 - read_write_ratio) * float(instance_write_iops)
-                )
-                * instance.drive.block_size_kib
-                * 1024.0
-            )
-            if instance_adjusted_io != 0.0:
-                count = max(
-                    count, math.ceil(adjusted_disk_io_needed / instance_adjusted_io)
-                )
+        count_disk_capacity, count_disk_iops = _local_disk_node_counts(
+            instance=instance,
+            needed_disk_gib=needed_disk_gib,
+            adjusted_disk_io_needed=adjusted_disk_io_needed,
+            read_write_ratio=read_write_ratio,
+        )
 
-    count = max(cluster_size(count), min_count)
-    cost = count * instance.annual_cost
-
-    attached_drives = []
+    attached_drives: List[Drive] = []
     if instance.drive is None and needed_disk_gib > 0:
-        # If we don't have disks attach the cloud drive with enough
-        # space and IO for the requirement
-
-        # Note that cloud drivers are provisioned _per node_ and must be chosen for
-        # the max of space and IOS.
-        space_gib = max(1, math.ceil(needed_disk_gib / count))
-        read_io, write_io = required_disk_ios(space_gib, count)
-        read_io, write_io = (
-            utils.next_n(read_io, n=200),
-            utils.next_n(write_io, n=200),
+        count_disk_capacity, count_disk_iops, attached_drives = _attached_drive_plan(
+            drive=drive,
+            needed_disk_gib=needed_disk_gib,
+            count_cpu=count_cpu,
+            count_memory=count_memory,
+            count_network=count_network,
+            cluster_size=cluster_size,
+            min_count=min_count,
+            required_disk_ios=required_disk_ios,
+            max_node_disk_gib=max_node_disk_gib,
         )
-        total_ios = read_io + write_io
-        io_gib = cloud_gib_for_io(drive, total_ios, space_gib)
 
-        # Provision EBS in increments of 100 GiB
-        ebs_gib = utils.next_n(max(1, io_gib, space_gib), n=100)
-
-        max_size = max_node_disk_gib(drive)
-        if ebs_gib > max_size > 0:
-            ratio = ebs_gib / max_size
-            count = max(cluster_size(math.ceil(count * ratio)), min_count)
-            cost = count * instance.annual_cost
-            ebs_gib = int(max_size)
-
-        read_io, write_io = required_disk_ios(space_gib, count)
-        read_io, write_io = (
-            utils.next_n(read_io, n=200),
-            utils.next_n(write_io, n=200),
-        )
-        if (read_io + write_io) > drive.max_io_per_s:
-            ratio = (read_io + write_io) / drive.max_io_per_s
-            count = max(cluster_size(math.ceil(count * ratio)), min_count)
-            cost = count * instance.annual_cost
-            read_io = utils.next_n(read_io * ratio, n=200)
-            write_io = utils.next_n(write_io * ratio, n=200)
-
-        attached_drive = drive.model_copy()
-        attached_drive.size_gib = ebs_gib
-        attached_drive.read_io_per_s = int(round(read_io, 2))
-        attached_drive.write_io_per_s = int(round(write_io, 2))
-
-        # TODO: appropriately handle RAID setups for throughput requirements
-        attached_drives.append(attached_drive)
-
-        cost = cost + (attached_drive.annual_cost * count)
+    raw_count = max(
+        count_cpu, count_memory, count_network, count_disk_capacity, count_disk_iops
+    )
+    cluster_size_count = cluster_size(raw_count)
+    count = max(cluster_size_count, min_count)
+    cost = count * instance.annual_cost
+    if attached_drives:
+        cost += attached_drives[0].annual_cost * count
 
     logger.debug(
         "For (cpu, memory_gib, disk_gib) = (%s, %s, %s) need (%s, %s, %s, %s)",
@@ -653,12 +748,25 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
         cost,
     )
 
+    cluster_params: Dict[str, Any] = {}
+    if include_node_count_breakdown:
+        cluster_params = _count_breakdown(
+            count_cpu=count_cpu,
+            count_memory=count_memory,
+            count_network=count_network,
+            count_disk_capacity=count_disk_capacity,
+            count_disk_iops=count_disk_iops,
+            cluster_size_count=cluster_size_count,
+            min_count=min_count,
+        )
+
     return ZoneClusterCapacity(
         cluster_type="stateful-cluster",
         count=count,
         instance=instance,
         attached_drives=attached_drives,
         annual_cost=cost,
+        cluster_params=cluster_params,
     )
 
 

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -1,0 +1,145 @@
+"""Tests for opt-in node-count explainability in compute_stateful_zone."""
+
+import pytest
+
+from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.models.common import compute_stateful_zone
+
+EBS = Drive(name="gp3", size_gib=0)
+M5_4XL = shapes.instance("m5.4xlarge")  # 16 vCPU, 64 GiB
+I4I_4XL = shapes.instance("i4i.4xlarge")
+
+EXPECTED_KEYS = {
+    "cpu",
+    "memory",
+    "network",
+    "disk_capacity",
+    "disk_iops",
+    "cluster_size",
+    "min_count",
+}
+
+
+@pytest.mark.parametrize(
+    "cores,mem,disk,net,expected_bottleneck",
+    [
+        (48, 10, 100, 100, "cpu"),  # ceil(48/16)=3 dominates
+        (4, 200, 100, 100, "memory"),  # ceil(200/64)=4 dominates
+        (4, 10, 100, 60_000, "network"),  # ceil(60000/10000)=6 dominates
+    ],
+    ids=["cpu-bound", "memory-bound", "network-bound"],
+)
+def test_count_bottleneck_resource(cores, mem, disk, net, expected_bottleneck):
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=cores,
+        needed_disk_gib=disk,
+        needed_memory_gib=mem,
+        needed_network_mbps=net,
+        include_node_count_breakdown=True,
+    )
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert set(counts.keys()) == EXPECTED_KEYS
+    assert cluster.cluster_params["count_bottleneck"] == expected_bottleneck
+
+
+def test_storage_bound_local():
+    cluster = compute_stateful_zone(
+        instance=I4I_4XL,
+        drive=I4I_4XL.drive,
+        needed_cores=4,
+        needed_disk_gib=20_000,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        include_node_count_breakdown=True,
+    )
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert cluster.cluster_params["count_bottleneck"] == "disk_capacity"
+    assert counts["disk_capacity"] > counts["cpu"]
+
+
+def test_write_buffer_merged_into_memory():
+    """Write buffer inflates memory count (same RAM, different slice)."""
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=4,
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        reserve_memory=lambda x: 4.0,
+        write_buffer=lambda x: 0.25,  # 0.25 GiB per node
+        required_write_buffer_gib=2.0,  # ceil(2.0/0.25) = 8 nodes
+        include_node_count_breakdown=True,
+    )
+    assert cluster.cluster_params["required_nodes_by_type"]["memory"] == 8
+
+
+def test_breakdown_is_opt_in():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=48,
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+    )
+    assert "required_nodes_by_type" not in cluster.cluster_params
+    assert "count_bottleneck" not in cluster.cluster_params
+
+
+def test_cluster_size_is_reported_when_rounding_adds_nodes():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=48,  # ceil(48/16) = 3 nodes
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        cluster_size=lambda x: x if x % 2 == 0 else x + 1,  # round up to even
+        include_node_count_breakdown=True,
+    )
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert counts["cpu"] == 3
+    assert counts["cluster_size"] == 4
+    assert counts["min_count"] == 0
+    assert cluster.cluster_params["count_bottleneck"] == "cluster_size"
+    assert cluster.count == 4
+
+
+def test_min_count_is_reported_when_it_adds_nodes():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=4,  # ceil(4/16) = 1 node
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        min_count=6,
+        include_node_count_breakdown=True,
+    )
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert counts["cpu"] == 1
+    assert counts["cluster_size"] == 1
+    assert counts["min_count"] == 6
+    assert cluster.cluster_params["count_bottleneck"] == "min_count"
+    assert cluster.count == 6
+
+
+def test_topology_constraints_do_not_override_stronger_resource_limits():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=640,  # ceil(640/16) = 40 nodes
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        min_count=6,
+        include_node_count_breakdown=True,
+    )
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert counts["cpu"] == 40
+    assert counts["min_count"] == 6
+    assert cluster.cluster_params["count_bottleneck"] == "cpu"

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -60,6 +60,31 @@ def test_storage_bound_local():
     assert counts["disk_capacity"] > counts["cpu"]
 
 
+def test_attached_drive_iops_overflow_recalculates_per_node_iops():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=Drive(
+            name="tiny-ebs",
+            size_gib=0,
+            max_scale_size_gib=1_000,
+            max_scale_io_per_s=1_000,
+        ),
+        needed_cores=4,
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        required_disk_ios=lambda _size, count: (1200 / count, 0.0),
+        include_node_count_breakdown=True,
+    )
+
+    attached_drive = cluster.attached_drives[0]
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert counts["disk_iops"] == 2
+    assert cluster.count == 2
+    assert attached_drive.read_io_per_s == 600
+    assert attached_drive.read_io_per_s < attached_drive.max_io_per_s
+
+
 def test_write_buffer_merged_into_memory():
     """Write buffer inflates memory count (same RAM, different slice)."""
     cluster = compute_stateful_zone(


### PR DESCRIPTION
## Summary
- Add opt-in `required_nodes_by_type` and `count_bottleneck` cluster params from `compute_stateful_zone`
- Keep explainability off by default for existing callers
- Split the attached-drive EBS IOPS overflow fix into its own atomic commit so the behavior change is reviewable on its own

## Commits
- `feat: add opt-in node-count bottleneck breakdown`
- `fix: recalculate EBS IOPS after overflow instead of scaling by ratio`

## Test plan
- [x] `tox -e py310 -- tests/test_resource_counts.py`
- [x] Added attached-drive IOPS overflow regression coverage

> Stack 1/3: base of #259, then #260.