### PR TITLE
feat: surface Cassandra count bottleneck details and write-buffer caps

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -46,6 +46,8 @@ from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models import RANK_PENALTIES
+from service_capacity_modeling.models.common import COUNT_BOTTLENECK
+from service_capacity_modeling.models.common import REQUIRED_NODES_BY_TYPE
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import DerivedBuffers
@@ -690,6 +692,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         write_buffer=lambda x: heap_fn(x) * max_write_buffer_percent * 0.25,
         required_write_buffer_gib=float(requirement.context["write_buffer_gib"]),
         max_node_disk_gib=max_node_disk,
+        include_node_count_breakdown=True,
     )
 
     # Communicate to the actual provision that if we want reduced RF
@@ -731,15 +734,21 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     # Sometimes we don't want modify cluster topology, so only allow
     # topologies that match the desired zone size
     if required_cluster_size is not None and cluster.count != required_cluster_size:
+        required_nodes_by_type = cluster.cluster_params.get(REQUIRED_NODES_BY_TYPE, {})
+        count_bottleneck = cluster.cluster_params.get(COUNT_BOTTLENECK, "unknown")
         return Excuse(
             instance=instance.name,
             drive=drive_name,
             reason=(
-                f"Cluster size {cluster.count} != required {required_cluster_size}"
+                f"Cluster size {cluster.count} "
+                f"(count bottleneck: {count_bottleneck}) "
+                f"!= required {required_cluster_size}"
             ),
             context={
                 "computed_count": cluster.count,
                 "required_cluster_size": required_cluster_size,
+                "required_nodes_by_type": required_nodes_by_type,
+                "count_bottleneck": count_bottleneck,
             },
             bottleneck=Bottleneck.cluster_size,
         )

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -66,6 +66,7 @@ from service_capacity_modeling.models.org.netflix.cassandra_memory import (
     estimate_memory_experimental,
     estimate_memory_legacy,
 )
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.models.utils import is_power_of_2
 from service_capacity_modeling.models.utils import next_doubling
 from service_capacity_modeling.models.utils import next_power_of_2
@@ -667,6 +668,35 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     def max_node_disk(d: Drive) -> int:
         return max(math.ceil(d.max_size_gib / 3), ebs_disk_floor)
 
+    # Apply memory-only derived buffers to the write-buffer requirement so
+    # scale_down caps both page cache and memtable space at current allocation.
+    raw_write_buffer_gib = float(requirement.context["write_buffer_gib"])
+    if raw_write_buffer_gib > 0 and current_capacity:
+        try:
+            current_instance = current_capacity.cluster_instance or shapes.instance(
+                current_capacity.cluster_instance_name
+            )
+        except KeyError:
+            current_instance = None
+        if current_instance is not None:
+            # Per-node write buffer = heap × max_write_buffer_percent × 0.25,
+            # matching the write_buffer lambda passed to compute_stateful_zone.
+            existing_write_buffer = (
+                current_capacity.cluster_instance_count.mid
+                * _cass_heap(current_instance.ram_gib)
+                * max_write_buffer_percent
+                * 0.25
+            )
+            memory_derived = DerivedBuffers.for_components(
+                desires.buffers.derived,
+                [BufferComponent.memory],
+                component_fallbacks={},
+            )
+            raw_write_buffer_gib = memory_derived.calculate_requirement(
+                current_usage=raw_write_buffer_gib,
+                existing_capacity=existing_write_buffer,
+            )
+
     cluster = compute_stateful_zone(
         instance=instance,
         drive=drive,
@@ -690,7 +720,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         # memtable_cleanup_threshold * memtable_size. At Netflix this
         # is 0.11 * 25 * heap
         write_buffer=lambda x: heap_fn(x) * max_write_buffer_percent * 0.25,
-        required_write_buffer_gib=float(requirement.context["write_buffer_gib"]),
+        required_write_buffer_gib=raw_write_buffer_gib,
         max_node_disk_gib=max_node_disk,
         include_node_count_breakdown=True,
     )

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -111,7 +111,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -128,7 +138,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -145,7 +165,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -180,7 +210,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -200,7 +240,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -220,7 +270,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -252,7 +312,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -269,7 +339,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -286,7 +366,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -321,7 +411,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -341,7 +441,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -361,7 +471,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -396,9 +516,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -419,9 +549,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -442,9 +582,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -480,7 +630,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -500,7 +660,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -520,7 +690,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -812,9 +992,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",
@@ -832,9 +1022,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",
@@ -852,9 +1052,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -1,0 +1,51 @@
+"""Tests for Cassandra cluster-size excuse explainability."""
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import (
+    AccessPattern,
+    CapacityDesires,
+    DataShape,
+    Interval,
+    QueryPattern,
+)
+
+SMALL_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_cluster_size_excuse_has_count_bottleneck_details():
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=SMALL_KV,
+        extra_model_arguments={"required_cluster_size": 2, "require_local_disks": True},
+        num_results=5,
+    )
+    excuses = [e for e in explained.excuses if "count bottleneck:" in e.reason]
+    assert excuses, "Expected cluster_size excuses with count bottleneck details"
+    for e in excuses:
+        counts = e.context["required_nodes_by_type"]
+        assert set(counts.keys()) == {
+            "cpu",
+            "memory",
+            "network",
+            "disk_capacity",
+            "disk_iops",
+            "cluster_size",
+            "min_count",
+        }
+        assert e.context["count_bottleneck"] in counts
+        assert e.context["count_bottleneck"] in e.reason

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -1,12 +1,21 @@
 """Tests for Cassandra cluster-size excuse explainability."""
 
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import (
     AccessPattern,
+    Buffer,
+    BufferComponent,
+    BufferIntent,
+    Buffers,
     CapacityDesires,
+    CurrentClusters,
+    CurrentZoneClusterCapacity,
     DataShape,
     Interval,
     QueryPattern,
+    certain_float,
+    certain_int,
 )
 
 SMALL_KV = CapacityDesires(
@@ -49,3 +58,80 @@ def test_cluster_size_excuse_has_count_bottleneck_details():
         }
         assert e.context["count_bottleneck"] in counts
         assert e.context["count_bottleneck"] in e.reason
