### PR TITLE
feat: add explicit derived buffer floor and ceiling intents

### DIFF
--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from pydantic import computed_field
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 from service_capacity_modeling.enum_utils import enum_docstrings
 from service_capacity_modeling.enum_utils import StrEnum
@@ -947,13 +948,26 @@ class BufferIntent(StrEnum):
 
     Example 2: need 20 cores but have 40 → scale down to 20 cores."""
 
+    floor = "floor"
+    """Set a minimum requirement as a fraction of existing capacity. ratio specifies
+    the fraction (e.g. ratio=0.8 means never drop below 80% of current capacity).
+    Only valid in buffers.derived."""
+
+    ceiling = "ceiling"
+    """Set a maximum requirement as a fraction of existing capacity. ratio specifies
+    the fraction (e.g. ratio=1.2 means never exceed 120% of current capacity).
+    Only valid in buffers.derived."""
+
 
 class Buffer(ExcludeUnsetModel):
     """Represents a buffer (headroom) directive for capacity planning"""
 
     ratio: float = 1.0
     """The buffer value expressed as a ratio over normal load (e.g. 1.5 =
-    50% headroom)"""
+    50% headroom).
+
+    For derived buffers with intent=floor or intent=ceiling, ratio is the
+    bound expressed as a fraction of existing capacity."""
 
     intent: BufferIntent = BufferIntent.desired
     """The intent of this buffer directive (almost always 'desired')"""
@@ -1004,14 +1018,33 @@ class Buffers(ExcludeUnsetModel):
     default: Buffer = Buffer(ratio=1.5)
     # Desired compute, storage, cpu, memory, etc... buffers
     desired: Dict[str, Buffer] = {}
-    # Derive these buffers from current clusters or model context
-    # Buffer.intent MUST be set on these Buffers to something other than "desired":
-    #   scale    = ratio on top of existing buffers to ensure. Let the "derived"
-    #              buffer multiplied by this ratio "needed". If the "needed" buffer
-    #              is greater than desired, the needed buffer is created. If the
-    #              "needed" buffer is less than desired, the needed buffer is created.
-    #   preserve = ignore desired buffer entirely, just maintain existing buffers
+    # Derive these buffers from current clusters or model context.
+    # Use intent to specify the policy:
+    #   scale      = ratio × current usage
+    #   scale_up   = scale + floor at 1× existing (sugar)
+    #   scale_down = scale + ceiling at 1× existing (sugar)
+    #   preserve   = floor=1× and ceiling=1× (sugar)
+    #   floor      = ratio = minimum fraction of existing capacity
+    #   ceiling    = ratio = maximum fraction of existing capacity
     derived: Dict[str, Buffer] = {}
