### PR TITLE
test: capture uncertain planner regression baselines

### DIFF
--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -34,6 +34,9 @@ from service_capacity_modeling.interface import (
     QueryPattern,
 )
 
+BASELINE_UNCERTAIN_SIMULATIONS = 16
+BASELINE_UNCERTAIN_NUM_RESULTS = 3
+
 
 def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]:
     """Format a single cluster's details."""
@@ -60,6 +63,84 @@ def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]
     return info
 
 
+def _capture_candidate(candidate: Any) -> dict[str, Any]:
+    """Serialize a candidate cluster set into a stable regression snapshot."""
+    cluster_details = []
+    for zonal_cluster in candidate.zonal:
+        cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
+    for regional_cluster in candidate.regional:
+        cluster_details.append(_format_cluster(regional_cluster, "regional"))
+
+    return {
+        "total_annual_cost": float(candidate.total_annual_cost),
+        "clusters": cluster_details,
+        "annual_costs": dict(
+            sorted((k, float(v)) for k, v in candidate.annual_costs.items())
+        ),
+    }
+
+
+def _capture_plan_sequence(plans: Any) -> list[dict[str, Any]]:
+    return [_capture_candidate(plan.candidate_clusters) for plan in plans]
+
+
+def _capture_counted_excuse(excuse: Any) -> dict[str, Any]:
+    return {
+        "instance": excuse.instance,
+        "drive": excuse.drive,
+        "reason": excuse.reason,
+        "count": excuse.count,
+        "bottleneck": (
+            str(excuse.bottleneck) if excuse.bottleneck is not None else None
+        ),
+        "tags": sorted(str(tag) for tag in excuse.tags),
+    }
+
+
+def _capture_regret_summary(summary: Any) -> dict[str, Any]:
+    return {
+        "plan": _capture_candidate(summary.plan.candidate_clusters),
+        "equivalent_plan_count": summary.equivalent_plan_count,
+        "selected_total_regret": summary.selected_total_regret,
+        "min_total_regret": summary.min_total_regret,
+        "max_total_regret": summary.max_total_regret,
+        "mean_total_regret": summary.mean_total_regret,
+        "selected_regret_components": dict(
+            sorted(summary.selected_regret_components.items())
+        ),
+        "mean_regret_components": dict(sorted(summary.mean_regret_components.items())),
+        "selected_regret_components_by_model": {
+            model: dict(sorted(components.items()))
+            for model, components in sorted(
+                summary.selected_regret_components_by_model.items()
+            )
+        },
+        "mean_regret_components_by_model": {
+            model: dict(sorted(components.items()))
+            for model, components in sorted(
+                summary.mean_regret_components_by_model.items()
+            )
+        },
+        "representative_models": sorted(summary.representative_desires_by_model.keys()),
+    }
+
+
+def _capture_error(
+    scenario_name: str,
+    error: Exception,
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+) -> dict[str, Any]:
+    return {
+        "error": str(error),
+        "scenario": scenario_name,
+        "model": model_name,
+        "region": region,
+        "service_tier": desires.service_tier,
+    }
+
+
 def capture_costs(
     model_name: str,
     region: str,
@@ -80,31 +161,91 @@ def capture_costs(
         if not cap_plans:
             return {"error": "No capacity plans generated", "scenario": scenario_name}
 
-        cap_plan = cap_plans[0]
-        candidate = cap_plan.candidate_clusters
-
-        # Build cluster details for each cluster
-        cluster_details = []
-        for zonal_cluster in candidate.zonal:
-            cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
-        for regional_cluster in candidate.regional:
-            cluster_details.append(_format_cluster(regional_cluster, "regional"))
-
         result = {
             "scenario": scenario_name,
             "model": model_name,
             "region": region,
             "service_tier": desires.service_tier,
-            "total_annual_cost": float(candidate.total_annual_cost),
-            "clusters": cluster_details,
-            "annual_costs": dict(
-                sorted((k, float(v)) for k, v in candidate.annual_costs.items())
-            ),
         }
-
+        result.update(_capture_candidate(cap_plans[0].candidate_clusters))
         return result
     except (ValueError, KeyError, AttributeError) as e:
-        return {"error": str(e), "scenario": scenario_name}
+        return _capture_error(scenario_name, e, model_name, region, desires)
+
+
+def capture_uncertain(  # pylint: disable=too-many-positional-arguments
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+    extra_args: dict[str, Any] | None = None,
+    scenario_name: str = "",
+    simulations: int = BASELINE_UNCERTAIN_SIMULATIONS,
+    num_results: int = BASELINE_UNCERTAIN_NUM_RESULTS,
+) -> dict[str, Any]:
+    """Capture a compact snapshot from the stochastic planner."""
+    try:
+        cap_plan = planner.plan(
+            model_name=model_name,
+            region=region,
+            desires=desires,
+            simulations=simulations,
+            num_results=num_results,
+            extra_model_arguments=extra_args or {},
+        )
+        return {
+            "scenario": scenario_name,
+            "model": model_name,
+            "region": region,
+            "service_tier": desires.service_tier,
+            "simulations": simulations,
+            "num_results": num_results,
+            "least_regret": _capture_plan_sequence(cap_plan.least_regret),
+            "mean": _capture_plan_sequence(cap_plan.mean),
+            "percentiles": {
+                str(percentile): _capture_plan_sequence(plans)
+                for percentile, plans in sorted(cap_plan.percentiles.items())
+            },
+        }
+    except (ValueError, KeyError, AttributeError) as e:
+        return _capture_error(scenario_name, e, model_name, region, desires)
+
+
+def capture_uncertain_explained(  # pylint: disable=too-many-positional-arguments
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+    extra_args: dict[str, Any] | None = None,
+    scenario_name: str = "",
+    simulations: int = BASELINE_UNCERTAIN_SIMULATIONS,
+    num_results: int = BASELINE_UNCERTAIN_NUM_RESULTS,
+) -> dict[str, Any]:
+    """Capture the richer uncertain explainability surface."""
+    try:
+        explained = planner.plan_explained(
+            model_name=model_name,
+            region=region,
+            desires=desires,
+            simulations=simulations,
+            num_results=num_results,
+            extra_model_arguments=extra_args or {},
+        )
+        return {
+            "scenario": scenario_name,
+            "model": model_name,
+            "region": region,
+            "service_tier": desires.service_tier,
+            "simulations": simulations,
+            "num_results": num_results,
+            "least_regret_summaries": [
+                _capture_regret_summary(summary)
+                for summary in explained.least_regret_summaries
+            ],
+            "excuse_summary": [
+                _capture_counted_excuse(excuse) for excuse in explained.excuse_summary
+            ],
+        }
+    except (ValueError, KeyError, AttributeError) as e:
+        return _capture_error(scenario_name, e, model_name, region, desires)
 
 
 # Define test scenarios for each service
@@ -654,6 +795,28 @@ SCENARIOS: dict[str, dict[str, Any]] = {
     for model, region, desires, extra_args, name in scenarios
 }
 
+UNCERTAIN_SCENARIOS: dict[str, dict[str, Any]] = {
+    name: SCENARIOS[name]
+    for name in (
+        "cassandra_timeseries_ebs",
+        "cassandra_kv_dense_ebs",
+        "cassandra_kv_compact_ebs",
+        "kafka_100mib_throughput",
+        "evcache_large_with_replication",
+        "kv_with_cache",
+    )
+}
+
+UNCERTAIN_EXPLAINED_SCENARIOS: dict[str, dict[str, Any]] = {
+    name: SCENARIOS[name]
+    for name in (
+        "cassandra_timeseries_ebs",
+        "cassandra_kv_dense_ebs",
+        "cassandra_kv_compact_ebs",
+        "kv_with_cache",
+    )
+}
+
 
 if __name__ == "__main__":
     # Capture all scenarios
@@ -669,12 +832,79 @@ if __name__ == "__main__":
             print(f"  Total cost: ${result['total_annual_cost']:,.2f}")
             print(f"  Cost breakdown: {list(result['annual_costs'].keys())}")
 
-    # Save results
-    output_file = Path(__file__).parent / "data" / "baseline_costs.json"
+    uncertain_results = []
+    for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():
+        print(f"Capturing uncertain: {scenario_name}...")
+        result = capture_uncertain(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+        )
+        uncertain_results.append(result)
+        if "error" in result:
+            print(f"  ERROR: {result['error']}")
+        else:
+            print(
+                "  Least regret families: "
+                + ", ".join(
+                    p["clusters"][0]["instance"]
+                    for p in result["least_regret"]
+                    if p["clusters"]
+                )
+            )
+
+    # Save deterministic results
+    output_dir = Path(__file__).parent / "data"
+    output_file = output_dir / "baseline_costs.json"
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2, sort_keys=True)
         f.write("\n")  # Ensure trailing newline for pre-commit
 
+    uncertain_output_file = output_dir / "baseline_uncertain.json"
+    with open(uncertain_output_file, "w", encoding="utf-8") as f:
+        json.dump(uncertain_results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    uncertain_explained_results = []
+    for scenario_name, scenario in UNCERTAIN_EXPLAINED_SCENARIOS.items():
+        print(f"Capturing uncertain explained: {scenario_name}...")
+        result = capture_uncertain_explained(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+        )
+        uncertain_explained_results.append(result)
+        if "error" in result:
+            print(f"  ERROR: {result['error']}")
+        else:
+            print(
+                f"  Summaries: {len(result['least_regret_summaries'])} plans, "
+                f"{len(result['excuse_summary'])} counted excuses"
+            )
+
+    uncertain_explained_output_file = output_dir / "baseline_uncertain_explained.json"
+    with open(uncertain_explained_output_file, "w", encoding="utf-8") as f:
+        json.dump(uncertain_explained_results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
     print(f"\nResults saved to: {output_file}")
     success_count = len([r for r in results if "error" not in r])
     print(f"Total scenarios captured: {success_count}/{len(results)}")
+    uncertain_success_count = len([r for r in uncertain_results if "error" not in r])
+    print(f"Uncertain results saved to: {uncertain_output_file}")
+    print(
+        f"Total uncertain scenarios captured: "
+        f"{uncertain_success_count}/{len(uncertain_results)}"
+    )
+    uncertain_explained_success_count = len(
+        [r for r in uncertain_explained_results if "error" not in r]
+    )
+    print(f"Uncertain explained results saved to: {uncertain_explained_output_file}")
+    print(
+        "Total uncertain explained scenarios captured: "
+        f"{uncertain_explained_success_count}/{len(uncertain_explained_results)}"
+    )

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -1,0 +1,3946 @@
+[
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 405481.92149738566,
+          "cassandra.net.inter.region": 1190853.6608613518,
+          "cassandra.net.intra.region": 3572560.9825840555,
+          "cassandra.zonal-clusters": 1752128.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 6921025.2
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1772864.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 6164706.62
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1978688.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          },
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          },
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 6370530.62
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1703744.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 4195926.6
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1909568.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 4401750.6
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1765952.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 5980921.69
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1971776.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 6186745.69
+        }
+      ],
+      "95": []
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_timeseries_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 36792.02039092105,
+          "cassandra.net.inter.region": 23088.6091673735,
+          "cassandra.net.intra.region": 69265.82750212049,
+          "cassandra.zonal-clusters": 618240.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          }
+        ],
+        "total_annual_cost": 747386.46
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 627456.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          }
+        ],
+        "total_annual_cost": 784198.88
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 645183.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          },
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          },
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          }
+        ],
+        "total_annual_cost": 801926.24
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 440896.32
+          },
+          "clusters": [
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 527674.02
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 492352.32
+          },
+          "clusters": [
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 579130.02
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 620544.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            }
+          ],
+          "total_annual_cost": 767357.1
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 638271.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            }
+          ],
+          "total_annual_cost": 785084.46
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 682752.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            }
+          ],
+          "total_annual_cost": 959428.42
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 700479.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            }
+          ],
+          "total_annual_cost": 977155.78
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_dense_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15419.192097730262,
+          "cassandra.net.inter.region": 5772.152291843375,
+          "cassandra.net.intra.region": 17316.456875530122,
+          "cassandra.zonal-clusters": 265791.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 304299.16
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 270399.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 315721.47
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 279168.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          }
+        ],
+        "total_annual_cost": 324490.11
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 192800.16
+          },
+          "clusters": [
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 219767.5
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 218528.16
+          },
+          "clusters": [
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 245495.5
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 265791.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 308607.15
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 274560.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 317375.79
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 298047.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 374269.38
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 306816.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 383038.02
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_compact_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 13494.059999999998
+        },
+        "clusters": [
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          }
+        ],
+        "total_annual_cost": 13494.06
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 13494.059999999998
+        },
+        "clusters": [
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          }
+        ],
+        "total_annual_cost": 13494.06
+      },
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 18529.98
+        },
+        "clusters": [
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 18529.98
+      }
+    ],
+    "model": "org.netflix.kafka",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 12711.93
+          },
+          "clusters": [
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            }
+          ],
+          "total_annual_cost": 12711.93
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 17953.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 17953.98
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 15743.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            }
+          ],
+          "total_annual_cost": 15743.07
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 26473.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 26473.98
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kafka_100mib_throughput",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 32829.10006879722,
+          "evcache.net.intra.region": 49243.65010319583,
+          "evcache.zonal-clusters": 100204.26000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 182277.01
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 100204.26000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 175441.83
+      },
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 113098.35999999999
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          }
+        ],
+        "total_annual_cost": 188335.93
+      }
+    ],
+    "model": "org.netflix.evcache",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 127287.4
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 140181.5
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 169256.37
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 182150.47
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 238343.12
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 251237.22
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "evcache_large_with_replication",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 19184.434642913817,
+          "cassandra.net.inter.region": 78646.77717536688,
+          "cassandra.net.intra.region": 235940.33152610064,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 636770.82
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18441.540387680056,
+          "cassandra.net.inter.region": 75766.5887735784,
+          "cassandra.net.intra.region": 227299.76632073522,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 105994.83
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 105994.83,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 51,
+            "deployment": "regional",
+            "instance": "c6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 622069.14
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 16085.217869522095,
+          "cassandra.net.inter.region": 65774.09840002656,
+          "cassandra.net.intra.region": 197322.29520007968,
+          "cassandra.zonal-clusters": 30828.0,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 111150.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 111150.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 9,
+            "deployment": "regional",
+            "instance": "c6a.24xlarge"
+          }
+        ],
+        "total_annual_cost": 571466.0
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 618040.95
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 46243.979999999996,
+          "evcache.zonal-clusters": 169647.53999999998,
+          "nflx-java-app.regional-clusters": 110355.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 110355.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 105,
+            "deployment": "regional",
+            "instance": "c6a.2xlarge"
+          }
+        ],
+        "total_annual_cost": 641288.19
+      }
+    ],
+    "model": "org.netflix.key-value",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 104049.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 104049.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 99,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 537454.21
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 105150.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 105150.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 75,
+              "deployment": "regional",
+              "instance": "c7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 564586.36
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 108432.87
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 108432.87,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 39,
+              "deployment": "regional",
+              "instance": "c7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 593889.53
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 110355.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 110355.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 105,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 621842.81
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 116270.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 116270.07,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 21,
+              "deployment": "regional",
+              "instance": "c7a.8xlarge"
+            }
+          ],
+          "total_annual_cost": 721578.8
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 46243.979999999996,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 116661.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 116661.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 111,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 743294.84
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kv_with_cache",
+    "service_tier": 1,
+    "simulations": 16
+  }
+]

