### PR TITLE
feat: expand uncertain planner explainability surface

### DIFF
--- a/notebooks/kafka_demo.ipynb
+++ b/notebooks/kafka_demo.ipynb
@@ -88,28 +88,7 @@
    "id": "f07ab2d2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from service_capacity_modeling.capacity_planner import planner\n",
-    "from service_capacity_modeling.models.org import netflix\n",
-    "\n",
-    "# Load up the Netflix capacity models\n",
-    "planner.register_group(netflix.models)\n",
-    "model_name = \"org.netflix.kafka\"\n",
-    "\n",
-    "\n",
-    "cap_plan = planner.plan(\n",
-    "    model_name=model_name,\n",
-    "    region=\"us-east-1\",\n",
-    "    desires=kafka_desires,\n",
-    "    simulations=1024,\n",
-    "    explain=True,\n",
-    "    extra_model_arguments={\n",
-    "        \"cluster_type\": \"strong\",\n",
-    "        \"retention\": \"PT2H\",\n",
-    "        #\"copies_per_region\": 2\n",
-    "    },\n",
-    ")\n"
-   ]
+   "source": "from service_capacity_modeling.capacity_planner import planner\nfrom service_capacity_modeling.models.org import netflix\n\n# Load up the Netflix capacity models\nplanner.register_group(netflix.models)\nmodel_name = \"org.netflix.kafka\"\n\n\ncap_plan = planner.plan(\n    model_name=model_name,\n    region=\"us-east-1\",\n    desires=kafka_desires,\n    simulations=1024,\n    extra_model_arguments={\n        \"cluster_type\": \"strong\",\n        \"retention\": \"PT2H\",\n        #\"copies_per_region\": 2\n    },\n)"
   },
   {
    "cell_type": "markdown",
@@ -188,10 +167,7 @@
    "cell_type": "markdown",
    "id": "481c7806",
    "metadata": {},
-   "source": [
-    "# Visualize the Simulation\n",
-    "We can visualize what is happening via the explain param"
-   ]
+   "source": "# Visualize the Simulation\nWe can visualize what is happening via the explanation on the plan"
   },
   {
    "cell_type": "code",

--- a/notebooks/visualize_regret.ipynb
+++ b/notebooks/visualize_regret.ipynb
@@ -91,22 +91,7 @@
    "id": "0c0f540a",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from service_capacity_modeling.capacity_planner import planner\n",
-    "from service_capacity_modeling.models.org import netflix\n",
-    "\n",
-    "# Load up the Netflix capacity models\n",
-    "planner.register_group(netflix.models)\n",
-    "\n",
-    "# Plan a cluster\n",
-    "plan = planner.plan(\n",
-    "    model_name=model_name,\n",
-    "    region=\"us-east-1\",\n",
-    "    desires=desires,\n",
-    "    simulations=1024,\n",
-    "    explain=True\n",
-    ")"
-   ]
+   "source": "from service_capacity_modeling.capacity_planner import planner\nfrom service_capacity_modeling.models.org import netflix\n\n# Load up the Netflix capacity models\nplanner.register_group(netflix.models)\n\n# Plan a cluster\nplan = planner.plan(\n    model_name=model_name,\n    region=\"us-east-1\",\n    desires=desires,\n    simulations=1024,\n)"
   },
   {
    "cell_type": "code",

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
 import functools
+import json
 import logging
 import math
 from hashlib import blake2b
@@ -14,8 +15,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
-
-import numpy as np
 from pydantic import Field
 
 from service_capacity_modeling.hardware import HardwareShapes
@@ -32,8 +31,10 @@ from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import ExcludeUnsetModel
 from service_capacity_modeling.interface import Excuse
+from service_capacity_modeling.explainability import count_excuses
 from service_capacity_modeling.explainability import deduplicate_excuses
 from service_capacity_modeling.explainability import ExplainedPlans
+from service_capacity_modeling.explainability import ExplainedUncertainPlans
 from service_capacity_modeling.explainability import FamilyGraph
 from service_capacity_modeling.interface import Hardware
 from service_capacity_modeling.interface import Instance
@@ -45,6 +46,8 @@ from service_capacity_modeling.interface import Platform
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
 from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.interface import RegretCandidate
+from service_capacity_modeling.interface import RegretPlanSummary
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.interface import UncertainCapacityPlan
@@ -91,6 +94,15 @@ class _CertainResult(ExcludeUnsetModel):
 
     plans: Sequence[CapacityPlan]
     excuses: Sequence[Excuse] = []
+
+
+class _MergedRegretCandidate(ExcludeUnsetModel):
+    """Merged plan plus regret breadcrumbs across composed models."""
+
+    plan: CapacityPlan
+    total_regret: float
+    regret_components_by_model: Dict[str, Dict[str, float]] = {}
+    desires_by_model: Dict[str, CapacityDesires] = {}
 
 
 def simulate_interval(
@@ -379,31 +391,227 @@ def _regret(
     regret_params: CapacityRegretParameters,
     model: CapacityModel,
 ) -> Sequence[Tuple[CapacityPlan, CapacityDesires, float]]:
-    plans_by_regret = []
+    return [
+        (candidate.plan, candidate.desires, candidate.total_regret)
+        for candidate in _regret_detailed(
+            capacity_plans=capacity_plans,
+            regret_params=regret_params,
+            model=model,
+        )
+    ]
 
-    # Unfortunately has to be O(N^2) since regret isn't symmetric.
-    # We could create the entire NxN regret matrix and use
-    # einsum('ij->i') to quickly do a row wise sum, but that would
-    # require a _lot_ more memory than this ...
-    regret = np.zeros(len(capacity_plans), dtype=np.float64)
-    for i, proposed_plan in enumerate(capacity_plans):
-        for j, optimal_plan in enumerate(capacity_plans):
-            if j == i:
-                regret[j] = 0
 
-            regret[j] = sum(
-                model.regret(
-                    regret_params=regret_params,
-                    optimal_plan=optimal_plan[1],
-                    proposed_plan=proposed_plan[1],
-                ).values()
+def _regret_detailed(
+    capacity_plans: Sequence[Tuple[CapacityDesires, CapacityPlan]],
+    regret_params: CapacityRegretParameters,
+    model: CapacityModel,
+) -> Sequence[RegretCandidate]:
+    """Return per-candidate regret totals plus per-component totals."""
+    plans_by_regret: List[RegretCandidate] = []
+
+    for proposed_desires, proposed_plan in capacity_plans:
+        total_regret = 0.0
+        component_totals: Dict[str, float] = {}
+        for _, optimal_plan in capacity_plans:
+            components = model.regret(
+                regret_params=regret_params,
+                optimal_plan=optimal_plan,
+                proposed_plan=proposed_plan,
             )
+            total_regret += sum(components.values())
+            for component, value in components.items():
+                component_totals[component] = (
+                    component_totals.get(component, 0.0) + value
+                )
+
         plans_by_regret.append(
-            (proposed_plan[1], proposed_plan[0], np.einsum("i->", regret))
+            RegretCandidate(
+                plan=proposed_plan,
+                desires=proposed_desires,
+                total_regret=total_regret,
+                regret_components=dict(sorted(component_totals.items())),
+            )
         )
 
-    plans_by_regret.sort(key=lambda p: p[2])
+    plans_by_regret.sort(key=lambda candidate: candidate.total_regret)
     return plans_by_regret
+
+
+def _aggregate_component_maps(
+    component_maps: Sequence[Dict[str, float]],
+) -> Dict[str, float]:
+    totals: Dict[str, float] = {}
+    for component_map in component_maps:
+        for component, value in component_map.items():
+            totals[component] = totals.get(component, 0.0) + value
+    return dict(sorted(totals.items()))
+
+
+def _mean_component_maps(
+    component_maps: Sequence[Dict[str, float]],
+) -> Dict[str, float]:
+    if not component_maps:
+        return {}
+    totals = _aggregate_component_maps(component_maps)
+    count = float(len(component_maps))
+    return {component: value / count for component, value in totals.items()}
+
+
+def _plan_signature(plan: CapacityPlan) -> str:
+    return json.dumps(plan.candidate_clusters.model_dump(mode="json"), sort_keys=True)
+
+
+def _reduce_regret_by_family(
+    candidates: Sequence[_MergedRegretCandidate],
+    max_results_per_family: int,
+) -> List[_MergedRegretCandidate]:
+    zonal_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
+    regional_families: Dict[Tuple[Tuple[str, str], ...], int] = {}
+    result: List[_MergedRegretCandidate] = []
+
+    for candidate in candidates:
+        topo = candidate.plan.candidate_clusters
+        regional_type: Tuple[Tuple[str, str], ...] = tuple()
+        zonal_type: Tuple[Tuple[str, str], ...] = tuple()
+
+        if topo.regional:
+            regional_type = tuple(
+                sorted({(c.cluster_type, c.instance.family) for c in topo.regional})
+            )
+        if topo.zonal:
+            zonal_type = tuple(
+                sorted({(c.cluster_type, c.instance.family) for c in topo.zonal})
+            )
+
+        zonal_count = zonal_families.get(zonal_type, 0)
+        regional_count = regional_families.get(regional_type, 0)
+        if (
+            zonal_count < max_results_per_family
+            or regional_count < max_results_per_family
+        ):
+            result.append(candidate)
+            zonal_families[zonal_type] = zonal_count + 1
+            regional_families[regional_type] = regional_count + 1
+
+    return result
+
+
+def _merge_regret_candidates(
+    regret_details_by_model: Dict[str, Sequence[RegretCandidate]],
+    zonal_requirements: Dict[str, Dict[str, List[Interval]]],
+    regional_requirements: Dict[str, Dict[str, List[Interval]]],
+) -> List[_MergedRegretCandidate]:
+    model_names = [
+        model_name
+        for model_name, regret_details in regret_details_by_model.items()
+        if regret_details
+    ]
+    if not model_names:
+        return []
+
+    merged_candidates: List[_MergedRegretCandidate] = []
+    detail_lists = [regret_details_by_model[model_name] for model_name in model_names]
+    for components in zip(*detail_lists):
+        merged_plan = functools.reduce(
+            merge_plan, [detail.plan for detail in components]
+        )
+        for req in merged_plan.requirements.zonal:
+            _add_requirement(req, zonal_requirements)
+        for req in merged_plan.requirements.regional:
+            _add_requirement(req, regional_requirements)
+
+        merged_candidates.append(
+            _MergedRegretCandidate(
+                plan=merged_plan,
+                total_regret=sum(detail.total_regret for detail in components),
+                regret_components_by_model={
+                    model_name: dict(detail.regret_components)
+                    for model_name, detail in zip(model_names, components)
+                },
+                desires_by_model={
+                    model_name: detail.desires
+                    for model_name, detail in zip(model_names, components)
+                },
+            )
+        )
+
+    return merged_candidates
+
+
+def _summarize_regret_candidates(
+    candidates: Sequence[_MergedRegretCandidate],
+) -> Dict[str, RegretPlanSummary]:
+    grouped: Dict[str, Dict[str, Any]] = {}
+    ordered_signatures: List[str] = []
+
+    for candidate in candidates:
+        signature = _plan_signature(candidate.plan)
+        if signature not in grouped:
+            grouped[signature] = {
+                "plan": candidate.plan,
+                "selected_total_regret": candidate.total_regret,
+                "selected_regret_components_by_model": (
+                    candidate.regret_components_by_model
+                ),
+                "representative_desires_by_model": candidate.desires_by_model,
+                "equivalent_plan_count": 0,
+                "sum_total_regret": 0.0,
+                "min_total_regret": candidate.total_regret,
+                "max_total_regret": candidate.total_regret,
+                "regret_components_by_model_samples": {
+                    model_name: [components]
+                    for model_name, components in (
+                        candidate.regret_components_by_model.items()
+                    )
+                },
+            }
+            ordered_signatures.append(signature)
+
+        group = grouped[signature]
+        group["equivalent_plan_count"] += 1
+        group["sum_total_regret"] += candidate.total_regret
+        group["min_total_regret"] = min(
+            group["min_total_regret"], candidate.total_regret
+        )
+        group["max_total_regret"] = max(
+            group["max_total_regret"], candidate.total_regret
+        )
+        for model_name, components in candidate.regret_components_by_model.items():
+            samples = group["regret_components_by_model_samples"].setdefault(
+                model_name, []
+            )
+            samples.append(components)
+
+    summaries: Dict[str, RegretPlanSummary] = {}
+    for signature in ordered_signatures:
+        group = grouped[signature]
+        mean_by_model = {
+            model_name: _mean_component_maps(samples)
+            for model_name, samples in group[
+                "regret_components_by_model_samples"
+            ].items()
+        }
+        selected_by_model = group["selected_regret_components_by_model"]
+        count = group["equivalent_plan_count"]
+        summaries[signature] = RegretPlanSummary(
+            plan=group["plan"],
+            equivalent_plan_count=count,
+            selected_total_regret=group["selected_total_regret"],
+            min_total_regret=group["min_total_regret"],
+            max_total_regret=group["max_total_regret"],
+            mean_total_regret=group["sum_total_regret"] / count,
+            selected_regret_components=_aggregate_component_maps(
+                list(selected_by_model.values())
+            ),
+            mean_regret_components=_aggregate_component_maps(
+                list(mean_by_model.values())
+            ),
+            selected_regret_components_by_model=selected_by_model,
+            mean_regret_components_by_model=mean_by_model,
+            representative_desires_by_model=group["representative_desires_by_model"],
+        )
+
+    return summaries
 
 
 def _add_requirement(
@@ -1099,10 +1307,44 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]] = None,
         regret_params: Optional[CapacityRegretParameters] = None,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
-        explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
     ) -> UncertainCapacityPlan:
+        return self.plan_explained(
+            model_name=model_name,
+            region=region,
+            desires=desires,
+            percentiles=percentiles,
+            simulations=simulations,
+            num_results=num_results,
+            num_regions=num_regions,
+            lifecycles=lifecycles,
+            instance_families=instance_families,
+            drives=drives,
+            regret_params=regret_params,
+            extra_model_arguments=extra_model_arguments,
+            max_results_per_family=max_results_per_family,
+            planner_arguments=planner_arguments,
+        ).plan
+
+    def plan_explained(  # pylint: disable=too-many-positional-arguments
+        self,
+        model_name: str,
+        region: str,
+        desires: CapacityDesires,
+        percentiles: Tuple[int, ...] = (5, 50, 95),
+        simulations: Optional[int] = None,
+        num_results: Optional[int] = None,
+        num_regions: int = 3,
+        lifecycles: Optional[Sequence[Lifecycle]] = None,
+        instance_families: Optional[Sequence[str]] = None,
+        drives: Optional[Sequence[str]] = None,
+        regret_params: Optional[CapacityRegretParameters] = None,
+        extra_model_arguments: Optional[Dict[str, Any]] = None,
+        max_results_per_family: int = 1,
+        planner_arguments: Optional[PlannerArguments] = None,
+    ) -> ExplainedUncertainPlans:
+        """Like plan() but returns excuses and family graph too."""
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
             max_results_per_family=max_results_per_family
@@ -1128,8 +1370,10 @@ class CapacityPlanner:
         regret_clusters_by_model: Dict[
             str, Sequence[Tuple[CapacityPlan, CapacityDesires, float]]
         ] = {}
+        regret_details_by_model: Dict[str, Sequence[RegretCandidate]] = {}
         desires_by_model: Dict[str, CapacityDesires] = {}
         excuses_by_model: Dict[str, List[Excuse]] = {}
+        all_excuses: List[Excuse] = []
         for sub_model, sub_desires in self._sub_models(
             model_name=model_name,
             desires=desires,
@@ -1152,32 +1396,39 @@ class CapacityPlanner:
                     planner_arguments=pargs,
                 )
                 model_plans.append((sim_desires, sim_result.plans))
-                if explain:
-                    model_excuses.extend(sim_result.excuses)
-            if explain:
-                excuses_by_model[sub_model] = model_excuses
-            regret_clusters_by_model[sub_model] = _regret(
+                model_excuses.extend(sim_result.excuses)
+            all_excuses.extend(model_excuses)
+            excuses_by_model[sub_model] = model_excuses
+            regret_details = _regret_detailed(
                 capacity_plans=[
                     (sim_desires, plan[0]) for sim_desires, plan in model_plans if plan
                 ],
                 regret_params=regret_params,
                 model=self._models[sub_model],
             )
+            regret_details_by_model[sub_model] = regret_details
+            regret_clusters_by_model[sub_model] = [
+                (candidate.plan, candidate.desires, candidate.total_regret)
+                for candidate in regret_details
+            ]
 
         # Now accumulate across the composed models and return the top N
         # by distinct hardware type
-        least_regret = reduce_by_family(
-            _merge_models(
-                # First param is the actual plan which we care about
-                [
-                    [plan[0] for plan in component]
-                    for component in regret_clusters_by_model.values()
-                ],
-                zonal_requirements,
-                regional_requirements,
-            ),
+        merged_regret_candidates = _merge_regret_candidates(
+            regret_details_by_model=regret_details_by_model,
+            zonal_requirements=zonal_requirements,
+            regional_requirements=regional_requirements,
+        )
+        least_regret_candidates = _reduce_regret_by_family(
+            merged_regret_candidates,
             max_results_per_family=pargs.max_results_per_family,
         )[:num_results]
+        least_regret = [candidate.plan for candidate in least_regret_candidates]
+        regret_summary_map = _summarize_regret_candidates(merged_regret_candidates)
+        least_regret_summaries = [
+            regret_summary_map[_plan_signature(candidate.plan)]
+            for candidate in least_regret_candidates
+        ]
 
         low_p, high_p = sorted(percentiles)[0], sorted(percentiles)[-1]
 
@@ -1214,7 +1465,7 @@ class CapacityPlanner:
             instance_families=instance_families,
         )
 
-        result = UncertainCapacityPlan(
+        uncertain_plan = UncertainCapacityPlan(
             requirements=final_requirement,
             least_regret=least_regret,
             mean=mean_plan,
@@ -1229,18 +1480,53 @@ class CapacityPlanner:
                     )
                     for model in regret_clusters_by_model
                 },
+                regret_clusters_by_model=regret_clusters_by_model,
+                regret_details_by_model=regret_details_by_model,
+                regret_summaries_by_model={
+                    model_name: list(
+                        _summarize_regret_candidates(
+                            [
+                                _MergedRegretCandidate(
+                                    plan=candidate.plan,
+                                    total_regret=candidate.total_regret,
+                                    regret_components_by_model={
+                                        model_name: candidate.regret_components
+                                    },
+                                    desires_by_model={model_name: candidate.desires},
+                                )
+                                for candidate in regret_details
+                            ]
+                        ).values()
+                    )
+                    for model_name, regret_details in regret_details_by_model.items()
+                },
+                excuses_by_model={
+                    model: deduplicate_excuses(excuses)
+                    for model, excuses in excuses_by_model.items()
+                    if excuses
+                },
+                excuse_counts_by_model={
+                    model: count_excuses(excuses)
+                    for model, excuses in excuses_by_model.items()
+                    if excuses
+                },
+                context={"regret": least_regret},
             ),
         )