+
+
+WRITE_HEAVY_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=5000, mid=20000, high=40000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_memory_scale_down_caps_write_buffer():
+    """Memory scale_down should not exceed current write-buffer capacity."""
+    i4i_4xl = shapes.instance("i4i.4xlarge")
+    current_cluster = CurrentZoneClusterCapacity(
+        cluster_instance=i4i_4xl,
+        cluster_instance_name="i4i.4xlarge",
+        cluster_instance_count=certain_int(4),
+        cpu_utilization=certain_float(10),
+        memory_utilization_gib=certain_float(10),
+        disk_utilization_gib=certain_float(500),
+        network_utilization_mbps=certain_float(100),
+    )
+
+    uncapped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=WRITE_HEAVY_KV,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert uncapped_plans, "Expected uncapped plan"
+
+    capped_desires = WRITE_HEAVY_KV.model_copy(deep=True)
+    capped_desires.current_clusters = CurrentClusters(zonal=[current_cluster])
+    capped_desires.buffers = Buffers(
+        derived={
+            "memory": Buffer(
+                intent=BufferIntent.scale_down,
+                ratio=1.0,
+                components=[BufferComponent.memory],
+            ),
+        }
+    )
+
+    capped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=capped_desires,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert capped_plans, "Expected capped plan"
+
+    capped_zone = capped_plans[0].candidate_clusters.zonal[0]
+    capped_counts = capped_zone.cluster_params["required_nodes_by_type"]
+
+    assert "memory" in capped_counts
+    assert capped_zone.cluster_params["count_bottleneck"] is not None
+
+    for plan in uncapped_plans:
+        zone = plan.candidate_clusters.zonal[0]
+        if zone.instance.name == capped_zone.instance.name:
+            uncapped_mem = zone.cluster_params["required_nodes_by_type"]["memory"]
+            assert capped_counts["memory"] <= uncapped_mem, (
+                f"Expected capped memory ({capped_counts['memory']}) "
+                f"<= uncapped ({uncapped_mem}) for {capped_zone.instance.name}"
+            )
+            break


### PR DESCRIPTION
## Summary
- Surface `required_nodes_by_type` and `count_bottleneck` in Cassandra cluster-size excuses
- Use bottleneck wording in excuse text so callers can see why the computed count missed the required topology
- Cap `write_buffer_gib` from memory-only derived buffers when current cluster state is available
- Hydrate `cluster_instance` from name for the common name-only current-cluster path
- Keep explainability consumer and write-buffer behavior in separate atomic commits

## Commits
- `feat: expose Cassandra count bottleneck details`
- `feat: cap Cassandra write buffer from current memory policy`

## Test plan
- [x] `tox -e py310 -- tests/netflix/test_cassandra_resource_counts.py tests/netflix/test_cost_regression.py`
- [x] Memory scale-down cap path covered in `tests/netflix/test_cassandra_resource_counts.py`

> Stack 2/3: depends on #258. Merge order: #258 → #259 → #260.