--- a/service_capacity_modeling/tools/data/baseline_uncertain_explained.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain_explained.json
@@ -1,0 +1,19274 @@
+[
+  {
+    "excuse_summary": [
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.10xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Cluster too large: 4096 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Cluster too large: 4096 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Cluster too large: 4096 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Cluster too large: 4096 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Cluster too large: 1024 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Cluster too large: 512 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Cluster too large: 2048 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5n.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c5n.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "c7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m4.10xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "m7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r4.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "current_shape"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 5,
+        "drive": "gp3",
+        "instance": "r7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      }
+    ],
+    "least_regret_summaries": [
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 912273.9808874261,
+        "mean_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 912273.9808874261
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 912273.9808874261
+          }
+        },
+        "mean_total_regret": 912273.9808874261,
+        "min_total_regret": 912273.9808874261,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 405481.92149738566,
+            "cassandra.net.inter.region": 1190853.6608613518,
+            "cassandra.net.intra.region": 3572560.9825840555,
+            "cassandra.zonal-clusters": 1752128.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 584042.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 584042.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 584042.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 6921025.2
+        },
+        "representative_models": [
+          "org.netflix.cassandra"
+        ],
+        "selected_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 912273.9808874261
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 912273.9808874261
+          }
+        },
+        "selected_total_regret": 912273.9808874261
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "region": "us-east-1",
+    "scenario": "cassandra_timeseries_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "excuse_summary": [
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Requires attached disks but c5d.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Requires attached disks but c5d.18xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Requires attached disks but c5d.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Requires attached disks but c5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Requires attached disks but c5d.9xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Requires attached disks but c6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Requires attached disks but c6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Requires attached disks but c6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Requires attached disks but c6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Requires attached disks but c6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Requires attached disks but c6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Requires attached disks but i3.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Requires attached disks but i3.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Requires attached disks but i3.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Requires attached disks but i3en.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Requires attached disks but i3en.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Requires attached disks but i3en.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Requires attached disks but i3en.3xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Requires attached disks but i3en.6xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Requires attached disks but i3en.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Requires attached disks but i4i.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Requires attached disks but i4i.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Requires attached disks but i4i.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Requires attached disks but i4i.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Requires attached disks but i4i.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Requires attached disks but i4i.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Requires attached disks but i4i.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Requires attached disks but i4i.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Requires attached disks but m5d.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Requires attached disks but m5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Requires attached disks but m5d.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Requires attached disks but m5dn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Requires attached disks but m5dn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Requires attached disks but m5dn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Requires attached disks but m6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Requires attached disks but m6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Requires attached disks but m6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Requires attached disks but m6id.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Requires attached disks but m6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Requires attached disks but m6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Requires attached disks but m6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Requires attached disks but m6idn.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Requires attached disks but m6idn.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Requires attached disks but m6idn.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Requires attached disks but m6idn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Requires attached disks but m6idn.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Requires attached disks but m6idn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Requires attached disks but m6idn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Requires attached disks but r5d.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Requires attached disks but r5d.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Requires attached disks but r5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Requires attached disks but r5d.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Requires attached disks but r5d.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Requires attached disks but r5dn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Requires attached disks but r5dn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Requires attached disks but r5dn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Requires attached disks but r5dn.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Requires attached disks but r6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Requires attached disks but r6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Requires attached disks but r6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Requires attached disks but r6id.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Requires attached disks but r6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Requires attached disks but r6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Requires attached disks but r6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Requires attached disks but r6id.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Requires attached disks but r6idn.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Requires attached disks but r6idn.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Requires attached disks but r6idn.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Requires attached disks but r6idn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Requires attached disks but r6idn.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Requires attached disks but r6idn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Requires attached disks but r6idn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Requires attached disks but r6idn.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Requires attached disks but c5d.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Requires attached disks but c5d.18xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Requires attached disks but c5d.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Requires attached disks but c5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Requires attached disks but c5d.9xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 256 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Requires attached disks but c6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Requires attached disks but c6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Requires attached disks but c6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Requires attached disks but c6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Requires attached disks but c6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Requires attached disks but c6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Requires attached disks but i3.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Requires attached disks but i3.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Requires attached disks but i3.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Requires attached disks but i3en.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Requires attached disks but i3en.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Requires attached disks but i3en.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Requires attached disks but i3en.3xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Requires attached disks but i3en.6xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Requires attached disks but i3en.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Requires attached disks but i4i.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Requires attached disks but i4i.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Requires attached disks but i4i.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Requires attached disks but i4i.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Requires attached disks but i4i.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Requires attached disks but i4i.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Requires attached disks but i4i.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Requires attached disks but i4i.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Requires attached disks but m5d.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Requires attached disks but m5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Requires attached disks but m5d.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Requires attached disks but m5dn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Requires attached disks but m5dn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Requires attached disks but m5dn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Requires attached disks but m6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Requires attached disks but m6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Requires attached disks but m6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Requires attached disks but m6id.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Requires attached disks but m6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Requires attached disks but m6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Requires attached disks but m6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Requires attached disks but m6idn.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Requires attached disks but m6idn.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Requires attached disks but m6idn.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Requires attached disks but m6idn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Requires attached disks but m6idn.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Requires attached disks but m6idn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Requires attached disks but m6idn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Requires attached disks but r5d.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Requires attached disks but r5d.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Requires attached disks but r5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Requires attached disks but r5d.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Requires attached disks but r5d.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Requires attached disks but r5dn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Requires attached disks but r5dn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Requires attached disks but r5dn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Requires attached disks but r5dn.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Requires attached disks but r6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Requires attached disks but r6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Requires attached disks but r6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Requires attached disks but r6id.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Requires attached disks but r6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Requires attached disks but r6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Requires attached disks but r6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Requires attached disks but r6id.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Requires attached disks but r6idn.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Requires attached disks but r6idn.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Requires attached disks but r6idn.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Requires attached disks but r6idn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Requires attached disks but r6idn.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Requires attached disks but r6idn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Requires attached disks but r6idn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Requires attached disks but r6idn.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5n.18xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c5n.9xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "c7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m4.10xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "m7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r4.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r4.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r4.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5n.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5n.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5n.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r5n.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "current_shape"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "same_family",
+          "size_up"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r6in.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.32xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7a.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.12xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.16xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.24xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.48xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 2,
+        "drive": "gp3",
+        "instance": "r7i.8xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.4xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      }
+    ],
+    "least_regret_summaries": [
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 2224381.1598233664,
+        "mean_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 2224381.1598233664
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 2224381.1598233664
+          }
+        },
+        "mean_total_regret": 2224381.1598233664,
+        "min_total_regret": 2224381.1598233664,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 36792.02039092105,
+            "cassandra.net.inter.region": 23088.6091673735,
+            "cassandra.net.intra.region": 69265.82750212049,
+            "cassandra.zonal-clusters": 618240.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 206080.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206080.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206080.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            }
+          ],
+          "total_annual_cost": 747386.46
+        },
+        "representative_models": [
+          "org.netflix.cassandra"
+        ],
+        "selected_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 2224381.1598233664
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 2224381.1598233664
+          }
+        },
+        "selected_total_regret": 2224381.1598233664
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_dense_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "excuse_summary": [
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Requires attached disks but c5d.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Requires attached disks but c5d.18xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Requires attached disks but c5d.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Requires attached disks but c5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Requires attached disks but c5d.9xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Requires attached disks but c6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Requires attached disks but c6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Requires attached disks but c6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Requires attached disks but c6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Requires attached disks but c6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Requires attached disks but c6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Requires attached disks but i3.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Requires attached disks but i3.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Requires attached disks but i3.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Requires attached disks but i3en.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Requires attached disks but i3en.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Requires attached disks but i3en.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Requires attached disks but i3en.3xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Requires attached disks but i3en.6xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Requires attached disks but i3en.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Requires attached disks but i4i.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Requires attached disks but i4i.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Requires attached disks but i4i.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Requires attached disks but i4i.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Requires attached disks but i4i.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Requires attached disks but i4i.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Requires attached disks but i4i.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Requires attached disks but i4i.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Requires attached disks but m5d.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Requires attached disks but m5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Requires attached disks but m5d.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Requires attached disks but m5dn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Requires attached disks but m5dn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Requires attached disks but m5dn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Requires attached disks but m6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Requires attached disks but m6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Requires attached disks but m6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Requires attached disks but m6id.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Requires attached disks but m6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Requires attached disks but m6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Requires attached disks but m6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Requires attached disks but m6idn.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Requires attached disks but m6idn.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Requires attached disks but m6idn.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Requires attached disks but m6idn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Requires attached disks but m6idn.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Requires attached disks but m6idn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Requires attached disks but m6idn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Requires attached disks but r5d.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Requires attached disks but r5d.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Requires attached disks but r5d.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Requires attached disks but r5d.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Requires attached disks but r5d.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Requires attached disks but r5dn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Requires attached disks but r5dn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Requires attached disks but r5dn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Requires attached disks but r5dn.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Requires attached disks but r6id.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Requires attached disks but r6id.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Requires attached disks but r6id.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Requires attached disks but r6id.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Requires attached disks but r6id.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Requires attached disks but r6id.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Requires attached disks but r6id.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Requires attached disks but r6id.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Requires attached disks but r6idn.12xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Requires attached disks but r6idn.16xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Requires attached disks but r6idn.24xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Requires attached disks but r6idn.2xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Requires attached disks but r6idn.32xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Requires attached disks but r6idn.4xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Requires attached disks but r6idn.8xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Requires attached disks but r6idn.xlarge has local drives",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 1,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.12xlarge",
+        "reason": "Requires attached disks but c5d.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.18xlarge",
+        "reason": "Requires attached disks but c5d.18xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.24xlarge",
+        "reason": "Requires attached disks but c5d.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.4xlarge",
+        "reason": "Requires attached disks but c5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.9xlarge",
+        "reason": "Requires attached disks but c5d.9xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "disk_capacity",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Cluster too large: 128 nodes > max 64 per zone",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.12xlarge",
+        "reason": "Requires attached disks but c6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.16xlarge",
+        "reason": "Requires attached disks but c6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.24xlarge",
+        "reason": "Requires attached disks but c6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.32xlarge",
+        "reason": "Requires attached disks but c6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.4xlarge",
+        "reason": "Requires attached disks but c6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.8xlarge",
+        "reason": "Requires attached disks but c6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.2xlarge",
+        "reason": "Requires attached disks but i3.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.4xlarge",
+        "reason": "Requires attached disks but i3.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3.xlarge",
+        "reason": "Requires attached disks but i3.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.12xlarge",
+        "reason": "Requires attached disks but i3en.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.24xlarge",
+        "reason": "Requires attached disks but i3en.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.2xlarge",
+        "reason": "Requires attached disks but i3en.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.3xlarge",
+        "reason": "Requires attached disks but i3en.3xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.6xlarge",
+        "reason": "Requires attached disks but i3en.6xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i3en.xlarge",
+        "reason": "Requires attached disks but i3en.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.12xlarge",
+        "reason": "Requires attached disks but i4i.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.16xlarge",
+        "reason": "Requires attached disks but i4i.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.24xlarge",
+        "reason": "Requires attached disks but i4i.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.2xlarge",
+        "reason": "Requires attached disks but i4i.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.32xlarge",
+        "reason": "Requires attached disks but i4i.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.4xlarge",
+        "reason": "Requires attached disks but i4i.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.8xlarge",
+        "reason": "Requires attached disks but i4i.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "i4i.xlarge",
+        "reason": "Requires attached disks but i4i.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.2xlarge",
+        "reason": "Requires attached disks but m5d.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.4xlarge",
+        "reason": "Requires attached disks but m5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.8xlarge",
+        "reason": "Requires attached disks but m5d.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.2xlarge",
+        "reason": "Requires attached disks but m5dn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.4xlarge",
+        "reason": "Requires attached disks but m5dn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.8xlarge",
+        "reason": "Requires attached disks but m5dn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.12xlarge",
+        "reason": "Requires attached disks but m6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.16xlarge",
+        "reason": "Requires attached disks but m6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.24xlarge",
+        "reason": "Requires attached disks but m6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.2xlarge",
+        "reason": "Requires attached disks but m6id.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.32xlarge",
+        "reason": "Requires attached disks but m6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.4xlarge",
+        "reason": "Requires attached disks but m6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.8xlarge",
+        "reason": "Requires attached disks but m6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.12xlarge",
+        "reason": "Requires attached disks but m6idn.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.16xlarge",
+        "reason": "Requires attached disks but m6idn.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.24xlarge",
+        "reason": "Requires attached disks but m6idn.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.2xlarge",
+        "reason": "Requires attached disks but m6idn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.32xlarge",
+        "reason": "Requires attached disks but m6idn.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.4xlarge",
+        "reason": "Requires attached disks but m6idn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.8xlarge",
+        "reason": "Requires attached disks but m6idn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.16xlarge",
+        "reason": "Requires attached disks but r5d.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.2xlarge",
+        "reason": "Requires attached disks but r5d.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.4xlarge",
+        "reason": "Requires attached disks but r5d.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.8xlarge",
+        "reason": "Requires attached disks but r5d.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5d.xlarge",
+        "reason": "Requires attached disks but r5d.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.2xlarge",
+        "reason": "Requires attached disks but r5dn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.4xlarge",
+        "reason": "Requires attached disks but r5dn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.8xlarge",
+        "reason": "Requires attached disks but r5dn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5dn.xlarge",
+        "reason": "Requires attached disks but r5dn.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "same_family",
+          "size_down"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.12xlarge",
+        "reason": "Requires attached disks but r6id.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.16xlarge",
+        "reason": "Requires attached disks but r6id.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.24xlarge",
+        "reason": "Requires attached disks but r6id.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.2xlarge",
+        "reason": "Requires attached disks but r6id.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.32xlarge",
+        "reason": "Requires attached disks but r6id.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.4xlarge",
+        "reason": "Requires attached disks but r6id.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.8xlarge",
+        "reason": "Requires attached disks but r6id.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6id.xlarge",
+        "reason": "Requires attached disks but r6id.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.12xlarge",
+        "reason": "Requires attached disks but r6idn.12xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.16xlarge",
+        "reason": "Requires attached disks but r6idn.16xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.24xlarge",
+        "reason": "Requires attached disks but r6idn.24xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.2xlarge",
+        "reason": "Requires attached disks but r6idn.2xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.32xlarge",
+        "reason": "Requires attached disks but r6idn.32xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.4xlarge",
+        "reason": "Requires attached disks but r6idn.4xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.8xlarge",
+        "reason": "Requires attached disks but r6idn.8xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6idn.xlarge",
+        "reason": "Requires attached disks but r6idn.xlarge has local drives",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      },
+      {
+        "bottleneck": "memory",
+        "count": 15,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": [
+          "different_family"
+        ]
+      }
+    ],
+    "least_regret_summaries": [
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 1423265.032320923,
+        "mean_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 1423265.032320923
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 1423265.032320923
+          }
+        },
+        "mean_total_regret": 1423265.032320923,
+        "min_total_regret": 1423265.032320923,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15419.192097730262,
+            "cassandra.net.inter.region": 5772.152291843375,
+            "cassandra.net.intra.region": 17316.456875530122,
+            "cassandra.zonal-clusters": 265791.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 304299.16
+        },
+        "representative_models": [
+          "org.netflix.cassandra"
+        ],
+        "selected_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 1423265.032320923
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 1423265.032320923
+          }
+        },
+        "selected_total_regret": 1423265.032320923
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_compact_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "excuse_summary": [
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5d.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5d.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.18xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.9xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 5.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 5.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 5.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c5n.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 10.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 10.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c5n.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 10.0 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c6id.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c6id.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7a.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "c7i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "c7i.xlarge",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.10xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.10xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.10xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5d.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.5 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.5 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5d.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.5 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6id.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6id.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6idn.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6idn.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.large",
+        "reason": "Insufficient memory: requires >=12 GiB, got 7.6 GiB",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "m7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "m7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r4.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r5n.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r6in.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.32xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7a.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.12xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.16xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.24xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.2xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.48xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.4xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.8xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.large",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp2",
+        "instance": "r7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "aurora",
+        "instance": "r7i.xlarge",
+        "reason": "Workload requires 500 GiB disk but instance has no ephemeral drive",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.12xlarge",
+        "reason": "Requires local disks but c5.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.18xlarge",
+        "reason": "Requires local disks but c5.18xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.24xlarge",
+        "reason": "Requires local disks but c5.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.4xlarge",
+        "reason": "Requires local disks but c5.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.9xlarge",
+        "reason": "Requires local disks but c5.9xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.12xlarge",
+        "reason": "Requires local disks but c5a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.16xlarge",
+        "reason": "Requires local disks but c5a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.24xlarge",
+        "reason": "Requires local disks but c5a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.4xlarge",
+        "reason": "Requires local disks but c5a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.8xlarge",
+        "reason": "Requires local disks but c5a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5d.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.18xlarge",
+        "reason": "Requires local disks but c5n.18xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.2xlarge",
+        "reason": "Requires local disks but c5n.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.4xlarge",
+        "reason": "Requires local disks but c5n.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.9xlarge",
+        "reason": "Requires local disks but c5n.9xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 5 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 10 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.12xlarge",
+        "reason": "Requires local disks but c6a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.16xlarge",
+        "reason": "Requires local disks but c6a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.24xlarge",
+        "reason": "Requires local disks but c6a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.32xlarge",
+        "reason": "Requires local disks but c6a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.48xlarge",
+        "reason": "Requires local disks but c6a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.4xlarge",
+        "reason": "Requires local disks but c6a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.8xlarge",
+        "reason": "Requires local disks but c6a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.12xlarge",
+        "reason": "Requires local disks but c6i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.16xlarge",
+        "reason": "Requires local disks but c6i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.24xlarge",
+        "reason": "Requires local disks but c6i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.32xlarge",
+        "reason": "Requires local disks but c6i.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.4xlarge",
+        "reason": "Requires local disks but c6i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.8xlarge",
+        "reason": "Requires local disks but c6i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6id.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.12xlarge",
+        "reason": "Requires local disks but c7a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.16xlarge",
+        "reason": "Requires local disks but c7a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.24xlarge",
+        "reason": "Requires local disks but c7a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.32xlarge",
+        "reason": "Requires local disks but c7a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.48xlarge",
+        "reason": "Requires local disks but c7a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.4xlarge",
+        "reason": "Requires local disks but c7a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.8xlarge",
+        "reason": "Requires local disks but c7a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.12xlarge",
+        "reason": "Requires local disks but c7i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.16xlarge",
+        "reason": "Requires local disks but c7i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.24xlarge",
+        "reason": "Requires local disks but c7i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.2xlarge",
+        "reason": "Instance too small: 8 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.48xlarge",
+        "reason": "Requires local disks but c7i.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.4xlarge",
+        "reason": "Requires local disks but c7i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.8xlarge",
+        "reason": "Requires local disks but c7i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "c7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "i3en.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "i4i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.10xlarge",
+        "reason": "Requires local disks but m4.10xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.16xlarge",
+        "reason": "Requires local disks but m4.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.2xlarge",
+        "reason": "Requires local disks but m4.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.4xlarge",
+        "reason": "Requires local disks but m4.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m4.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.12xlarge",
+        "reason": "Requires local disks but m5.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.16xlarge",
+        "reason": "Requires local disks but m5.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.24xlarge",
+        "reason": "Requires local disks but m5.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.2xlarge",
+        "reason": "Requires local disks but m5.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.4xlarge",
+        "reason": "Requires local disks but m5.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.8xlarge",
+        "reason": "Requires local disks but m5.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.12xlarge",
+        "reason": "Requires local disks but m5a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.16xlarge",
+        "reason": "Requires local disks but m5a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.24xlarge",
+        "reason": "Requires local disks but m5a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.2xlarge",
+        "reason": "Requires local disks but m5a.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.4xlarge",
+        "reason": "Requires local disks but m5a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.8xlarge",
+        "reason": "Requires local disks but m5a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 7 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5d.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5dn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.12xlarge",
+        "reason": "Requires local disks but m5n.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.16xlarge",
+        "reason": "Requires local disks but m5n.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.24xlarge",
+        "reason": "Requires local disks but m5n.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.2xlarge",
+        "reason": "Requires local disks but m5n.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.4xlarge",
+        "reason": "Requires local disks but m5n.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.8xlarge",
+        "reason": "Requires local disks but m5n.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m5n.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.12xlarge",
+        "reason": "Requires local disks but m6a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.16xlarge",
+        "reason": "Requires local disks but m6a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.24xlarge",
+        "reason": "Requires local disks but m6a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.2xlarge",
+        "reason": "Requires local disks but m6a.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.32xlarge",
+        "reason": "Requires local disks but m6a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.48xlarge",
+        "reason": "Requires local disks but m6a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.4xlarge",
+        "reason": "Requires local disks but m6a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.8xlarge",
+        "reason": "Requires local disks but m6a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.12xlarge",
+        "reason": "Requires local disks but m6i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.16xlarge",
+        "reason": "Requires local disks but m6i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.24xlarge",
+        "reason": "Requires local disks but m6i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.2xlarge",
+        "reason": "Requires local disks but m6i.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.32xlarge",
+        "reason": "Requires local disks but m6i.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.4xlarge",
+        "reason": "Requires local disks but m6i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.8xlarge",
+        "reason": "Requires local disks but m6i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6id.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6idn.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.12xlarge",
+        "reason": "Requires local disks but m6in.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.16xlarge",
+        "reason": "Requires local disks but m6in.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.24xlarge",
+        "reason": "Requires local disks but m6in.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.2xlarge",
+        "reason": "Requires local disks but m6in.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.32xlarge",
+        "reason": "Requires local disks but m6in.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.4xlarge",
+        "reason": "Requires local disks but m6in.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.8xlarge",
+        "reason": "Requires local disks but m6in.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m6in.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.12xlarge",
+        "reason": "Requires local disks but m7a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.16xlarge",
+        "reason": "Requires local disks but m7a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.24xlarge",
+        "reason": "Requires local disks but m7a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.2xlarge",
+        "reason": "Requires local disks but m7a.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.32xlarge",
+        "reason": "Requires local disks but m7a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.48xlarge",
+        "reason": "Requires local disks but m7a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.4xlarge",
+        "reason": "Requires local disks but m7a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.8xlarge",
+        "reason": "Requires local disks but m7a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7a.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.12xlarge",
+        "reason": "Requires local disks but m7i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.16xlarge",
+        "reason": "Requires local disks but m7i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.24xlarge",
+        "reason": "Requires local disks but m7i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.2xlarge",
+        "reason": "Requires local disks but m7i.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.48xlarge",
+        "reason": "Requires local disks but m7i.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.4xlarge",
+        "reason": "Requires local disks but m7i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.8xlarge",
+        "reason": "Requires local disks but m7i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 8 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "m7i.xlarge",
+        "reason": "Instance too small: 4 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.16xlarge",
+        "reason": "Requires local disks but r4.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.2xlarge",
+        "reason": "Requires local disks but r4.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.4xlarge",
+        "reason": "Requires local disks but r4.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.8xlarge",
+        "reason": "Requires local disks but r4.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r4.xlarge",
+        "reason": "Requires local disks but r4.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.12xlarge",
+        "reason": "Requires local disks but r5.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.16xlarge",
+        "reason": "Requires local disks but r5.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.24xlarge",
+        "reason": "Requires local disks but r5.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.2xlarge",
+        "reason": "Requires local disks but r5.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.4xlarge",
+        "reason": "Requires local disks but r5.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.8xlarge",
+        "reason": "Requires local disks but r5.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5.xlarge",
+        "reason": "Requires local disks but r5.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5d.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5dn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 16 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.12xlarge",
+        "reason": "Requires local disks but r5n.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.16xlarge",
+        "reason": "Requires local disks but r5n.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.24xlarge",
+        "reason": "Requires local disks but r5n.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.2xlarge",
+        "reason": "Requires local disks but r5n.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.4xlarge",
+        "reason": "Requires local disks but r5n.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.8xlarge",
+        "reason": "Requires local disks but r5n.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r5n.xlarge",
+        "reason": "Requires local disks but r5n.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.12xlarge",
+        "reason": "Requires local disks but r6a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.16xlarge",
+        "reason": "Requires local disks but r6a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.24xlarge",
+        "reason": "Requires local disks but r6a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.2xlarge",
+        "reason": "Requires local disks but r6a.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.32xlarge",
+        "reason": "Requires local disks but r6a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.48xlarge",
+        "reason": "Requires local disks but r6a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.4xlarge",
+        "reason": "Requires local disks but r6a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.8xlarge",
+        "reason": "Requires local disks but r6a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6a.xlarge",
+        "reason": "Requires local disks but r6a.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.12xlarge",
+        "reason": "Requires local disks but r6i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.16xlarge",
+        "reason": "Requires local disks but r6i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.24xlarge",
+        "reason": "Requires local disks but r6i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.2xlarge",
+        "reason": "Requires local disks but r6i.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.32xlarge",
+        "reason": "Requires local disks but r6i.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.4xlarge",
+        "reason": "Requires local disks but r6i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.8xlarge",
+        "reason": "Requires local disks but r6i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6i.xlarge",
+        "reason": "Requires local disks but r6i.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6id.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6idn.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.12xlarge",
+        "reason": "Requires local disks but r6in.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.16xlarge",
+        "reason": "Requires local disks but r6in.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.24xlarge",
+        "reason": "Requires local disks but r6in.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.2xlarge",
+        "reason": "Requires local disks but r6in.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.32xlarge",
+        "reason": "Requires local disks but r6in.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.4xlarge",
+        "reason": "Requires local disks but r6in.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.8xlarge",
+        "reason": "Requires local disks but r6in.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r6in.xlarge",
+        "reason": "Requires local disks but r6in.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.12xlarge",
+        "reason": "Requires local disks but r7a.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.16xlarge",
+        "reason": "Requires local disks but r7a.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.24xlarge",
+        "reason": "Requires local disks but r7a.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.2xlarge",
+        "reason": "Requires local disks but r7a.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.32xlarge",
+        "reason": "Requires local disks but r7a.32xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.48xlarge",
+        "reason": "Requires local disks but r7a.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.4xlarge",
+        "reason": "Requires local disks but r7a.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.8xlarge",
+        "reason": "Requires local disks but r7a.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7a.xlarge",
+        "reason": "Requires local disks but r7a.xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.12xlarge",
+        "reason": "Requires local disks but r7i.12xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.16xlarge",
+        "reason": "Requires local disks but r7i.16xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.24xlarge",
+        "reason": "Requires local disks but r7i.24xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.2xlarge",
+        "reason": "Requires local disks but r7i.2xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.48xlarge",
+        "reason": "Requires local disks but r7i.48xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.4xlarge",
+        "reason": "Requires local disks but r7i.4xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.8xlarge",
+        "reason": "Requires local disks but r7i.8xlarge is EBS-only",
+        "tags": []
+      },
+      {
+        "bottleneck": "memory",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.large",
+        "reason": "Instance too small: 2 vCPUs (min 2), 15 GiB RAM (requires > 16 GiB)",
+        "tags": []
+      },
+      {
+        "bottleneck": "drive_type",
+        "count": 16,
+        "drive": "gp3",
+        "instance": "r7i.xlarge",
+        "reason": "Requires local disks but r7i.xlarge is EBS-only",
+        "tags": []
+      }
+    ],
+    "least_regret_summaries": [
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 1043765.1804626025,
+        "mean_regret_components": {
+          "disk": 155.25709188244494,
+          "large_instance": 70816.032,
+          "mem": 0.0,
+          "spend": 972793.8913707202
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 155.25709188244494,
+            "large_instance": 70816.032,
+            "mem": 0.0,
+            "spend": 719216.2008369877
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 253577.69053373256
+          }
+        },
+        "mean_total_regret": 1043765.1804626025,
+        "min_total_regret": 1043765.1804626025,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19184.434642913817,
+            "cassandra.net.inter.region": 78646.77717536688,
+            "cassandra.net.intra.region": 235940.33152610064,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 108432.87
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 108432.87,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 39,
+              "deployment": "regional",
+              "instance": "c7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 636770.82
+        },
+        "representative_models": [
+          "org.netflix.cassandra",
+          "org.netflix.evcache",
+          "org.netflix.key-value"
+        ],
+        "selected_regret_components": {
+          "disk": 155.25709188244494,
+          "large_instance": 70816.032,
+          "mem": 0.0,
+          "spend": 972793.8913707202
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 155.25709188244494,
+            "large_instance": 70816.032,
+            "mem": 0.0,
+            "spend": 719216.2008369877
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 253577.69053373256
+          }
+        },
+        "selected_total_regret": 1043765.1804626025
+      },
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 1087726.2786105168,
+        "mean_regret_components": {
+          "disk": 4735.280085164462,
+          "large_instance": 70816.032,
+          "mem": 0.0,
+          "spend": 1012174.9665253523
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 4735.280085164462,
+            "large_instance": 70816.032,
+            "mem": 0.0,
+            "spend": 719216.7048983559
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 292958.26162699645
+          }
+        },
+        "mean_total_regret": 1087726.2786105168,
+        "min_total_regret": 1087726.2786105168,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 18441.540387680056,
+            "cassandra.net.inter.region": 75766.5887735784,
+            "cassandra.net.intra.region": 227299.76632073522,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 105994.83
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 105994.83,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 51,
+              "deployment": "regional",
+              "instance": "c6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 622069.14
+        },
+        "representative_models": [
+          "org.netflix.cassandra",
+          "org.netflix.evcache",
+          "org.netflix.key-value"
+        ],
+        "selected_regret_components": {
+          "disk": 4735.280085164462,
+          "large_instance": 70816.032,
+          "mem": 0.0,
+          "spend": 1012174.9665253523
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 4735.280085164462,
+            "large_instance": 70816.032,
+            "mem": 0.0,
+            "spend": 719216.7048983559
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 292958.26162699645
+          }
+        },
+        "selected_total_regret": 1087726.2786105168
+      },
+      {
+        "equivalent_plan_count": 1,
+        "max_total_regret": 1311145.4660684338,
+        "mean_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 1311145.4660684338
+        },
+        "mean_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 940051.5397315472
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 371093.92633688654
+          }
+        },
+        "mean_total_regret": 1311145.4660684338,
+        "min_total_regret": 1311145.4660684338,
+        "plan": {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 16085.217869522095,
+            "cassandra.net.inter.region": 65774.09840002656,
+            "cassandra.net.intra.region": 197322.29520007968,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 111150.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 111150.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 9,
+              "deployment": "regional",
+              "instance": "c6a.24xlarge"
+            }
+          ],
+          "total_annual_cost": 571466.0
+        },
+        "representative_models": [
+          "org.netflix.cassandra",
+          "org.netflix.evcache",
+          "org.netflix.key-value"
+        ],
+        "selected_regret_components": {
+          "disk": 0.0,
+          "mem": 0.0,
+          "spend": 1311145.4660684338
+        },
+        "selected_regret_components_by_model": {
+          "org.netflix.cassandra": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 940051.5397315472
+          },
+          "org.netflix.evcache": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 0.0
+          },
+          "org.netflix.key-value": {
+            "disk": 0.0,
+            "mem": 0.0,
+            "spend": 371093.92633688654
+          }
+        },
+        "selected_total_regret": 1311145.4660684338
+      }
+    ],
+    "model": "org.netflix.key-value",
+    "num_results": 3,
+    "region": "us-east-1",
+    "scenario": "kv_with_cache",
+    "service_tier": 1,
+    "simulations": 16
+  }
+]