-        if explain:
-            result.explanation.regret_clusters_by_model = regret_clusters_by_model
-            result.explanation.excuses_by_model = {
-                model: deduplicate_excuses(excuses)
-                for model, excuses in excuses_by_model.items()
-                if excuses
-            }
-            result.explanation.context["regret"] = least_regret
 
-        return result
+        excuses = deduplicate_excuses(all_excuses)
+        excuse_summary = count_excuses(all_excuses)
+        hardware = self._shapes.region(region)
+        model = self._models[model_name]
+        graph = FamilyGraph.build(excuses, hardware, model.preferred_families())
+
+        return ExplainedUncertainPlans(
+            plan=uncertain_plan,
+            excuses=excuses,
+            excuse_summary=excuse_summary,
+            family_graph=graph,
+            least_regret_summaries=least_regret_summaries,
+        )
 
     def _sub_models(
         self,

--- a/service_capacity_modeling/explainability.py
+++ b/service_capacity_modeling/explainability.py
@@ -2,9 +2,10 @@
 
 **Experimental** — this API may change.
 
-This module contains the family graph (FamilyTrait, FamilyEdge, FamilyGraph)
-and ExplainedPlans — types used to explain *why* the planner rejected
-certain instance/drive combinations and what alternatives exist.
+This module contains the family graph (FamilyTrait, FamilyEdge, FamilyGraph),
+ExplainedPlans, and ExplainedUncertainPlans — types used to explain *why*
+the planner rejected certain instance/drive combinations and what
+alternatives exist.
 
 Core contract types (Bottleneck, Excuse) live in interface.py because they
 are part of the CapacityModel.capacity_plan() return type.
@@ -34,6 +35,17 @@ Consumer usage::
     # Serialize both for downstream consumers
     explained.model_dump_json()
     comparison.model_dump_json()
+
+    # Uncertain (stochastic) explained mode
+    explained_uncertain = planner.plan_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments=extra,
+    )
+    explained_uncertain.plan          # UncertainCapacityPlan
+    explained_uncertain.excuses       # deduped across all simulations
+    explained_uncertain.family_graph  # hardware trade-off graph
 """
 
 from __future__ import annotations
@@ -50,12 +62,15 @@ from typing import Tuple
 
 from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import CountedExcuse
 from service_capacity_modeling.interface import DriveType
 from service_capacity_modeling.interface import ExcludeUnsetModel
 from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import ExcuseTag
 from service_capacity_modeling.interface import Hardware
 from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import RegretPlanSummary
+from service_capacity_modeling.interface import UncertainCapacityPlan
 
 
 class FamilyTrait(ExcludeUnsetModel):
@@ -297,14 +312,48 @@ STATELESS_SERVICE_FAMILIES: FrozenSet[str] = frozenset(
 
 def deduplicate_excuses(excuses: Sequence[Excuse]) -> Sequence[Excuse]:
     """Deduplicate excuses by (instance, drive, reason) across simulations."""
-    seen: Set[Tuple[str, str, str]] = set()
+    seen: Set[Tuple[str, str, str, Optional[Bottleneck], Tuple[str, ...]]] = set()
     result: List[Excuse] = []
     for exc in excuses:
-        key = (exc.instance, exc.drive, exc.reason)
+        key = (
+            exc.instance,
+            exc.drive,
+            exc.reason,
+            exc.bottleneck,
+            tuple(sorted(tag.value for tag in exc.tags)),
+        )
         if key not in seen:
             seen.add(key)
             result.append(exc)
     return result
+
+
+def count_excuses(excuses: Sequence[Excuse]) -> Sequence[CountedExcuse]:
+    """Count excuse frequency across simulations without merging distinct tags."""
+    keys_in_order: List[
+        Tuple[str, str, str, Optional[Bottleneck], Tuple[str, ...]]
+    ] = []
+    counted: Dict[
+        Tuple[str, str, str, Optional[Bottleneck], Tuple[str, ...]], CountedExcuse
+    ] = {}
+
+    for exc in excuses:
+        key = (
+            exc.instance,
+            exc.drive,
+            exc.reason,
+            exc.bottleneck,
+            tuple(sorted(tag.value for tag in exc.tags)),
+        )
+        if key not in counted:
+            counted[key] = CountedExcuse(**exc.model_dump(), count=0)
+            keys_in_order.append(key)
+        current = counted[key]
+        current.count += 1
+        if current.context and exc.context and current.context != exc.context:
+            current.context = {}
+
+    return [counted[key] for key in keys_in_order]
 
 
 class ExplainedPlans(ExcludeUnsetModel):
@@ -317,3 +366,17 @@ class ExplainedPlans(ExcludeUnsetModel):
     plans: Sequence[CapacityPlan]
     excuses: Sequence[Excuse] = []
     family_graph: FamilyGraph = FamilyGraph()
+
+
+class ExplainedUncertainPlans(ExcludeUnsetModel):
+    """Uncertain plans + excuses + family context.
+
+    Mirrors ExplainedPlans but wraps UncertainCapacityPlan instead
+    of deterministic plans. Returned by plan_explained().
+    """
+
+    plan: UncertainCapacityPlan
+    excuses: Sequence[Excuse] = []
+    excuse_summary: Sequence[CountedExcuse] = []
+    family_graph: FamilyGraph = FamilyGraph()
+    least_regret_summaries: Sequence[RegretPlanSummary] = []

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -1332,13 +1332,47 @@ class Excuse(ExcludeUnsetModel):
     bottleneck: Optional[Bottleneck] = None
 
 
+class CountedExcuse(Excuse):
+    """An excuse plus how often it appeared across simulations."""
+
+    count: int = 1
+
+
+class RegretCandidate(ExcludeUnsetModel):
+    """Detailed regret record for one candidate sampled from one world."""
+
+    plan: CapacityPlan
+    desires: CapacityDesires
+    total_regret: float
+    regret_components: Dict[str, float] = {}
+
+
+class RegretPlanSummary(ExcludeUnsetModel):
+    """Aggregated regret summary for one returned plan shape."""
+
+    plan: CapacityPlan
+    equivalent_plan_count: int = 1
+    selected_total_regret: float
+    min_total_regret: float
+    max_total_regret: float
+    mean_total_regret: float
+    selected_regret_components: Dict[str, float] = {}
+    mean_regret_components: Dict[str, float] = {}
+    selected_regret_components_by_model: Dict[str, Dict[str, float]] = {}
+    mean_regret_components_by_model: Dict[str, Dict[str, float]] = {}
+    representative_desires_by_model: Dict[str, CapacityDesires] = {}
+
+
 class PlanExplanation(ExcludeUnsetModel):
     regret_params: CapacityRegretParameters
     regret_clusters_by_model: Dict[
         str, Sequence[Tuple[CapacityPlan, CapacityDesires, float]]
     ] = {}
+    regret_details_by_model: Dict[str, Sequence[RegretCandidate]] = {}
+    regret_summaries_by_model: Dict[str, Sequence[RegretPlanSummary]] = {}
     desires_by_model: Dict[str, CapacityDesires] = {}
     excuses_by_model: Dict[str, Sequence[Excuse]] = {}
+    excuse_counts_by_model: Dict[str, Sequence[CountedExcuse]] = {}
     context: Dict[str, Any] = {}
 
 

--- a/tests/netflix/test_cassandra_explainability.py
+++ b/tests/netflix/test_cassandra_explainability.py
@@ -10,14 +10,19 @@ import pytest
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.explainability import (
     ExplainedPlans,
+    ExplainedUncertainPlans,
     STATEFUL_DATASTORE_FAMILIES,
 )
 from service_capacity_modeling.interface import (
     Bottleneck,
     CapacityDesires,
+    CountedExcuse,
     DataShape,
     Excuse,
     QueryPattern,
+    RegretCandidate,
+    RegretPlanSummary,
+    UncertainCapacityPlan,
     certain_float,
     certain_int,
 )
@@ -111,34 +116,88 @@ class TestPlanCertainExplained:
         assert len(explained_plans.family_graph.edges) > 0
 
 
-class TestPlanExplainFlag:
-    """Test that plan(explain=True) populates excuses_by_model."""
+class TestPlanExplained:
+    """Test that plan_explained() returns excuses, family graph, and plan."""
 
-    def test_plan_explain_includes_excuses(self):
-        result = planner.plan(
+    @pytest.fixture(scope="class")
+    def explained_uncertain(self):
+        return planner.plan_explained(
             model_name="org.netflix.cassandra",
             region="us-east-1",
             desires=small_workload,
             simulations=2,
-            explain=True,
             extra_model_arguments=EXTRA_MODEL_ARGS,
         )
-        assert result.explanation.excuses_by_model, (
-            "explain=True should produce excuses for a real workload"
-        )
+
+    def test_returns_explained_uncertain_plans(self, explained_uncertain):
+        assert isinstance(explained_uncertain, ExplainedUncertainPlans)
+
+    def test_plan_is_uncertain_capacity_plan(self, explained_uncertain):
+        assert isinstance(explained_uncertain.plan, UncertainCapacityPlan)
+        assert len(explained_uncertain.plan.least_regret) > 0
+
+    def test_excuses_populated(self, explained_uncertain):
+        assert len(explained_uncertain.excuses) > 0
+        assert all(isinstance(e, Excuse) for e in explained_uncertain.excuses)
+
+    def test_family_graph_populated(self, explained_uncertain):
+        assert len(explained_uncertain.family_graph.traits) > 0
+        assert len(explained_uncertain.family_graph.edges) > 0
+
+    def test_explanation_has_excuses_by_model(self, explained_uncertain):
+        assert explained_uncertain.plan.explanation.excuses_by_model
         excuses_flat = [
-            e for es in result.explanation.excuses_by_model.values() for e in es
+            e
+            for es in explained_uncertain.plan.explanation.excuses_by_model.values()
+            for e in es
         ]
         assert len(excuses_flat) > 0
-        assert all(isinstance(e, Excuse) for e in excuses_flat)
 
-    def test_plan_explain_false_has_no_excuses(self):
-        result = planner.plan(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=small_workload,
-            simulations=2,
-            explain=False,
-            extra_model_arguments=EXTRA_MODEL_ARGS,
+    def test_explanation_has_regret_clusters(self, explained_uncertain):
+        assert explained_uncertain.plan.explanation.regret_clusters_by_model
+
+    def test_explanation_has_regret_details(self, explained_uncertain):
+        details_by_model = explained_uncertain.plan.explanation.regret_details_by_model
+        assert details_by_model
+        details = next(iter(details_by_model.values()))
+        assert len(details) > 0
+        assert all(isinstance(detail, RegretCandidate) for detail in details)
+        assert details[0].total_regret >= 0
+        assert details[0].regret_components
+
+    def test_explanation_has_regret_summaries(self, explained_uncertain):
+        summaries_by_model = (
+            explained_uncertain.plan.explanation.regret_summaries_by_model
         )
-        assert not result.explanation.excuses_by_model
+        assert summaries_by_model
+        summaries = next(iter(summaries_by_model.values()))
+        assert len(summaries) > 0
+        assert all(isinstance(summary, RegretPlanSummary) for summary in summaries)
+        assert summaries[0].equivalent_plan_count >= 1
+        assert summaries[0].selected_total_regret >= 0
+
+    def test_explained_uncertain_has_least_regret_summaries(self, explained_uncertain):
+        assert len(explained_uncertain.least_regret_summaries) == len(
+            explained_uncertain.plan.least_regret
+        )
+        assert all(
+            isinstance(summary, RegretPlanSummary)
+            for summary in explained_uncertain.least_regret_summaries
+        )
+
+    def test_explained_uncertain_has_counted_excuses(self, explained_uncertain):
+        assert explained_uncertain.excuse_summary
+        assert all(
+            isinstance(excuse, CountedExcuse)
+            for excuse in explained_uncertain.excuse_summary
+        )
+        assert max(excuse.count for excuse in explained_uncertain.excuse_summary) >= 1
+        assert explained_uncertain.plan.explanation.excuse_counts_by_model
+
+    def test_plan_wrapper_returns_uncertain_capacity_plan(self, explained_uncertain):
+        """plan() returns UncertainCapacityPlan (not the explained wrapper)."""
+        assert isinstance(explained_uncertain.plan, UncertainCapacityPlan)
+
+    def test_plan_always_has_excuses(self, explained_uncertain):
+        """Excuses are always populated — no explain flag needed."""
+        assert explained_uncertain.plan.explanation.excuses_by_model

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -7,6 +7,8 @@ Model integration tests live in tests/netflix/test_<model>_explainability.py.
 import pytest
 
 from service_capacity_modeling.explainability import (
+    count_excuses,
+    deduplicate_excuses,
     FamilyEdge,
     FamilyGraph,
     FamilyTrait,
@@ -15,6 +17,7 @@ from service_capacity_modeling.explainability import (
 from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import (
     Bottleneck,
+    CountedExcuse,
     Excuse,
     ExcuseTag,
 )
@@ -58,6 +61,58 @@ class TestExcuseModel:
         data = excuse.model_dump()
         assert "bottleneck" not in data
         assert data["instance"] == "r6a.xlarge"
+
+    def test_deduplicate_preserves_distinct_bottlenecks_and_tags(self):
+        excuses = [
+            Excuse(
+                instance="r6a.xlarge",
+                drive="gp3",
+                reason="too small",
+                bottleneck=Bottleneck.cpu,
+                tags=[ExcuseTag.same_family],
+            ),
+            Excuse(
+                instance="r6a.xlarge",
+                drive="gp3",
+                reason="too small",
+                bottleneck=Bottleneck.memory,
+                tags=[ExcuseTag.same_family],
+            ),
+            Excuse(
+                instance="r6a.xlarge",
+                drive="gp3",
+                reason="too small",
+                bottleneck=Bottleneck.cpu,
+                tags=[ExcuseTag.size_up],
+            ),
+        ]
+        deduped = deduplicate_excuses(excuses)
+        assert len(deduped) == 3
+
+    def test_count_excuses_merges_same_identity_but_drops_conflicting_context(self):
+        excuses = [
+            Excuse(
+                instance="r6a.xlarge",
+                drive="gp3",
+                reason="too small",
+                bottleneck=Bottleneck.cpu,
+                tags=[ExcuseTag.same_family],
+                context={"needed_cores": 12},
+            ),
+            Excuse(
+                instance="r6a.xlarge",
+                drive="gp3",
+                reason="too small",
+                bottleneck=Bottleneck.cpu,
+                tags=[ExcuseTag.same_family],
+                context={"needed_cores": 16},
+            ),
+        ]
+        counted = count_excuses(excuses)
+        assert len(counted) == 1
+        assert isinstance(counted[0], CountedExcuse)
+        assert counted[0].count == 2
+        assert counted[0].context == {}
 
 
 class TestFamilyTrait:

--- a/tests/test_reproducible.py
+++ b/tests/test_reproducible.py
@@ -54,14 +54,12 @@ def test_compositional():
         region="us-east-1",
         desires=uncertain_mid,
         num_results=4,
-        explain=True,
     )
     composed_result = planner.plan(
         model_name="org.netflix.key-value",
         region="us-east-1",
         desires=uncertain_mid,
         num_results=4,
-        explain=True,
     )
 
     # Strictest test: Cassandra regret clusters must be EXACTLY identical


### PR DESCRIPTION
## What am I trying to do?

Expand the uncertain planner explainability surface so callers can get a dedicated explained result object and richer regret breadcrumbs without reverse-engineering the raw planner output.

## Why did I do it this way?

I moved uncertain explainability onto `planner.plan_explained(...)` and made `planner.plan(...)` return only the `UncertainCapacityPlan`. This is an intentional API break: the old `explain` flag is removed. The new explained surface carries structured regret details, per-model regret summaries, and counted excuses so downstream consumers can narrate why the least-regret plans win and how often alternatives fail across sampled worlds.

I also tightened excuse grouping so distinct bottlenecks or tag sets are not silently merged into the same counted explanation bucket.

## Stack position

Base branch for the uncertain stack. This PR targets `main` directly. `#262` is intended to stack on top of this branch.

## Are there any tests?

Yes. Verified with:
- `tox -e py312 -- tests/test_explainability.py tests/netflix/test_cassandra_explainability.py tests/test_reproducible.py`

Coverage includes:
- `planner.plan_explained()` return type and wrapper behavior
- richer `PlanExplanation` fields (`regret_details_by_model`, `regret_summaries_by_model`, `excuse_counts_by_model`)
- counted-excuse grouping behavior
- reproducibility of uncertain planning output

## How would I use the new code?

```python
from service_capacity_modeling.capacity_planner import planner

explained = planner.plan_explained(
    model_name="org.netflix.cassandra",
    region="us-east-1",
    desires=desires,
    extra_model_arguments=extra,
)

explained.plan
explained.excuses
explained.excuse_summary
explained.least_regret_summaries
explained.plan.explanation.regret_details_by_model
explained.plan.explanation.regret_summaries_by_model
```