+
+    @model_validator(mode="after")
+    def _validate_buffer_contexts(self) -> "Buffers":
+        for name, buf in self.desired.items():
+            if buf.intent != BufferIntent.desired:
+                raise ValueError(
+                    f"desired buffer '{name}' has intent '{buf.intent}' "
+                    "which is only valid in buffers.derived"
+                )
+
+        for name, buf in self.derived.items():
+            if buf.intent == BufferIntent.desired:
+                raise ValueError(
+                    f"derived buffer '{name}' has intent 'desired' — "
+                    "use scale/scale_up/scale_down/preserve/floor/ceiling "
+                    "instead"
+                )
+        return self
 
 
 class CapacityDesires(ExcludeUnsetModel):

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -961,7 +961,6 @@ def merge_plan(
 
 class DerivedBuffers(BaseModel):
     scale: float = Field(default=1, gt=0)
-    preserve: bool = False
     # When present, this is the maximum ratio of the current usage
     ceiling: Optional[float] = Field(
         default=None,
@@ -969,6 +968,15 @@ class DerivedBuffers(BaseModel):
     )
     # When present, this is the minimum ratio of the current usage
     floor: Optional[float] = Field(default=None, gt=0)
+
+    @property
+    def is_preserve(self) -> bool:
+        """True when this policy pins the requirement to existing capacity.
+
+        Equivalent to the old ``preserve=True`` boolean — the requirement
+        is both floored and capped at 1× existing capacity with no scaling.
+        """
+        return self.scale == 1 and self.floor == 1 and self.ceiling == 1
 
     @staticmethod
     def for_components(
@@ -979,30 +987,41 @@ class DerivedBuffers(BaseModel):
         expanded_components = _expand_components(components, component_fallbacks)
 
         scale = 1.0
-        preserve = False
-        ceiling = None
-        floor = None
+        ceiling: Optional[float] = None
+        floor: Optional[float] = None
 
         for bfr in buffer.values():
             if not expanded_components.intersection(bfr.components):
                 continue
 
-            if bfr.intent in [
+            if bfr.intent == BufferIntent.preserve:
+                # Preserve pins both bounds to existing capacity, no scale change
+                floor = max(floor or 0, 1.0)
+                ceiling = min(ceiling if ceiling is not None else float("inf"), 1.0)
+            elif bfr.intent in (
                 BufferIntent.scale,
                 BufferIntent.scale_up,
                 BufferIntent.scale_down,
-            ]:
+            ):
                 scale = combine_buffer_ratios(scale, bfr.ratio)
-            if bfr.intent == BufferIntent.scale_up:
-                floor = 1  # Create a floor of 1.0x the current usage
-            if bfr.intent == BufferIntent.scale_down:
-                ceiling = 1  # Create a ceiling of 1.0x the current usage
-            if bfr.intent == BufferIntent.preserve:
-                preserve = True
+                if bfr.intent == BufferIntent.scale_up:
+                    floor = max(floor or 0, 1.0)
+                elif bfr.intent == BufferIntent.scale_down:
+                    ceiling = min(ceiling if ceiling is not None else float("inf"), 1.0)
+            elif bfr.intent == BufferIntent.floor:
+                floor = max(floor or 0, bfr.ratio)
+            elif bfr.intent == BufferIntent.ceiling:
+                ceiling = min(
+                    ceiling if ceiling is not None else float("inf"), bfr.ratio
+                )
+            # desired intent: no derived policy
 
-        return DerivedBuffers(
-            scale=scale, preserve=preserve, ceiling=ceiling, floor=floor
-        )
+        if floor is not None and ceiling is not None and floor > ceiling:
+            raise ValueError(
+                f"Merged derived policy has floor ({floor}) > ceiling ({ceiling})"
+            )
+
+        return DerivedBuffers(scale=scale, ceiling=ceiling, floor=floor)
 
     def calculate_requirement(
         self,
@@ -1010,9 +1029,6 @@ class DerivedBuffers(BaseModel):
         existing_capacity: float,
         desired_buffer_ratio: float = 1.0,
     ) -> float:
-        if self.preserve:
-            return existing_capacity
-
         requirement = self.scale * current_usage * desired_buffer_ratio
         if self.ceiling is not None:
             requirement = min(requirement, self.ceiling * existing_capacity)

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -46,6 +46,8 @@ from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models import RANK_PENALTIES
+from service_capacity_modeling.models.common import COUNT_BOTTLENECK
+from service_capacity_modeling.models.common import REQUIRED_NODES_BY_TYPE
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import DerivedBuffers
@@ -690,6 +692,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         write_buffer=lambda x: heap_fn(x) * max_write_buffer_percent * 0.25,
         required_write_buffer_gib=float(requirement.context["write_buffer_gib"]),
         max_node_disk_gib=max_node_disk,
+        include_node_count_breakdown=True,
     )
 
     # Communicate to the actual provision that if we want reduced RF
@@ -731,15 +734,21 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     # Sometimes we don't want modify cluster topology, so only allow
     # topologies that match the desired zone size
     if required_cluster_size is not None and cluster.count != required_cluster_size:
+        required_nodes_by_type = cluster.cluster_params.get(REQUIRED_NODES_BY_TYPE, {})
+        count_bottleneck = cluster.cluster_params.get(COUNT_BOTTLENECK, "unknown")
         return Excuse(
             instance=instance.name,
             drive=drive_name,
             reason=(
-                f"Cluster size {cluster.count} != required {required_cluster_size}"
+                f"Cluster size {cluster.count} "
+                f"(count bottleneck: {count_bottleneck}) "
+                f"!= required {required_cluster_size}"
             ),
             context={
                 "computed_count": cluster.count,
                 "required_cluster_size": required_cluster_size,
+                "required_nodes_by_type": required_nodes_by_type,
+                "count_bottleneck": count_bottleneck,
             },
             bottleneck=Bottleneck.cluster_size,
         )

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -66,6 +66,7 @@ from service_capacity_modeling.models.org.netflix.cassandra_memory import (
     estimate_memory_experimental,
     estimate_memory_legacy,
 )
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.models.utils import is_power_of_2
 from service_capacity_modeling.models.utils import next_doubling
 from service_capacity_modeling.models.utils import next_power_of_2
@@ -667,6 +668,35 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     def max_node_disk(d: Drive) -> int:
         return max(math.ceil(d.max_size_gib / 3), ebs_disk_floor)
 
+    # Apply memory-only derived buffers to the write-buffer requirement so
+    # scale_down caps both page cache and memtable space at current allocation.
+    raw_write_buffer_gib = float(requirement.context["write_buffer_gib"])
+    if raw_write_buffer_gib > 0 and current_capacity:
+        try:
+            current_instance = current_capacity.cluster_instance or shapes.instance(
+                current_capacity.cluster_instance_name
+            )
+        except KeyError:
+            current_instance = None
+        if current_instance is not None:
+            # Per-node write buffer = heap × max_write_buffer_percent × 0.25,
+            # matching the write_buffer lambda passed to compute_stateful_zone.
+            existing_write_buffer = (
+                current_capacity.cluster_instance_count.mid
+                * _cass_heap(current_instance.ram_gib)
+                * max_write_buffer_percent
+                * 0.25
+            )
+            memory_derived = DerivedBuffers.for_components(
+                desires.buffers.derived,
+                [BufferComponent.memory],
+                component_fallbacks={},
+            )
+            raw_write_buffer_gib = memory_derived.calculate_requirement(
+                current_usage=raw_write_buffer_gib,
+                existing_capacity=existing_write_buffer,
+            )
+
     cluster = compute_stateful_zone(
         instance=instance,
         drive=drive,
@@ -690,7 +720,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         # memtable_cleanup_threshold * memtable_size. At Netflix this
         # is 0.11 * 25 * heap
         write_buffer=lambda x: heap_fn(x) * max_write_buffer_percent * 0.25,
-        required_write_buffer_gib=float(requirement.context["write_buffer_gib"]),
+        required_write_buffer_gib=raw_write_buffer_gib,
         max_node_disk_gib=max_node_disk,
         include_node_count_breakdown=True,
     )

--- a/service_capacity_modeling/models/org/netflix/cassandra_memory.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra_memory.py
@@ -109,7 +109,7 @@ def estimate_memory_experimental(  # pylint: disable=too-many-positional-argumen
         desires.buffers.derived, [BufferComponent.memory]
     )
     if (
-        memory_derived.preserve
+        memory_derived.is_preserve
         and current_capacity
         and current_capacity.cluster_instance
     ):

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -111,7 +111,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -128,7 +138,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -145,7 +165,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.99,
-          "effective_disk_per_node_gib": 373
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 373,
+          "required_nodes_by_type": {
+            "cluster_size": 4,
+            "cpu": 3,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 2,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 4,
@@ -180,7 +210,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -200,7 +240,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -220,7 +270,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 2,
           "cassandra.storage_buffer_ratio": 3.92,
-          "effective_disk_per_node_gib": 8100
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 8100,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 7,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 5,
+            "min_count": 2,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -252,7 +312,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -269,7 +339,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -286,7 +366,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
-          "effective_disk_per_node_gib": 885
+          "count_bottleneck": "cpu",
+          "effective_disk_per_node_gib": 885,
+          "required_nodes_by_type": {
+            "cluster_size": 8,
+            "cpu": 8,
+            "disk_capacity": 3,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 4,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 8,
@@ -321,7 +411,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -341,7 +441,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -361,7 +471,17 @@
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
-          "effective_disk_per_node_gib": 6600
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 6600,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 32,
+            "disk_capacity": 56,
+            "disk_iops": 0,
+            "memory": 24,
+            "min_count": 64,
+            "network": 2
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -396,9 +516,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -419,9 +549,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -442,9 +582,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
+          "count_bottleneck": "cluster_size",
           "effective_disk_per_node_gib": 5100,
           "rank_penalties": {
             "family_migration": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 33,
+            "disk_capacity": 15,
+            "disk_iops": 0,
+            "memory": 32,
+            "min_count": 16,
+            "network": 2
           }
         },
         "cluster_type": "cassandra",
@@ -480,7 +630,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -500,7 +660,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -520,7 +690,17 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.74,
-          "effective_disk_per_node_gib": 5700
+          "count_bottleneck": "cluster_size",
+          "effective_disk_per_node_gib": 5700,
+          "required_nodes_by_type": {
+            "cluster_size": 64,
+            "cpu": 18,
+            "disk_capacity": 6,
+            "disk_iops": 0,
+            "memory": 40,
+            "min_count": 8,
+            "network": 1
+          }
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -812,9 +992,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",
@@ -832,9 +1022,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",
@@ -852,9 +1052,19 @@
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 3.83,
+          "count_bottleneck": "cpu",
           "effective_disk_per_node_gib": 1676,
           "rank_penalties": {
             "large_instance": 0.1
+          },
+          "required_nodes_by_type": {
+            "cluster_size": 2,
+            "cpu": 2,
+            "disk_capacity": 1,
+            "disk_iops": 0,
+            "memory": 1,
+            "min_count": 2,
+            "network": 1
           }
         },
         "cluster_type": "cassandra",

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -1,0 +1,51 @@
+"""Tests for Cassandra cluster-size excuse explainability."""
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import (
+    AccessPattern,
+    CapacityDesires,
+    DataShape,
+    Interval,
+    QueryPattern,
+)
+
+SMALL_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_cluster_size_excuse_has_count_bottleneck_details():
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=SMALL_KV,
+        extra_model_arguments={"required_cluster_size": 2, "require_local_disks": True},
+        num_results=5,
+    )
+    excuses = [e for e in explained.excuses if "count bottleneck:" in e.reason]
+    assert excuses, "Expected cluster_size excuses with count bottleneck details"
+    for e in excuses:
+        counts = e.context["required_nodes_by_type"]
+        assert set(counts.keys()) == {
+            "cpu",
+            "memory",
+            "network",
+            "disk_capacity",
+            "disk_iops",
+            "cluster_size",
+            "min_count",
+        }
+        assert e.context["count_bottleneck"] in counts
+        assert e.context["count_bottleneck"] in e.reason

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -1,12 +1,21 @@
 """Tests for Cassandra cluster-size excuse explainability."""
 
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import (
     AccessPattern,
+    Buffer,
+    BufferComponent,
+    BufferIntent,
+    Buffers,
     CapacityDesires,
+    CurrentClusters,
+    CurrentZoneClusterCapacity,
     DataShape,
     Interval,
     QueryPattern,
+    certain_float,
+    certain_int,
 )
 
 SMALL_KV = CapacityDesires(
@@ -49,3 +58,80 @@ def test_cluster_size_excuse_has_count_bottleneck_details():
         }
         assert e.context["count_bottleneck"] in counts
         assert e.context["count_bottleneck"] in e.reason