--- a/tests/netflix/test_uncertain_explained_regression.py
+++ b/tests/netflix/test_uncertain_explained_regression.py
@@ -1,0 +1,180 @@
+"""Regression tests for uncertain explained snapshots."""
+
+import json
+from importlib import resources
+from typing import Any
+
+import pytest
+
+from service_capacity_modeling import tools as scm_tools
+from service_capacity_modeling.tools.capture_baseline_costs import (
+    UNCERTAIN_EXPLAINED_SCENARIOS,
+    capture_uncertain_explained,
+)
+
+_BASELINE_HELP = (
+    "To fix: tox -e capture-baseline\nTo auto-update on commit: pre-commit install"
+)
+
+
+def load_baseline() -> dict[str, dict[str, Any]]:
+    """Load explained uncertain baselines from package resources."""
+    try:
+        baseline_file = resources.files(scm_tools).joinpath(
+            "data", "baseline_uncertain_explained.json"
+        )
+        content = baseline_file.read_text(encoding="utf-8")
+        baselines = json.loads(content)
+        return {b["scenario"]: b for b in baselines if "scenario" in b}
+    except FileNotFoundError:
+        return {}
+
+
+@pytest.fixture(scope="session")
+def explained_baselines() -> dict[str, dict[str, Any]]:
+    return load_baseline()
+
+
+def _assert_cost_blocks_match(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str, label: str
+) -> None:
+    assert actual["plan"]["total_annual_cost"] == pytest.approx(
+        expected["plan"]["total_annual_cost"], rel=0.01
+    ), f"{label} plan cost drift for {scenario_name}.\n{_BASELINE_HELP}"
+    assert len(actual["plan"]["clusters"]) == len(expected["plan"]["clusters"]), (
+        f"{label} cluster count drift for {scenario_name}.\n{_BASELINE_HELP}"
+    )
+    for actual_cluster, expected_cluster in zip(
+        actual["plan"]["clusters"], expected["plan"]["clusters"]
+    ):
+        for field in ("cluster_type", "deployment", "instance", "count"):
+            assert actual_cluster[field] == expected_cluster[field], (
+                f"{label} cluster field '{field}' drift for {scenario_name}.\n"
+                f"{_BASELINE_HELP}"
+            )
+        assert actual_cluster.get("attached_drives", []) == expected_cluster.get(
+            "attached_drives", []
+        ), f"{label} attached drives drift for {scenario_name}.\n{_BASELINE_HELP}"
+        assert actual_cluster.get("cluster_params", {}) == expected_cluster.get(
+            "cluster_params", {}
+        ), f"{label} cluster_params drift for {scenario_name}.\n{_BASELINE_HELP}"
+        assert actual_cluster["annual_cost"] == pytest.approx(
+            expected_cluster["annual_cost"], rel=0.01
+        ), f"{label} cluster annual_cost drift for {scenario_name}.\n{_BASELINE_HELP}"
+    assert (
+        actual["plan"]["annual_costs"].keys() == expected["plan"]["annual_costs"].keys()
+    ), f"{label} annual_cost keys drift for {scenario_name}.\n{_BASELINE_HELP}"
+    for key, expected_cost in expected["plan"]["annual_costs"].items():
+        assert actual["plan"]["annual_costs"][key] == pytest.approx(
+            expected_cost, rel=0.01
+        ), (
+            f"{label} annual_cost bucket '{key}' drift for {scenario_name}.\n"
+            f"{_BASELINE_HELP}"
+        )
+
+
+def _assert_regret_summary_match(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str, label: str
+) -> None:
+    _assert_cost_blocks_match(actual, expected, scenario_name, label)
+    assert actual["equivalent_plan_count"] == expected["equivalent_plan_count"]
+    for field in (
+        "selected_total_regret",
+        "min_total_regret",
+        "max_total_regret",
+        "mean_total_regret",
+    ):
+        assert actual[field] == pytest.approx(expected[field], rel=0.01), (
+            f"{label} {field} drift for {scenario_name}.\n{_BASELINE_HELP}"
+        )
+    assert actual["selected_regret_components"] == pytest.approx(
+        expected["selected_regret_components"], rel=0.01
+    ), (
+        f"{label} selected regret components drift for {scenario_name}.\n"
+        f"{_BASELINE_HELP}"
+    )
+    assert actual["mean_regret_components"] == pytest.approx(
+        expected["mean_regret_components"], rel=0.01
+    ), f"{label} mean regret components drift for {scenario_name}.\n{_BASELINE_HELP}"
+    assert (
+        actual["selected_regret_components_by_model"].keys()
+        == expected["selected_regret_components_by_model"].keys()
+    ), (
+        f"{label} selected per-model regret keys drift for {scenario_name}.\n"
+        f"{_BASELINE_HELP}"
+    )
+    for model_name, expected_components in expected[
+        "selected_regret_components_by_model"
+    ].items():
+        assert actual["selected_regret_components_by_model"][
+            model_name
+        ] == pytest.approx(expected_components, rel=0.01), (
+            f"{label} selected per-model regret drift for "
+            f"{scenario_name}/{model_name}.\n{_BASELINE_HELP}"
+        )
+    assert (
+        actual["mean_regret_components_by_model"].keys()
+        == expected["mean_regret_components_by_model"].keys()
+    ), (
+        f"{label} mean per-model regret keys drift for {scenario_name}.\n"
+        f"{_BASELINE_HELP}"
+    )
+    for model_name, expected_components in expected[
+        "mean_regret_components_by_model"
+    ].items():
+        assert actual["mean_regret_components_by_model"][model_name] == pytest.approx(
+            expected_components, rel=0.01
+        ), (
+            f"{label} mean per-model regret drift for "
+            f"{scenario_name}/{model_name}.\n{_BASELINE_HELP}"
+        )
+    assert actual["representative_models"] == expected["representative_models"]
+
+
+class TestUncertainExplainedBaselineDrift:
+    @pytest.mark.parametrize(
+        "scenario_name", list(UNCERTAIN_EXPLAINED_SCENARIOS.keys())
+    )
+    def test_uncertain_explained_baseline_drift(
+        self,
+        scenario_name: str,
+        explained_baselines: dict[str, dict[str, Any]],
+    ) -> None:
+        if scenario_name not in explained_baselines:
+            pytest.fail(
+                f"Scenario '{scenario_name}' not in uncertain explained baseline.\n"
+                f"{_BASELINE_HELP}"
+            )
+
+        scenario = UNCERTAIN_EXPLAINED_SCENARIOS[scenario_name]
+        baseline = explained_baselines[scenario_name]
+        actual = capture_uncertain_explained(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+            simulations=baseline["simulations"],
+            num_results=baseline["num_results"],
+        )
+
+        assert "error" not in actual, (
+            f"Unexpected error for {scenario_name}: {actual['error']}\n{_BASELINE_HELP}"
+        )
+
+        assert len(actual["least_regret_summaries"]) == len(
+            baseline["least_regret_summaries"]
+        ), f"least_regret_summaries length drift for {scenario_name}.\n{_BASELINE_HELP}"
+        for idx, (actual_summary, expected_summary) in enumerate(
+            zip(actual["least_regret_summaries"], baseline["least_regret_summaries"])
+        ):
+            _assert_regret_summary_match(
+                actual_summary,
+                expected_summary,
+                scenario_name,
+                f"least_regret_summaries[{idx}]",
+            )
+
+        assert actual["excuse_summary"] == baseline["excuse_summary"], (
+            f"excuse_summary drift for {scenario_name}.\n{_BASELINE_HELP}"
+        )