+
+
+WRITE_HEAVY_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=5000, mid=20000, high=40000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_memory_scale_down_caps_write_buffer():
+    """Memory scale_down should not exceed current write-buffer capacity."""
+    i4i_4xl = shapes.instance("i4i.4xlarge")
+    current_cluster = CurrentZoneClusterCapacity(
+        cluster_instance=i4i_4xl,
+        cluster_instance_name="i4i.4xlarge",
+        cluster_instance_count=certain_int(4),
+        cpu_utilization=certain_float(10),
+        memory_utilization_gib=certain_float(10),
+        disk_utilization_gib=certain_float(500),
+        network_utilization_mbps=certain_float(100),
+    )
+
+    uncapped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=WRITE_HEAVY_KV,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert uncapped_plans, "Expected uncapped plan"
+
+    capped_desires = WRITE_HEAVY_KV.model_copy(deep=True)
+    capped_desires.current_clusters = CurrentClusters(zonal=[current_cluster])
+    capped_desires.buffers = Buffers(
+        derived={
+            "memory": Buffer(
+                intent=BufferIntent.scale_down,
+                ratio=1.0,
+                components=[BufferComponent.memory],
+            ),
+        }
+    )
+
+    capped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=capped_desires,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert capped_plans, "Expected capped plan"
+
+    capped_zone = capped_plans[0].candidate_clusters.zonal[0]
+    capped_counts = capped_zone.cluster_params["required_nodes_by_type"]
+
+    assert "memory" in capped_counts
+    assert capped_zone.cluster_params["count_bottleneck"] is not None
+
+    for plan in uncapped_plans:
+        zone = plan.candidate_clusters.zonal[0]
+        if zone.instance.name == capped_zone.instance.name:
+            uncapped_mem = zone.cluster_params["required_nodes_by_type"]["memory"]
+            assert capped_counts["memory"] <= uncapped_mem, (
+                f"Expected capped memory ({capped_counts['memory']}) "
+                f"<= uncapped ({uncapped_mem}) for {capped_zone.instance.name}"
+            )
+            break

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,10 +1,12 @@
 import pytest