--- a/tests/netflix/test_uncertain_regression.py
+++ b/tests/netflix/test_uncertain_regression.py
@@ -1,0 +1,160 @@
+"""Regression tests for stochastic planner snapshots."""
+
+import json
+from importlib import resources
+from typing import Any
+
+import pytest
+
+from service_capacity_modeling import tools as scm_tools
+from service_capacity_modeling.tools.capture_baseline_costs import (
+    UNCERTAIN_SCENARIOS,
+    capture_uncertain,
+)
+
+_BASELINE_HELP = (
+    "To fix: tox -e capture-baseline\nTo auto-update on commit: pre-commit install"
+)
+
+
+def load_baseline() -> dict[str, dict[str, Any]]:
+    """Load uncertain planner baselines from package resources."""
+    try:
+        baseline_file = resources.files(scm_tools).joinpath(
+            "data", "baseline_uncertain.json"
+        )
+        content = baseline_file.read_text(encoding="utf-8")
+        baselines = json.loads(content)
+        return {b["scenario"]: b for b in baselines if "scenario" in b}
+    except FileNotFoundError:
+        return {}
+
+
+@pytest.fixture(scope="session")
+def uncertain_baselines() -> dict[str, dict[str, Any]]:
+    return load_baseline()
+
+
+def _assert_cluster_matches(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str
+) -> None:
+    assert actual["cluster_type"] == expected["cluster_type"], scenario_name
+    assert actual["deployment"] == expected["deployment"], scenario_name
+    assert actual["instance"] == expected["instance"], scenario_name
+    assert actual["count"] == expected["count"], scenario_name
+    assert actual.get("attached_drives", []) == expected.get("attached_drives", []), (
+        scenario_name
+    )
+    assert actual.get("cluster_params", {}) == expected.get("cluster_params", {}), (
+        f"cluster_params drift for {scenario_name}.\n{_BASELINE_HELP}"
+    )
+    assert actual["annual_cost"] == pytest.approx(expected["annual_cost"], rel=0.01), (
+        f"cluster annual_cost drift for {scenario_name}: "
+        f"baseline=${expected['annual_cost']:,.2f}, "
+        f"actual=${actual['annual_cost']:,.2f}.\n"
+        f"{_BASELINE_HELP}"
+    )
+
+
+def _assert_candidate_matches(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str, label: str
+) -> None:
+    assert actual["total_annual_cost"] == pytest.approx(
+        expected["total_annual_cost"], rel=0.01
+    ), (
+        f"{label} total cost drift for {scenario_name}: "
+        f"baseline=${expected['total_annual_cost']:,.2f}, "
+        f"actual=${actual['total_annual_cost']:,.2f}.\n{_BASELINE_HELP}"
+    )
+    assert set(actual["annual_costs"].keys()) == set(expected["annual_costs"].keys()), (
+        f"{label} annual_cost keys changed for {scenario_name}: "
+        f"baseline={set(expected['annual_costs'].keys())}, "
+        f"actual={set(actual['annual_costs'].keys())}.\n{_BASELINE_HELP}"
+    )
+    for key, expected_cost in expected["annual_costs"].items():
+        assert actual["annual_costs"][key] == pytest.approx(expected_cost, rel=0.01), (
+            f"{label} annual_cost bucket '{key}' drift for {scenario_name}: "
+            f"baseline=${expected_cost:,.2f}, "
+            f"actual=${actual['annual_costs'][key]:,.2f}.\n"
+            f"{_BASELINE_HELP}"
+        )
+
+    assert len(actual["clusters"]) == len(expected["clusters"]), (
+        f"{label} cluster count drift for {scenario_name}: "
+        f"baseline={len(expected['clusters'])}, actual={len(actual['clusters'])}.\n"
+        f"{_BASELINE_HELP}"
+    )
+    for actual_cluster, expected_cluster in zip(
+        actual["clusters"], expected["clusters"]
+    ):
+        _assert_cluster_matches(actual_cluster, expected_cluster, scenario_name)
+
+
+def _assert_plan_sequence_matches(
+    actual: list[dict[str, Any]],
+    expected: list[dict[str, Any]],
+    scenario_name: str,
+    label: str,
+) -> None:
+    assert len(actual) == len(expected), (
+        f"{label} plan count drift for {scenario_name}: "
+        f"baseline={len(expected)}, actual={len(actual)}.\n{_BASELINE_HELP}"
+    )
+    for idx, (actual_plan, expected_plan) in enumerate(zip(actual, expected)):
+        _assert_candidate_matches(
+            actual_plan, expected_plan, scenario_name, f"{label}[{idx}]"
+        )
+
+
+class TestUncertainBaselineDrift:
+    @pytest.mark.parametrize("scenario_name", list(UNCERTAIN_SCENARIOS.keys()))
+    def test_uncertain_baseline_drift(
+        self,
+        scenario_name: str,
+        uncertain_baselines: dict[str, dict[str, Any]],
+    ) -> None:
+        if scenario_name not in uncertain_baselines:
+            pytest.fail(
+                "Scenario "
+                f"'{scenario_name}' not in uncertain baseline.\n{_BASELINE_HELP}"
+            )
+
+        scenario = UNCERTAIN_SCENARIOS[scenario_name]
+        baseline = uncertain_baselines[scenario_name]
+        actual = capture_uncertain(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+            simulations=baseline["simulations"],
+            num_results=baseline["num_results"],
+        )
+
+        assert "error" not in actual, (
+            f"Unexpected error for {scenario_name}: {actual['error']}\n{_BASELINE_HELP}"
+        )
+        assert baseline["simulations"] == actual["simulations"]
+        assert baseline["num_results"] == actual["num_results"]
+
+        _assert_plan_sequence_matches(
+            actual["least_regret"],
+            baseline["least_regret"],
+            scenario_name,
+            "least_regret",
+        )
+        _assert_plan_sequence_matches(
+            actual["mean"],
+            baseline["mean"],
+            scenario_name,
+            "mean",
+        )
+
+        assert set(actual["percentiles"].keys()) == set(baseline["percentiles"].keys())
+        for percentile, expected in baseline["percentiles"].items():
+            _assert_plan_sequence_matches(
+                actual["percentiles"][percentile],
+                expected,
+                scenario_name,
+                f"percentiles[{percentile}]",
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -87,8 +87,8 @@ commands =
     echo "Pre-commit hook installed successfully!"
 
 [testenv:capture-baseline]
-# Try compatible Python versions in order (package requires >=3.10,<3.13)
-basepython = python3.12,python3.11,python3.10
+# Canonical baseline capture runs on 3.11. CI and local pre-commit must agree.
+basepython = python3.11
 usedevelop = True
 commands =
     python -m service_capacity_modeling.tools.capture_baseline_costs


### PR DESCRIPTION
## What am I trying to do?

Add regression coverage for the rebuilt uncertain planner surface, including both the compact uncertain plan snapshots and the richer explained uncertain summaries.

## Why did I do it this way?

This is the fixture and regression layer for the uncertain stack. The planner/API changes live in `#261`; this PR captures those outputs in stable baseline files so future changes show up as intentional diffs instead of silent drift.

I kept the branch focused on capture and regression artifacts:
- extend `capture_baseline_costs.py` to serialize uncertain and uncertain-explained outputs
- add uncertain regression tests
- add uncertain explained regression tests
- pin `tox -e capture-baseline` to Python 3.11 so local regeneration matches the canonical environment

## Stack position

Stacks on `#261` (`uncertain-explained`). This PR should be reviewed after the explainability API layer.

## Are there any tests?

Yes. Verified with:
- `tox -e capture-baseline`
- `tox -e py312 -- tests/netflix/test_uncertain_regression.py tests/netflix/test_uncertain_explained_regression.py`

## How would I use the new code?

Run `tox -e capture-baseline` to regenerate uncertain baseline fixtures after intentional planner changes. The regression suites will automatically compare current output to:
- `baseline_uncertain.json`
- `baseline_uncertain_explained.json`