+from pydantic import ValidationError
 from pytest import approx
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
+from service_capacity_modeling.interface import BufferIntent
 from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import cpu_headroom_target
@@ -272,3 +274,178 @@ def test_derived_buffer_validation():
 
     with pytest.raises(ValueError):
         DerivedBuffers.for_components(derived_buffers, [BufferComponent.storage])
+
+
+# ──────────────────────────────────────────────────────────────────
+# Buffer context validation
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_desired_rejects_derived_only_intents():
+    """Derived-only intents must not appear in buffers.desired"""
+    for intent in [
+        BufferIntent.scale,
+        BufferIntent.scale_up,
+        BufferIntent.scale_down,
+        BufferIntent.preserve,
+        BufferIntent.floor,
+        BufferIntent.ceiling,
+    ]:
+        with pytest.raises(ValidationError):
+            Buffers(desired={"x": Buffer(intent=intent, components=["memory"])})
+
+
+def test_preserve_with_non_unit_ratio_normalized():
+    """preserve intent ignores ratio — for backward compat, ratio is accepted
+    but the normalization always uses scale=1, floor=1, ceiling=1."""
+    buffers = Buffers(
+        derived={
+            "mem": Buffer(
+                intent=BufferIntent.preserve,
+                ratio=2.0,
+                components=["memory"],
+            )
+        }
+    )
+    db = DerivedBuffers.for_components(buffers.derived, [BufferComponent.memory])
+    assert db.is_preserve  # ratio is ignored, still normalizes to preserve
+
+
+# ──────────────────────────────────────────────────────────────────
+# DerivedBuffers normalization from legacy intents
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "intent,ratio,exp_scale,exp_floor,exp_ceiling",
+    [
+        (BufferIntent.preserve, 1.0, 1, 1, 1),
+        (BufferIntent.scale_up, 1.5, 1.5, 1, None),
+        (BufferIntent.scale_down, 0.8, 0.8, None, 1),
+        (BufferIntent.scale, 2.0, 2.0, None, None),
+        (BufferIntent.floor, 0.8, 1.0, 0.8, None),
+        (BufferIntent.ceiling, 1.2, 1.0, None, 1.2),
+    ],
+    ids=["preserve", "scale_up", "scale_down", "scale", "floor", "ceiling"],
+)
+def test_intent_normalization(intent, ratio, exp_scale, exp_floor, exp_ceiling):
+    """Each intent normalizes to the correct (scale, floor, ceiling) triple."""
+    derived = {
+        "x": Buffer(intent=intent, ratio=ratio, components=[BufferComponent.memory])
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.scale == exp_scale
+    assert db.floor == exp_floor
+    assert db.ceiling == exp_ceiling
+
+
+def test_scale_with_floor_and_ceiling_intents_combine():
+    """scale + floor + ceiling as separate entries combine correctly"""
+    derived = {
+        "scale": Buffer(
+            intent=BufferIntent.scale,
+            ratio=1.5,
+            components=[BufferComponent.memory],
+        ),
+        "min": Buffer(
+            intent=BufferIntent.floor,
+            ratio=0.8,
+            components=[BufferComponent.memory],
+        ),
+        "max": Buffer(
+            intent=BufferIntent.ceiling,
+            ratio=1.2,
+            components=[BufferComponent.memory],
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.scale == 1.5
+    assert db.floor == 0.8
+    assert db.ceiling == 1.2
+
+
+# ──────────────────────────────────────────────────────────────────
+# DerivedBuffers combination semantics
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_multiple_floors_merge_max():
+    """Multiple floor-intent buffers → take the max"""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.floor, ratio=0.5, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.floor, ratio=0.8, components=[BufferComponent.memory]
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.floor == 0.8
+
+
+def test_multiple_ceilings_merge_min():
+    """Multiple ceiling-intent buffers → take the min"""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.5, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.2, components=[BufferComponent.memory]
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.ceiling == 1.2
+
+
+def test_merged_floor_exceeds_ceiling_rejected():
+    """Merged policy where floor > ceiling raises ValueError"""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.floor, ratio=2.0, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.0, components=[BufferComponent.memory]
+        ),
+    }
+    with pytest.raises(ValueError, match="floor.*ceiling"):
+        DerivedBuffers.for_components(derived, [BufferComponent.memory])
+
+
+# ──────────────────────────────────────────────────────────────────
+# calculate_requirement with normalized policies
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_preserve_calculate_requirement():
+    """Preserve-normalized policy returns existing_capacity"""
+    db = DerivedBuffers(scale=1, floor=1, ceiling=1)
+    assert db.is_preserve
+    # Regardless of current_usage or desired_buffer_ratio, result = existing
+    assert db.calculate_requirement(50, 100) == 100
+    assert db.calculate_requirement(150, 100) == 100
+    assert db.calculate_requirement(50, 100, desired_buffer_ratio=2.0) == 100
+
+
+def test_scale_up_calculate_requirement():
+    """scale_up: floor=1 means never drop below existing capacity"""
+    db = DerivedBuffers(scale=1.5, floor=1)
+    # Under-provisioned: need 150, have 100 → scale up to 150
+    assert db.calculate_requirement(100, 100) == 150
+    # Over-provisioned: need 30, have 100 → floor pins to 100
+    assert db.calculate_requirement(20, 100) == 100
+
+
+def test_scale_down_calculate_requirement():
+    """scale_down: ceiling=1 means never exceed existing capacity"""
+    db = DerivedBuffers(scale=0.8, ceiling=1)
+    # Over-provisioned: need 80, have 100 → scale down to 80
+    assert db.calculate_requirement(100, 100) == 80
+    # Under-provisioned: need 160, have 100 → ceiling caps to 100
+    assert db.calculate_requirement(200, 100) == 100
+
+
+def test_plain_scale_calculate_requirement():
+    """Plain scale with no bounds: just multiply"""
+    db = DerivedBuffers(scale=2.0)
+    assert db.calculate_requirement(50, 100) == 100
+    assert db.calculate_requirement(50, 100, desired_buffer_ratio=1.5) == 150


### PR DESCRIPTION
## Summary
- Add explicit `BufferIntent.floor` and `BufferIntent.ceiling` derived-buffer policies
- Normalize `preserve` to bounded `floor=1` / `ceiling=1` behavior via `DerivedBuffers.is_preserve`
- Validate desired-vs-derived intent placement in `Buffers`
- Keep this follow-up isolated from Cassandra explainability and agent-doc changes

## Test plan
- [x] `tox -e py310 -- tests/test_buffers.py tests/netflix/test_cassandra.py -k preserve_memory`

> Intended stack position: follow-up after #259.