### PR TITLE
Fix Cassandra memory sizing and resource counts

### DIFF
--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -1166,6 +1166,17 @@ _RESOURCE_CONSTRAINTS = frozenset(
         NodeCountConstraint.disk_iops,
     }
 )
+_BOTTLENECK_TIE_ORDER = (
+    NodeCountConstraint.cpu,
+    NodeCountConstraint.network,
+    NodeCountConstraint.disk_capacity,
+    NodeCountConstraint.disk_iops,
+    NodeCountConstraint.memory,
+)
+
+
+def _bottleneck_tie_rank(constraint: NodeCountConstraint) -> int:
+    return len(_BOTTLENECK_TIE_ORDER) - _BOTTLENECK_TIE_ORDER.index(constraint)
 
 
 class NodeCountContext(ExcludeUnsetModel):
@@ -1183,9 +1194,10 @@ class NodeCountContext(ExcludeUnsetModel):
                                "disk_capacity" | "disk_iops" | null
       }
     `resource_bottleneck` is derived from `required_nodes_by_type` — the
-    resource constraint with the highest count. It is serialized for reader
-    convenience but recomputed on deserialization; any stale value in a
-    hand-edited JSON is ignored.
+    resource constraint with the highest count, with memory losing ties to
+    non-memory resources. It is serialized for reader convenience but
+    recomputed on deserialization; any stale value in a hand-edited JSON is
+    ignored.
     """
 
     required_nodes_by_type: Dict[NodeCountConstraint, int]
@@ -1200,7 +1212,7 @@ class NodeCountContext(ExcludeUnsetModel):
         }
         if not counts:
             return None
-        return max(counts, key=lambda c: counts[c])
+        return max(counts, key=lambda c: (counts[c], _bottleneck_tie_rank(c)))
 
     @classmethod
     def from_counts(

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 import logging
 import math
+from functools import lru_cache
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -59,10 +60,11 @@ from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import working_set_from_drive_and_slo
 from service_capacity_modeling.models.common import zonal_requirements_from_current
 from service_capacity_modeling.models.org.netflix.cassandra_memory import (
-    _get_base_memory,
-    _cass_heap,
-    estimate_memory_experimental,
-    estimate_memory_legacy,
+    DEFAULT_MAX_PAGE_CACHE_GIB,
+    base_memory_gib,
+    MemoryLayout,
+    MemoryInputs,
+    estimate_memory,
 )
 from service_capacity_modeling.models.utils import is_power_of_2
 from service_capacity_modeling.models.utils import next_doubling
@@ -75,6 +77,7 @@ BACKGROUND_BUFFER = "background"
 CRITICAL_TIERS: Set[int] = {0, 1}
 # cluster size aka nodes per ASG
 CRITICAL_TIER_MIN_CLUSTER_SIZE = 2
+
 
 # --- CRR network and backup cost helpers ---
 #
@@ -277,20 +280,75 @@ def _zonal_requirement_for_new_cluster(
     )
 
 
+def _hard_page_cache_requirement_gib(
+    *,
+    memory_derived: DerivedBuffers,
+    current_capacity: Optional[CurrentClusterCapacity],
+    base_mem_gib: float,
+) -> float:
+    if current_capacity is None or current_capacity.cluster_instance is None:
+        return 1.0
+
+    current_page_cache_per_node = MemoryLayout.for_ram(
+        ram_gib=current_capacity.cluster_instance.ram_gib,
+        base_reserves_gib=base_mem_gib,
+        max_page_cache_gib=current_capacity.cluster_instance.ram_gib,
+    ).page_cache_capacity_gib
+
+    return memory_derived.calculate_requirement(
+        current_usage=1.0,
+        existing_capacity=(
+            current_capacity.cluster_instance_count.mid * current_page_cache_per_node
+        ),
+    )
+
+
+def _derived_write_buffer_requirement_gib(
+    *,
+    memory_derived: DerivedBuffers,
+    current_capacity: Optional[CurrentClusterCapacity],
+    base_mem_gib: float,
+    raw_write_buffer_gib: float,
+    max_write_buffer_percent: float,
+) -> float:
+    if current_capacity is None or current_capacity.cluster_instance is None:
+        return raw_write_buffer_gib
+
+    current_layout = MemoryLayout.for_ram(
+        ram_gib=current_capacity.cluster_instance.ram_gib,
+        base_reserves_gib=base_mem_gib,
+    )
+    return memory_derived.calculate_requirement(
+        current_usage=raw_write_buffer_gib,
+        existing_capacity=(
+            current_capacity.cluster_instance_count.mid
+            * current_layout.heap_gib
+            * max_write_buffer_percent
+            * 0.25
+        ),
+    )
+
+
+class _CassandraRequirementEstimate(BaseModel):
+    requirement: CapacityRequirement
+    write_buffer_gib: float
+    compaction_min_threshold: int
+
+
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-positional-arguments
 # pylint: disable=too-many-statements
 def _estimate_cassandra_requirement(
     instance: Instance,
     desires: CapacityDesires,
-    working_set: float,
+    disk_slo_working_set: float,
     reads_per_second: float,
     max_rps_to_disk: int,
     zones_per_region: int = 3,
     copies_per_region: int = 3,
-    experimental_memory_model: bool = False,
-    max_page_cache_gib: float = 32.0,
-) -> CapacityRequirement:
+    max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
+    max_write_buffer_percent: float = 0.25,
+) -> _CassandraRequirementEstimate:
     # Input: regional desires → Output: zonal requirement
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
@@ -324,6 +382,7 @@ def _estimate_cassandra_requirement(
     needed_cores = math.ceil(capacity_requirement.cpu_cores.mid)
     needed_disk = capacity_requirement.disk_gib.mid
     needed_network_mbps = capacity_requirement.network_mbps.mid
+    base_mem = base_memory_gib(desires)
 
     # it can be 0 for cases where disk utilization is not passed as a part of current cluster capacity
     if needed_disk == 0:
@@ -338,9 +397,14 @@ def _estimate_cassandra_requirement(
     estimated_cores_per_region = math.ceil(
         (needed_cores * zones_per_region) / instance.cpu
     )
+
     # Generally speaking we want fewer than some number of reads per second
     # hitting disk per instance. If we don't have many reads we don't need to
     # hold much data in memory.
+    # The SLO working set pushes page cache up when disk misses are too slow.
+    # The RPS working set pulls page cache down when read volume is low enough
+    # that disk can absorb more misses without crossing the per-node read
+    # budget.
     instance_rps = max(1, reads_per_second // estimated_cores_per_region)
     disk_rps = instance_rps * _cass_io_per_read(
         max(1, (disk_used_gib * zones_per_region) // estimated_cores_per_region)
@@ -366,55 +430,66 @@ def _estimate_cassandra_requirement(
         )
 
     # Compute effective working set and memory requirement.
-    if experimental_memory_model:
-        mem = estimate_memory_experimental(
-            current_capacity=current_capacity,
-            working_set=working_set,
-            rps_working_set=rps_working_set,
-            disk_used_gib=disk_used_gib,
-            desires=desires,
-            write_buffer_gib=write_buffer_gib,
+    mem_inputs = MemoryInputs(
+        disk_used_gib=disk_used_gib,
+        write_buffer_gib=write_buffer_gib,
+        disk_slo_working_set=disk_slo_working_set,
+        rps_working_set=rps_working_set,
+        effective_page_cache_gib_per_node=MemoryLayout.for_ram(
+            ram_gib=instance.ram_gib,
+            base_reserves_gib=base_mem,
             max_page_cache_gib=max_page_cache_gib,
-        )
-    else:
-        mem = estimate_memory_legacy(
-            working_set=working_set,
-            rps_working_set=rps_working_set,
-            disk_used_gib=disk_used_gib,
-            zones_per_region=zones_per_region,
-            write_buffer_gib=write_buffer_gib,
-        )
-    effective_working_set = mem.effective_working_set
-    needed_memory = mem.needed_memory_gib
-    write_buffer_gib = mem.write_buffer_gib
-
-    logger.debug(
-        "Need (cpu, mem, disk, working) = (%s, %s, %s, %f)",
-        needed_cores,
-        needed_memory,
-        needed_disk,
-        working_set,
+        ).page_cache_capacity_gib,
+    )
+    mem = estimate_memory(mem_inputs)
+    effective_working_set = mem.effective_ws_fraction
+    memory_derived = DerivedBuffers.for_components(
+        desires.buffers.derived,
+        [BufferComponent.memory],
+        component_fallbacks={},
+    )
+    hard_page_cache_gib = _hard_page_cache_requirement_gib(
+        memory_derived=memory_derived,
+        current_capacity=current_capacity,
+        base_mem_gib=base_mem,
+    )
+    write_buffer_gib = _derived_write_buffer_requirement_gib(
+        memory_derived=memory_derived,
+        current_capacity=current_capacity,
+        base_mem_gib=base_mem,
+        raw_write_buffer_gib=mem.write_buffer_gib,
+        max_write_buffer_percent=max_write_buffer_percent,
     )
 
-    return CapacityRequirement(
-        requirement_type=NflxCassandraCapacityModel.cluster_type,
-        reference_shape=reference_shape,
-        cpu_cores=certain_int(needed_cores),
-        mem_gib=certain_float(needed_memory),
-        disk_gib=certain_float(needed_disk),
-        network_mbps=certain_float(needed_network_mbps),
-        context={
-            "working_set": effective_working_set,
-            "rps_working_set": rps_working_set,
-            "disk_slo_working_set": working_set,
-            "replication_factor": copies_per_region,
-            "compression_ratio": round(
-                1.0 / desires.data_shape.estimated_compression_ratio.mid, 2
-            ),
-            "read_per_second": reads_per_second,
-            "write_buffer_gib": write_buffer_gib,
-            "min_threshold": min_threshold,
-        },
+    logger.debug(
+        "Need (cpu, hard mem, disk, working) = (%s, %s, %s, %f)",
+        needed_cores,
+        hard_page_cache_gib,
+        needed_disk,
+        disk_slo_working_set,
+    )
+
+    return _CassandraRequirementEstimate(
+        requirement=CapacityRequirement(
+            requirement_type=NflxCassandraCapacityModel.cluster_type,
+            reference_shape=reference_shape,
+            cpu_cores=certain_int(needed_cores),
+            mem_gib=certain_float(hard_page_cache_gib),
+            disk_gib=certain_float(needed_disk),
+            network_mbps=certain_float(needed_network_mbps),
+            context={
+                "effective_working_set": effective_working_set,
+                "rps_working_set": rps_working_set,
+                "disk_slo_working_set": disk_slo_working_set,
+                "replication_factor": copies_per_region,
+                "compression_ratio": round(
+                    1.0 / desires.data_shape.estimated_compression_ratio.mid, 2
+                ),
+                "read_per_second": reads_per_second,
+            },
+        ),
+        write_buffer_gib=write_buffer_gib,
+        compaction_min_threshold=min_threshold,
     )
 
 
@@ -500,8 +575,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     max_table_buffer_percent: float = 0.11,
     large_instance_regret: float = 0.2,
     different_family_regret: float = 0.10,
-    experimental_memory_model: bool = False,
-    max_page_cache_gib: float = 32.0,
+    max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
     backup_retention_days: Optional[float] = None,
 ) -> Union[CapacityPlan, Excuse, None]:
     drive_name = drive.name
@@ -584,7 +658,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     # working set to keep more or less data in RAM. Faster drives need
     # less fronting RAM.
     ws_drive = instance.drive or drive
-    working_set = working_set_from_drive_and_slo(
+    disk_slo_working_set = working_set_from_drive_and_slo(
         drive_read_latency_dist=dist_for_interval(ws_drive.read_io_latency_ms),
         read_slo_latency_dist=dist_for_interval(
             desires.query_pattern.read_latency_slo_ms
@@ -595,17 +669,18 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         target_percentile=0.95,
     ).mid
 
-    requirement = _estimate_cassandra_requirement(
+    requirement_estimate = _estimate_cassandra_requirement(
         instance=instance,
         desires=desires,
-        working_set=working_set,
+        disk_slo_working_set=disk_slo_working_set,
         reads_per_second=rps,
         max_rps_to_disk=max_rps_to_disk,
         zones_per_region=zones_per_region,
         copies_per_region=copies_per_region,
-        experimental_memory_model=experimental_memory_model,
         max_page_cache_gib=max_page_cache_gib,
+        max_write_buffer_percent=max_write_buffer_percent,
     )
+    requirement = requirement_estimate.requirement
 
     # Adjust the min count to adjust to prevent too much data on a single
     needed_disk_gib = int(requirement.disk_gib.mid)
@@ -618,16 +693,16 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     # current topology or inflate node count.
     current_capacity = _get_current_capacity(desires)
     is_ebs = instance.drive is None
-    is_existing = (
-        current_capacity is not None
-        and current_capacity.disk_utilization_gib is not None
-        and current_capacity.disk_utilization_gib.mid > 0
+    current_disk_utilization = (
+        current_capacity.disk_utilization_gib if current_capacity is not None else None
     )
     ebs_disk_floor = 0
-    if experimental_memory_model and is_ebs and is_existing:
-        assert current_capacity is not None
-        assert current_capacity.disk_utilization_gib is not None
-        observed_disk_per_node = int(current_capacity.disk_utilization_gib.mid)
+    if (
+        is_ebs
+        and current_disk_utilization is not None
+        and current_disk_utilization.mid > 0
+    ):
+        observed_disk_per_node = int(current_disk_utilization.mid)
         max_attached_data_per_node_gib = max(
             max_attached_data_per_node_gib, observed_disk_per_node
         )
@@ -653,14 +728,18 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         cluster_size_lambda=cluster_size_lambda,
     )
 
-    base_mem = _get_base_memory(desires)
+    base_mem = base_memory_gib(desires)
 
-    heap_fn = _cass_heap_for_write_buffer(
-        instance=instance,
-        max_zonal_size=max_regional_size // zones_per_region,
-        write_buffer_gib=requirement.context["write_buffer_gib"],
-        buffer_percent=(max_write_buffer_percent * max_table_buffer_percent),
-    )
+    @lru_cache(maxsize=None)
+    def memory_layout(ram_gib: float) -> MemoryLayout:
+        return MemoryLayout.for_ram(
+            ram_gib=ram_gib,
+            base_reserves_gib=base_mem,
+            max_page_cache_gib=max_page_cache_gib,
+        )
+
+    def heap_fn(ram_gib: float) -> float:
+        return memory_layout(ram_gib).heap_gib
 
     def max_node_disk(d: Drive) -> int:
         return max(math.ceil(d.max_size_gib / 3), ebs_disk_floor)
@@ -681,14 +760,9 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         # C* clusters provision in powers of 2 because doubling
         cluster_size=cluster_size_lambda,
         min_count=min_count,
-        # TODO: Take reserve memory calculation into account during buffer calculation
-        # C* heap usage takes away from OS page cache memory
-        reserve_memory=lambda x: base_mem + heap_fn(x),
-        # C* heap buffers the writes at roughly a rate of
-        # memtable_cleanup_threshold * memtable_size. At Netflix this
-        # is 0.11 * 25 * heap
+        reserve_memory=lambda x: x - memory_layout(x).page_cache_capacity_gib,
         write_buffer=lambda x: heap_fn(x) * max_write_buffer_percent * 0.25,
-        required_write_buffer_gib=float(requirement.context["write_buffer_gib"]),
+        required_write_buffer_gib=requirement_estimate.write_buffer_gib,
         max_node_disk_gib=max_node_disk,
     )
 
@@ -700,7 +774,9 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         "cassandra.heap.gib": heap_fn(instance.ram_gib),
         "cassandra.heap.write.percent": max_write_buffer_percent,
         "cassandra.heap.table.percent": max_table_buffer_percent,
-        "cassandra.compaction.min_threshold": requirement.context["min_threshold"],
+        "cassandra.compaction.min_threshold": (
+            requirement_estimate.compaction_min_threshold
+        ),
         EFFECTIVE_DISK_PER_NODE_GIB: disk_per_node_gib,
         "cassandra.storage_buffer_ratio": round(disk_buffer_ratio, 2),
         "cassandra.compute_buffer_ratio": round(
@@ -731,15 +807,30 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     # Sometimes we don't want modify cluster topology, so only allow
     # topologies that match the desired zone size
     if required_cluster_size is not None and cluster.count != required_cluster_size:
+        node_counts = cluster.node_count_context
+        required_nodes_by_type = (
+            {k.value: v for k, v in node_counts.required_nodes_by_type.items()}
+            if node_counts is not None
+            else {}
+        )
+        resource_bottleneck = (
+            node_counts.resource_bottleneck.value
+            if node_counts is not None and node_counts.resource_bottleneck is not None
+            else "unknown"
+        )
         return Excuse(
             instance=instance.name,
             drive=drive_name,
             reason=(
-                f"Cluster size {cluster.count} != required {required_cluster_size}"
+                f"Cluster size {cluster.count} "
+                f"(resource bottleneck: {resource_bottleneck}) "
+                f"!= required {required_cluster_size}"
             ),
             context={
                 "computed_count": cluster.count,
                 "required_cluster_size": required_cluster_size,
+                "required_nodes_by_type": required_nodes_by_type,
+                "resource_bottleneck": resource_bottleneck,
             },
             bottleneck=Bottleneck.cluster_size,
         )
@@ -825,22 +916,6 @@ def _cass_io_per_read(node_size_gib: float, sstable_size_mb: int = 160) -> int:
     # One disk IO per data read and one per index read (assume we miss
     # the key cache)
     return 2 * levels
-
-
-def _cass_heap_for_write_buffer(
-    instance: Instance,
-    write_buffer_gib: float,
-    max_zonal_size: int,
-    buffer_percent: float,
-) -> Callable[[float], float]:
-    # If there is no way we can get enough heap with the max zonal size, try
-    # letting max heap grow to 31 GiB per node to get more write buffer
-    if write_buffer_gib > (
-        max_zonal_size * _cass_heap(instance.ram_gib) * buffer_percent
-    ):
-        return lambda x: _cass_heap(x, max_heap_gib=30)
-    else:
-        return _cass_heap
 
 
 def _target_rf(desires: CapacityDesires, user_copies: Optional[int]) -> int:
@@ -1002,18 +1077,12 @@ class NflxCassandraArguments(BaseModel):
         "0.15-0.20 for risk-averse clusters. Only applies when "
         "current_clusters is set. Set to 0 to disable.",
     )
-    experimental_memory_model: bool = Field(
-        default=False,
-        description="Enable experimental memory model. When True, derives working "
-        "set from page cache capped at max_page_cache_gib instead of theoretical "
-        "disk/SLO estimate. When False (default), uses the legacy memory sizing.",
-    )
     max_page_cache_gib: float = Field(
-        default=32.0,
-        description="Maximum page cache (GiB) to assume per node when computing "
-        "working set in the experimental memory model. Caps the effective page "
-        "cache at this value regardless of instance RAM. Set to 0 to disable "
-        "the cap. Only applies when experimental_memory_model is True.",
+        default=DEFAULT_MAX_PAGE_CACHE_GIB,
+        description="Soft maximum page cache (GiB) to assume per node after "
+        "heap and base reserves. Normal page cache is a per-node layout target, "
+        "not an aggregate node-count requirement; explicit memory-preserve can "
+        "still make existing page cache hard.",
     )
     backup_retention_days: Optional[float] = Field(
         default=None,
@@ -1268,7 +1337,6 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             max_table_buffer_percent=max_table_buffer_percent,
             large_instance_regret=args.large_instance_regret,
             different_family_regret=args.different_family_regret,
-            experimental_memory_model=args.experimental_memory_model,
             max_page_cache_gib=args.max_page_cache_gib,
             backup_retention_days=args.backup_retention_days,
         )

--- a/service_capacity_modeling/models/org/netflix/cassandra_memory.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra_memory.py
@@ -1,128 +1,133 @@
 """Memory estimation for Cassandra capacity planning.
 
-Provides two strategies for estimating memory requirements:
-- Legacy: theoretical working set from drive latency and read SLO
-- Experimental: page-cache-capped working set with configurable max
+Single ``estimate_memory`` pipeline: combine the Cassandra working-set bounds,
+cap normal page cache to the candidate node's RAM layout, and emit the raw
+memory demand before current-cluster derived-buffer policy is applied.
+
+Glossary (used throughout this module):
+- ``ram_gib``: total instance RAM
+- ``heap_gib``: JVM heap portion from ``MemoryLayout.for_ram``
+- ``base_reserves_gib``: app + system reserves (from ``base_memory_gib``)
+- ``page_cache_capacity_gib``: per-node ``ram - heap - base_reserves_gib``,
+  optionally capped at ``max_page_cache_gib``
+- ``page_cache_demand_gib``: uncapped page-cache demand from
+  ``effective_ws_fraction * disk_used_gib``
+- ``page_cache_capped_demand_gib``: per-node soft page-cache target capped to
+  this instance shape's RAM layout. Normal page cache is not a zone-level
+  node-count requirement.
+- ``effective_ws_fraction``: final working-set fraction after applying the
+  disk-SLO and RPS bounds
+- ``effective_page_cache_gib_per_node``: candidate shape's per-node page-cache
+  capacity from ``MemoryLayout.for_ram``
+- ``disk_slo_working_set``: working-set fraction from drive latency vs read
+  SLO. This pushes cache up when disk misses are too slow for the request
+  latency target.
+- ``rps_working_set``: working-set fraction from read volume vs disk-read
+  budget. This pulls cache down when read traffic is low enough that disk can
+  absorb more cache misses.
+- ``write_buffer_gib``: raw zone-level memtable/write-buffer memory demand
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from pydantic import BaseModel, ConfigDict
 
-from pydantic import BaseModel
-
-from service_capacity_modeling.interface import (
-    BufferComponent,
-    CapacityDesires,
-    CurrentClusterCapacity,
-)
-from service_capacity_modeling.models.common import DerivedBuffers
+from service_capacity_modeling.interface import CapacityDesires
 
 
-def _get_base_memory(desires: CapacityDesires) -> float:
+DEFAULT_MAX_PAGE_CACHE_GIB = 28.0
+DEFAULT_MAX_HEAP_GIB = 30.0
+MIN_WORKING_SET = 0.01
+
+
+def base_memory_gib(desires: CapacityDesires) -> float:
     return (
         desires.data_shape.reserved_instance_app_mem_gib
         + desires.data_shape.reserved_instance_system_mem_gib
     )
 
 
-def _cass_heap(node_memory_gib: float, max_heap_gib: float = 30) -> float:
-    # Netflix Cassandra heap formula
-    return min(max(4, node_memory_gib // 2), max_heap_gib)
+class MemoryLayout(BaseModel):
+    """Per-node RAM partition: heap + reserves + page cache <= ram_gib."""
+
+    model_config = ConfigDict(frozen=True)
+
+    heap_gib: float
+    base_reserves_gib: float
+    page_cache_capacity_gib: float
+
+    @property
+    def total_gib(self) -> float:
+        return self.heap_gib + self.base_reserves_gib + self.page_cache_capacity_gib
+
+    @classmethod
+    def for_ram(
+        cls,
+        *,
+        ram_gib: float,
+        base_reserves_gib: float,
+        max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
+        max_heap_gib: float = DEFAULT_MAX_HEAP_GIB,
+    ) -> "MemoryLayout":
+        """Partition node RAM among heap, reserves, and page cache.
+
+        Heap follows the Cassandra rule: ``min(ram//2, max_heap_gib)``. Cache
+        is the residual ``ram - heap - base``, soft-capped by
+        ``max_page_cache_gib``. The default cache cap (28) is chosen so that
+        ``28 + 3 base + 30 heap = 61 <= 64 GiB`` boxes - a 4xlarge fit budget.
+
+        Invariant: ``heap + base + page_cache_capacity <= ram_gib`` whenever
+        ``ram_gib >= max(4, base) + 4``.
+        """
+        heap = float(min(max(4, ram_gib // 2), max_heap_gib))
+        cache_capacity = max(
+            0.0, min(max_page_cache_gib, ram_gib - heap - base_reserves_gib)
+        )
+        return cls(
+            heap_gib=heap,
+            base_reserves_gib=base_reserves_gib,
+            page_cache_capacity_gib=cache_capacity,
+        )
 
 
 class MemoryEstimate(BaseModel):
-    """Result of memory sizing: clear contract between old/new paths."""
+    """Raw memory sizing result before current-capacity derived buffers."""
 
-    effective_working_set: float
-    needed_memory_gib: float
+    effective_ws_fraction: float
+    page_cache_demand_gib: float
+    page_cache_capped_demand_gib: float
     write_buffer_gib: float
 
 
-def estimate_memory_legacy(
-    working_set: float,
-    rps_working_set: float,
-    disk_used_gib: float,
-    zones_per_region: int,
-    write_buffer_gib: float,
-) -> MemoryEstimate:
-    """Legacy: theoretical working set, simple memory calculation."""
-    effective_ws = min(working_set, rps_working_set)
-    needed = effective_ws * disk_used_gib * zones_per_region
-    needed = max(1, int(needed // zones_per_region))
-    return MemoryEstimate(
-        effective_working_set=effective_ws,
-        needed_memory_gib=needed,
-        write_buffer_gib=write_buffer_gib,
+class MemoryInputs(BaseModel):
+    """Inputs to raw Cassandra memory sizing."""
+
+    model_config = ConfigDict(frozen=True)
+
+    disk_used_gib: float
+    write_buffer_gib: float
+    disk_slo_working_set: float
+    rps_working_set: float
+    effective_page_cache_gib_per_node: float = DEFAULT_MAX_PAGE_CACHE_GIB
+
+
+def estimate_memory(inputs: MemoryInputs) -> MemoryEstimate:
+    """Estimate raw Cassandra memory demand before derived-buffer policy."""
+    effective_ws = max(
+        MIN_WORKING_SET,
+        min(
+            1.0,
+            inputs.disk_slo_working_set,
+            inputs.rps_working_set,
+        ),
     )
-
-
-def estimate_memory_experimental(  # pylint: disable=too-many-positional-arguments
-    current_capacity: Optional[CurrentClusterCapacity],
-    working_set: float,
-    rps_working_set: float,
-    disk_used_gib: float,
-    desires: CapacityDesires,
-    write_buffer_gib: float,
-    max_page_cache_gib: float = 32.0,
-) -> MemoryEstimate:
-    """Experimental: page-cache-capped working set.
-
-    Computes page cache per node as RAM - heap - base_reserves, then caps it
-    at max_page_cache_gib (0 or negative disables the cap).  The cap prevents
-    large-RAM instances from inflating the working-set estimate for workloads
-    that don't benefit from extra cache (e.g. write-heavy timeseries).
-
-    Honors memory preserve buffers: when set, keeps the current cluster's
-    total page cache as the memory requirement and zeros write_buffer_gib.
-
-    When no current capacity is available, falls back to the theoretical
-    working set (same as legacy).
-    """
-    if current_capacity and current_capacity.cluster_instance:
-        reserve = _get_base_memory(desires) + _cass_heap(
-            current_capacity.cluster_instance.ram_gib
-        )
-        page_cache_per_node = max(
-            0, current_capacity.cluster_instance.ram_gib - reserve
-        )
-        # Apply the cap (0 or negative disables it)
-        if max_page_cache_gib > 0:
-            page_cache_per_node = min(page_cache_per_node, max_page_cache_gib)
-
-        # Derive working set from capped page cache / disk ratio
-        raw_disk_per_node = current_capacity.disk_utilization_gib.mid
-        if raw_disk_per_node <= 0:
-            raw_disk_per_node = (
-                disk_used_gib / current_capacity.cluster_instance_count.mid
-            )
-        raw_disk_per_node = max(1, raw_disk_per_node)
-        effective_ws = min(1.0, page_cache_per_node / raw_disk_per_node)
-    else:
-        # Theoretical: from drive latency vs read SLO
-        effective_ws = min(working_set, rps_working_set)
-
-    needed_memory: float = max(1, int(effective_ws * disk_used_gib))
-
-    # Honor memory preserve buffer: keep current cluster's total page cache
-    memory_derived = DerivedBuffers.for_components(
-        desires.buffers.derived, [BufferComponent.memory]
+    page_cache_demand = max(1.0, effective_ws * inputs.disk_used_gib)
+    page_cache_capped_demand: float = max(
+        1, int(min(page_cache_demand, inputs.effective_page_cache_gib_per_node))
     )
-    if (
-        memory_derived.preserve
-        and current_capacity
-        and current_capacity.cluster_instance
-    ):
-        reserve_memory = _get_base_memory(desires) + _cass_heap(
-            current_capacity.cluster_instance.ram_gib
-        )
-        needed_memory = (
-            current_capacity.cluster_instance.ram_gib - reserve_memory
-        ) * current_capacity.cluster_instance_count.mid
-        write_buffer_gib = 0
-
     return MemoryEstimate(
-        effective_working_set=effective_ws,
-        needed_memory_gib=needed_memory,
-        write_buffer_gib=write_buffer_gib,
+        effective_ws_fraction=effective_ws,
+        page_cache_demand_gib=page_cache_demand,
+        page_cache_capped_demand_gib=page_cache_capped_demand,
+        write_buffer_gib=inputs.write_buffer_gib,
     )

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -306,7 +306,6 @@ scenarios.append(
         cassandra_timeseries_ebs,
         {
             "require_local_disks": False,
-            "experimental_memory_model": True,
         },
         "cassandra_timeseries_ebs",
     )
@@ -369,7 +368,6 @@ scenarios.append(
         {
             "require_local_disks": False,
             "require_attached_disks": True,
-            "experimental_memory_model": True,
         },
         "cassandra_kv_dense_ebs",
     )
@@ -431,7 +429,6 @@ scenarios.append(
         {
             "require_local_disks": False,
             "require_attached_disks": True,
-            "experimental_memory_model": True,
         },
         "cassandra_kv_compact_ebs",
     )

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -395,137 +395,143 @@
       "cassandra.backup.s3-standard": 353277.0672346802,
       "cassandra.net.inter.region": 1009641.2273436785,
       "cassandra.net.intra.region": 3028923.6820310354,
-      "cassandra.zonal-clusters": 1772864.6400000001
+      "cassandra.zonal-clusters": 1478336.6400000001
     },
     "clusters": [
       {
-        "annual_cost": 590954.88,
+        "annual_cost": 492778.88,
         "attached_drives": [
           "gp3 : 5600GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 8,
           "cassandra.compute_buffer_ratio": 1.32,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
           "effective_disk_per_node_gib": 6600,
+          "rank_penalties": {
+            "family_migration": 0.1
+          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 32,
+            "cpu": 50,
             "disk_capacity": 56,
             "disk_iops": 0,
-            "memory": 24,
+            "memory": 2,
             "min_count": 64,
-            "network": 2
+            "network": 3
           },
           "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r6a.4xlarge"
+        "instance": "m7a.2xlarge"
       },
       {
-        "annual_cost": 590954.88,
+        "annual_cost": 492778.88,
         "attached_drives": [
           "gp3 : 5600GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 8,
           "cassandra.compute_buffer_ratio": 1.32,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
           "effective_disk_per_node_gib": 6600,
+          "rank_penalties": {
+            "family_migration": 0.1
+          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 32,
+            "cpu": 50,
             "disk_capacity": 56,
             "disk_iops": 0,
-            "memory": 24,
+            "memory": 2,
             "min_count": 64,
-            "network": 2
+            "network": 3
           },
           "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r6a.4xlarge"
+        "instance": "m7a.2xlarge"
       },
       {
-        "annual_cost": 590954.88,
+        "annual_cost": 492778.88,
         "attached_drives": [
           "gp3 : 5600GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 8,
           "cassandra.compute_buffer_ratio": 1.32,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.17,
           "effective_disk_per_node_gib": 6600,
+          "rank_penalties": {
+            "family_migration": 0.1
+          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 32,
+            "cpu": 50,
             "disk_capacity": 56,
             "disk_iops": 0,
-            "memory": 24,
+            "memory": 2,
             "min_count": 64,
-            "network": 2
+            "network": 3
           },
           "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r6a.4xlarge"
+        "instance": "m7a.2xlarge"
       }
     ],
     "model": "org.netflix.cassandra",
     "region": "us-east-1",
     "scenario": "cassandra_timeseries_ebs",
     "service_tier": 1,
-    "total_annual_cost": 6164706.62
+    "total_annual_cost": 5870178.62
   },
   {
     "annual_costs": {
       "cassandra.backup.s3-standard": 37961.555153961184,
       "cassandra.net.inter.region": 29695.330215990543,
       "cassandra.net.intra.region": 89085.99064797163,
-      "cassandra.zonal-clusters": 627456.0
+      "cassandra.zonal-clusters": 459327.36
     },
     "clusters": [
       {
-        "annual_cost": 209152.0,
+        "annual_cost": 153109.12,
         "attached_drives": [
           "gp3 : 1200GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.37,
-          "cassandra.heap.gib": 30.0,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
           "effective_disk_per_node_gib": 5100,
-          "rank_penalties": {
-            "family_migration": 0.1
-          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 33,
+            "cpu": 56,
             "disk_capacity": 15,
             "disk_iops": 0,
-            "memory": 32,
+            "memory": 1,
             "min_count": 16,
             "network": 2
           },
@@ -534,31 +540,28 @@
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r5.2xlarge"
+        "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 209152.0,
+        "annual_cost": 153109.12,
         "attached_drives": [
           "gp3 : 1200GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.37,
-          "cassandra.heap.gib": 30.0,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
           "effective_disk_per_node_gib": 5100,
-          "rank_penalties": {
-            "family_migration": 0.1
-          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 33,
+            "cpu": 56,
             "disk_capacity": 15,
             "disk_iops": 0,
-            "memory": 32,
+            "memory": 1,
             "min_count": 16,
             "network": 2
           },
@@ -567,31 +570,28 @@
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r5.2xlarge"
+        "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 209152.0,
+        "annual_cost": 153109.12,
         "attached_drives": [
           "gp3 : 1200GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.37,
-          "cassandra.heap.gib": 30.0,
+          "cassandra.heap.gib": 15.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
           "cassandra.storage_buffer_ratio": 2.44,
           "effective_disk_per_node_gib": 5100,
-          "rank_penalties": {
-            "family_migration": 0.1
-          },
           "required_nodes_by_type": {
             "cluster_size": 64,
-            "cpu": 33,
+            "cpu": 56,
             "disk_capacity": 15,
             "disk_iops": 0,
-            "memory": 32,
+            "memory": 1,
             "min_count": 16,
             "network": 2
           },
@@ -600,27 +600,27 @@
         "cluster_type": "cassandra",
         "count": 64,
         "deployment": "zonal",
-        "instance": "r5.2xlarge"
+        "instance": "r6a.xlarge"
       }
     ],
     "model": "org.netflix.cassandra",
     "region": "us-east-1",
     "scenario": "cassandra_kv_dense_ebs",
     "service_tier": 1,
-    "total_annual_cost": 784198.88
+    "total_annual_cost": 616070.24
   },
   {
     "annual_costs": {
       "cassandra.backup.s3-standard": 15626.777788490295,
       "cassandra.net.inter.region": 7423.832553997636,
       "cassandra.net.intra.region": 22271.497661992908,
-      "cassandra.zonal-clusters": 270399.36
+      "cassandra.zonal-clusters": 202015.68
     },
     "clusters": [
       {
-        "annual_cost": 90133.12,
+        "annual_cost": 67338.56,
         "attached_drives": [
-          "gp3 : 500GB"
+          "gp3 : 900GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -632,25 +632,25 @@
           "cassandra.storage_buffer_ratio": 2.74,
           "effective_disk_per_node_gib": 5700,
           "required_nodes_by_type": {
-            "cluster_size": 64,
+            "cluster_size": 32,
             "cpu": 18,
             "disk_capacity": 6,
             "disk_iops": 0,
-            "memory": 40,
+            "memory": 1,
             "min_count": 8,
             "network": 1
           },
-          "resource_bottleneck": "memory"
+          "resource_bottleneck": "cpu"
         },
         "cluster_type": "cassandra",
-        "count": 64,
+        "count": 32,
         "deployment": "zonal",
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 90133.12,
+        "annual_cost": 67338.56,
         "attached_drives": [
-          "gp3 : 500GB"
+          "gp3 : 900GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -662,25 +662,25 @@
           "cassandra.storage_buffer_ratio": 2.74,
           "effective_disk_per_node_gib": 5700,
           "required_nodes_by_type": {
-            "cluster_size": 64,
+            "cluster_size": 32,
             "cpu": 18,
             "disk_capacity": 6,
             "disk_iops": 0,
-            "memory": 40,
+            "memory": 1,
             "min_count": 8,
             "network": 1
           },
-          "resource_bottleneck": "memory"
+          "resource_bottleneck": "cpu"
         },
         "cluster_type": "cassandra",
-        "count": 64,
+        "count": 32,
         "deployment": "zonal",
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 90133.12,
+        "annual_cost": 67338.56,
         "attached_drives": [
-          "gp3 : 500GB"
+          "gp3 : 900GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -692,18 +692,18 @@
           "cassandra.storage_buffer_ratio": 2.74,
           "effective_disk_per_node_gib": 5700,
           "required_nodes_by_type": {
-            "cluster_size": 64,
+            "cluster_size": 32,
             "cpu": 18,
             "disk_capacity": 6,
             "disk_iops": 0,
-            "memory": 40,
+            "memory": 1,
             "min_count": 8,
             "network": 1
           },
-          "resource_bottleneck": "memory"
+          "resource_bottleneck": "cpu"
         },
         "cluster_type": "cassandra",
-        "count": 64,
+        "count": 32,
         "deployment": "zonal",
         "instance": "r6a.xlarge"
       }
@@ -712,7 +712,7 @@
     "region": "us-east-1",
     "scenario": "cassandra_kv_compact_ebs",
     "service_tier": 1,
-    "total_annual_cost": 315721.47
+    "total_annual_cost": 247337.79
   },
   {
     "annual_costs": {
@@ -1157,7 +1157,7 @@
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.38,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 30.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
@@ -1187,7 +1187,7 @@
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.38,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 30.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
@@ -1217,7 +1217,7 @@
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
           "cassandra.compute_buffer_ratio": 1.38,
-          "cassandra.heap.gib": 30,
+          "cassandra.heap.gib": 30.0,
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -237,7 +237,7 @@ class TestCassandraStorage:
         result = cap_plan.candidate_clusters.zonal[0]
 
         cores = result.count * result.instance.cpu
-        assert 128 <= cores <= 512
+        assert 64 <= cores <= 512
         # Should get attached storage since we explicitly requested it
         assert result.attached_drives, (
             "Expected attached drives with require_attached_disks=True"
@@ -252,8 +252,9 @@ class TestCassandraStorage:
 
         # 10TiB ~= 4 IO/read -> 3.3k r/zone/s -> 12k /s
         assert 20_000 < read_ios < 60_000
-        # 33k wps * 8KiB  / 256KiB write IO size = 16.5k / s * 4 for compaction = 6.4k
-        assert 4_000 < write_ios < 7_000
+        # 33k wps * 8KiB / 256KiB write IO = ~6.4k base; page-cache cap
+        # constrains memory denominator → more nodes → higher total IOs
+        assert 4_000 < write_ios < 16_000
 
 
 class TestCassandraThroughput:
@@ -319,9 +320,16 @@ class TestCassandraThroughput:
         )[0]
         high_writes_result = cap_plan.candidate_clusters.zonal[0]
 
-        # With attached disks requested, should get general-purpose instances
-        assert high_writes_result.instance.family[0] in ("m", "r")
-        assert high_writes_result.count > 32
+        # With attached disks requested, stay in stateful datastore families.
+        assert high_writes_result.instance.family in {
+            "c6a",
+            "c7a",
+            "m6a",
+            "m7a",
+            "r6a",
+            "r7a",
+        }
+        assert high_writes_result.count >= 32
 
         # Should have attached storage since we explicitly requested it
         assert high_writes_result.attached_drives, (
@@ -426,32 +434,6 @@ class TestCassandraDurability:
         )
 
 
-def _make_memory_test_desire(
-    disk_utilization_gib: float = 100,
-    state_size_gib: int = 300,
-    reads: int = 10_000,
-    writes: int = 100_000,
-) -> CapacityDesires:
-    """Build a CapacityDesires for memory model tests with common defaults."""
-    cluster = CurrentZoneClusterCapacity(
-        cluster_instance_name="r5d.4xlarge",
-        cluster_instance=shapes.instance("r5d.4xlarge"),
-        cluster_instance_count=certain_int(2),
-        cpu_utilization=certain_float(13.0),
-        disk_utilization_gib=certain_float(disk_utilization_gib),
-        network_utilization_mbps=certain_float(128.0),
-    )
-    return CapacityDesires(
-        service_tier=1,
-        current_clusters=CurrentClusters(zonal=[cluster]),
-        query_pattern=QueryPattern(
-            estimated_read_per_second=certain_int(reads),
-            estimated_write_per_second=certain_int(writes),
-        ),
-        data_shape=DataShape(estimated_state_size_gib=certain_int(state_size_gib)),
-    )
-
-
 class TestCassandraCurrentCapacity:
     """Test scenarios with current capacity information."""
 
@@ -504,70 +486,13 @@ class TestCassandraCurrentCapacity:
             extra_model_arguments={
                 **EXTRA_MODEL_ARGS,
                 "required_cluster_size": 8,
-                "experimental_memory_model": True,
             },
         )
 
-        # Page cache cap (32 GiB default) limits working set on i4i.8xlarge
-        # (256 GiB RAM → raw page_cache≈224, capped to 32).  This prevents
-        # the planner from picking 256+ GiB RAM instances to satisfy inflated
-        # memory requirements.
         lr_clusters = cap_plan[0].candidate_clusters.zonal[0]
         assert lr_clusters.instance.ram_gib < 256, (
             f"Cap should prevent 256 GiB RAM instances, got {lr_clusters.instance.name}"
         )
-
-    def test_page_cache_cap_limits_working_set(self):
-        """Page cache cap (default 32 GiB) limits effective working set."""
-        # r5d.4xlarge: 128 GiB RAM, heap=30, base≈2 → raw page_cache≈96
-        # capped to 32, disk_per_node=100 → ws=0.32
-        desire = _make_memory_test_desire()
-        cap_plan = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desire,
-            extra_model_arguments={
-                **EXTRA_MODEL_ARGS,
-                "required_cluster_size": 2,
-                "experimental_memory_model": True,
-            },
-        )
-
-        ctx = cap_plan[0].requirements.zonal[0].context
-        assert ctx["working_set"] < 0.35
-        assert ctx["write_buffer_gib"] > 0
-
-    def test_custom_page_cache_cap(self):
-        """Custom max_page_cache_gib overrides default cap."""
-        desire = _make_memory_test_desire()
-        # With cap=64, ws = min(1.0, 64/100) = 0.64 → more RAM needed
-        cap_plan = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desire,
-            extra_model_arguments={
-                **EXTRA_MODEL_ARGS,
-                "required_cluster_size": 2,
-                "experimental_memory_model": True,
-                "max_page_cache_gib": 64.0,
-            },
-        )
-
-        ctx = cap_plan[0].requirements.zonal[0].context
-        assert ctx["working_set"] > 0.5
-
-    def test_legacy_path_ignores_cap(self):
-        """Without experimental_memory_model, legacy theoretical path is used."""
-        desire = _make_memory_test_desire()
-        cap_plan = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desire,
-            extra_model_arguments={**EXTRA_MODEL_ARGS, "required_cluster_size": 2},
-        )
-
-        ctx = cap_plan[0].requirements.zonal[0].context
-        assert ctx["working_set"] < 0.5
 
     def test_preserve_memory(self):
         """Memory preserve buffer keeps current cluster's page cache."""
@@ -602,14 +527,15 @@ class TestCassandraCurrentCapacity:
             desires=desire,
             extra_model_arguments={
                 **EXTRA_MODEL_ARGS,
-                "required_cluster_size": 2,
-                "experimental_memory_model": True,
+                "required_cluster_size": 8,
             },
         )
+        assert cap_plan, "Expected at least one plan for preserve memory"
 
-        # Preserve → write_buffer zeroed, RAM preserved at current level
-        ctx = cap_plan[0].requirements.zonal[0].context
-        assert ctx["write_buffer_gib"] == 0
+        # Preserve is applied at hard-memory node sizing, after the raw
+        # Cassandra memory requirement has been calculated.
+        cluster_params = cap_plan[0].candidate_clusters.zonal[0].cluster_params
+        assert cluster_params["required_nodes_by_type"]["memory"] == 8
 
     def test_capacity_non_power_of_two(self):
         cluster_capacity = CurrentZoneClusterCapacity(
@@ -710,76 +636,10 @@ class TestCassandraExtraModelArguments:
                 tier, extra_model_arguments
             )
 
-    def test_experimental_memory_model_defaults_to_false(self):
-        """Verify experimental_memory_model defaults to False."""
+    def test_page_cache_cap_default(self):
         from service_capacity_modeling.models.org.netflix.cassandra import (
             NflxCassandraArguments,
         )
 
         args = NflxCassandraArguments.from_extra_model_arguments({})
-        assert args.experimental_memory_model is False
-
-
-class TestCassandraPageCacheCap:
-    """Test page cache cap in the experimental memory model."""
-
-    def test_cap_with_high_disk_per_node(self):
-        """High disk per node with cap → low working set."""
-        desire = _make_memory_test_desire(
-            disk_utilization_gib=500,
-            state_size_gib=300,
-            reads=10_000,
-            writes=50_000,
-        )
-        cap_plan = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desire,
-            extra_model_arguments={
-                **EXTRA_MODEL_ARGS,
-                "required_cluster_size": 2,
-                "experimental_memory_model": True,
-            },
-        )
-
-        # r5d.4xlarge: 128 GiB RAM, page_cache capped to 32, disk=500
-        # ws = 32/500 = 0.064
-        ctx = cap_plan[0].requirements.zonal[0].context
-        assert ctx["working_set"] < 0.1
-
-    def test_large_state_cluster(self):
-        """Large-state cluster benefits from page cache cap."""
-        cluster = CurrentZoneClusterCapacity(
-            cluster_instance_name="r6a.4xlarge",
-            cluster_instance_count=certain_int(16),
-            cpu_utilization=certain_float(15.0),
-            disk_utilization_gib=certain_float(3000),
-            network_utilization_mbps=certain_float(50),
-        )
-        desire = CapacityDesires(
-            service_tier=1,
-            current_clusters=CurrentClusters(zonal=[cluster] * 3),
-            query_pattern=QueryPattern(
-                estimated_read_per_second=certain_int(60_000),
-                estimated_write_per_second=certain_int(170_000),
-            ),
-            data_shape=DataShape(
-                estimated_state_size_gib=certain_int(10_000),
-                estimated_compression_ratio=certain_float(1.0),
-            ),
-        )
-        cap_plan = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desire,
-            extra_model_arguments={
-                **EXTRA_MODEL_ARGS,
-                "experimental_memory_model": True,
-            },
-        )
-
-        assert cap_plan, "Page cache cap should produce a plan"
-        ctx = cap_plan[0].requirements.zonal[0].context
-        # r6a.4xlarge: 122 GiB RAM → raw page_cache≈90, capped to 32
-        # disk_per_node=3000 → ws ≈ 32/3000 ≈ 0.01
-        assert ctx["working_set"] < 0.02
+        assert args.max_page_cache_gib == 28.0

--- a/tests/netflix/test_cassandra_memory.py
+++ b/tests/netflix/test_cassandra_memory.py
@@ -1,24 +1,28 @@
-"""Tests for cassandra_memory.py — experimental memory estimation."""
+"""Tests for cassandra_memory.py memory estimation."""
 
 import pytest
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import (
-    Buffer,
-    BufferComponent,
-    BufferIntent,
-    Buffers,
+    AccessPattern,
     CapacityDesires,
+    CurrentClusters,
     CurrentZoneClusterCapacity,
     DataShape,
-    Instance,
+    Drive,
+    DriveType,
     QueryPattern,
     certain_float,
     certain_int,
 )
 from service_capacity_modeling.models.org.netflix.cassandra_memory import (
-    _cass_heap,
-    _get_base_memory,
-    estimate_memory_experimental,
+    DEFAULT_MAX_PAGE_CACHE_GIB,
+    DEFAULT_MAX_HEAP_GIB,
+    MemoryInputs,
+    MemoryLayout,
+    base_memory_gib,
+    estimate_memory,
 )
 
 
@@ -37,131 +41,180 @@ def _make_desires(**overrides) -> CapacityDesires:
     return CapacityDesires(**defaults)
 
 
-def _make_instance(
-    *,
-    name: str = "m5d.8xlarge",
-    ram_gib: float = 128.0,
-    cpu: int = 32,
-):
-    return Instance(
-        name=name,
-        cpu=cpu,
-        cpu_ghz=2.5,
-        ram_gib=ram_gib,
-        net_mbps=10000,
-        drive=None,
-    )
-
-
-def _make_current_capacity(
-    *,
-    instance_name: str = "m5d.8xlarge",
-    ram_gib: float = 128.0,
-    instance_count: int = 12,
-    disk_util_gib: float = 200.0,
-    cpu: int = 32,
-) -> CurrentZoneClusterCapacity:
-    return CurrentZoneClusterCapacity(
-        cluster_instance_name=instance_name,
-        cluster_instance=_make_instance(
-            name=instance_name,
-            ram_gib=ram_gib,
-            cpu=cpu,
+def _write_heavy_existing_4xlarge_desires() -> CapacityDesires:
+    current_instance = shapes.instance("r7a.4xlarge")
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(3_000),
+            estimated_write_per_second=certain_int(90_000),
         ),
-        cluster_instance_count=certain_float(instance_count),
-        cpu_utilization=certain_float(0.3),
-        disk_utilization_gib=certain_float(disk_util_gib),
+        data_shape=DataShape(
+            estimated_state_size_gib=certain_int(3_000),
+        ),
+        current_clusters=CurrentClusters(
+            zonal=[
+                CurrentZoneClusterCapacity(
+                    cluster_instance_name=current_instance.name,
+                    cluster_instance=current_instance,
+                    cluster_drive=Drive(
+                        name="gp3",
+                        drive_type=DriveType.attached_ssd,
+                        size_gib=2_500,
+                    ),
+                    cluster_instance_count=certain_int(8),
+                    cluster_type="cassandra",
+                    cpu_utilization=certain_float(20),
+                    network_utilization_mbps=certain_float(250),
+                    disk_utilization_gib=certain_float(400),
+                )
+            ],
+        ),
     )
 
 
-# 128 GiB: heap=30, base=3, raw_page_cache=95
-# 32 GiB: heap=16, base=3, raw_page_cache=13
-@pytest.mark.parametrize(
-    "ram_gib, disk_util, cap, expected_ws",
-    [
-        (128.0, 200.0, 32.0, 32.0 / 200.0),  # capped: 95 → 32
-        (32.0, 100.0, 32.0, 13.0 / 100.0),  # below cap: stays 13
-        (128.0, 200.0, 64.0, 64.0 / 200.0),  # custom cap: 95 → 64
-        (128.0, 200.0, 0, 95.0 / 200.0),  # cap=0 disables: full 95
-    ],
-    ids=["capped", "below_cap", "custom_cap", "cap_disabled"],
-)
-def test_page_cache_cap(ram_gib, disk_util, cap, expected_ws):
-    desires = _make_desires()
-    current = _make_current_capacity(ram_gib=ram_gib, disk_util_gib=disk_util)
+def _inputs(
+    *,
+    disk_used_gib: float,
+    write_buffer_gib: float,
+    disk_slo_working_set: float = 0.5,
+    rps_working_set: float = 0.4,
+    effective_page_cache_gib_per_node: float = DEFAULT_MAX_PAGE_CACHE_GIB,
+) -> MemoryInputs:
+    return MemoryInputs(
+        disk_used_gib=disk_used_gib,
+        write_buffer_gib=write_buffer_gib,
+        disk_slo_working_set=disk_slo_working_set,
+        rps_working_set=rps_working_set,
+        effective_page_cache_gib_per_node=effective_page_cache_gib_per_node,
+    )
 
-    result = estimate_memory_experimental(
-        current_capacity=current,
-        working_set=0.5,
-        rps_working_set=0.4,
-        disk_used_gib=1000.0,
-        desires=desires,
-        write_buffer_gib=2.0,
+
+@pytest.mark.parametrize(
+    "ram_gib, cap, expected_page_cache",
+    [
+        (128.0, 32.0, 32.0),
+        (32.0, 32.0, 13.0),
+        (128.0, 64.0, 64.0),
+        (128.0, 1e9, 95.0),
+    ],
+    ids=["capped", "below_cap", "custom_cap", "high_cap"],
+)
+def test_page_cache_cap(ram_gib, cap, expected_page_cache):
+    desires = _make_desires()
+    layout = MemoryLayout.for_ram(
+        ram_gib=ram_gib,
+        base_reserves_gib=base_memory_gib(desires),
         max_page_cache_gib=cap,
     )
 
-    assert result.effective_working_set == pytest.approx(expected_ws)
+    assert layout.page_cache_capacity_gib == pytest.approx(expected_page_cache)
+
+
+def test_m6id_2xlarge_memory_layout_fits_heap_base_and_page_cache():
+    desires = _make_desires()
+    instance = shapes.instance("m6id.2xlarge")
+    layout = MemoryLayout.for_ram(
+        ram_gib=instance.ram_gib,
+        base_reserves_gib=base_memory_gib(desires),
+    )
+
+    assert layout.total_gib <= instance.ram_gib
+    assert layout.page_cache_capacity_gib == pytest.approx(
+        instance.ram_gib - layout.heap_gib - layout.base_reserves_gib
+    )
+    assert layout.page_cache_capacity_gib <= DEFAULT_MAX_PAGE_CACHE_GIB
+
+
+def test_4xlarge_memory_layout_keeps_page_cache_within_ram():
+    desires = _make_desires()
+    instance = shapes.instance("m7a.4xlarge")
+    layout = MemoryLayout.for_ram(
+        ram_gib=instance.ram_gib,
+        base_reserves_gib=base_memory_gib(desires),
+    )
+
+    assert layout.heap_gib == DEFAULT_MAX_HEAP_GIB
+    assert layout.page_cache_capacity_gib == DEFAULT_MAX_PAGE_CACHE_GIB
+    assert layout.total_gib <= instance.ram_gib
+
+
+def test_page_cache_does_not_force_r_family_for_4xlarge_candidates():
+    plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=_write_heavy_existing_4xlarge_desires(),
+        instance_families=["m7a", "r7a"],
+        extra_model_arguments={
+            "require_local_disks": False,
+            "require_attached_disks": True,
+        },
+        max_results_per_family=20,
+        num_results=100,
+    )
+    by_instance = {p.candidate_clusters.zonal[0].instance.name: p for p in plans}
+
+    m7a = by_instance["m7a.4xlarge"].candidate_clusters.zonal[0]
+    r7a = by_instance["r7a.4xlarge"].candidate_clusters.zonal[0]
+    m7a_counts = m7a.cluster_params["required_nodes_by_type"]
+
+    assert m7a.count == r7a.count == 8
+    assert m7a_counts["memory"] <= max(
+        m7a_counts["cpu"],
+        m7a_counts["network"],
+        m7a_counts["disk_capacity"],
+        m7a_counts["disk_iops"],
+    )
 
 
 def test_no_current_capacity_uses_theoretical():
-    desires = _make_desires()
-
-    result = estimate_memory_experimental(
-        current_capacity=None,
-        working_set=0.5,
-        rps_working_set=0.4,
-        disk_used_gib=500.0,
-        desires=desires,
-        write_buffer_gib=1.0,
+    result = estimate_memory(
+        _inputs(
+            disk_used_gib=500.0,
+            write_buffer_gib=1.0,
+        )
     )
 
-    assert result.effective_working_set == pytest.approx(0.4)
-    assert result.needed_memory_gib == 200
+    assert result.effective_ws_fraction == pytest.approx(0.4)
+    assert result.page_cache_demand_gib == 200
+    assert result.page_cache_capped_demand_gib == DEFAULT_MAX_PAGE_CACHE_GIB
+
+
+def test_page_cache_capped_demand_keeps_small_datasets_uncapped():
+    result = estimate_memory(
+        _inputs(
+            disk_used_gib=20.0,
+            write_buffer_gib=1.0,
+            disk_slo_working_set=1.0,
+            rps_working_set=1.0,
+        )
+    )
+
+    assert result.page_cache_capped_demand_gib == 20
+
+
+def test_page_cache_capped_demand_caps_large_datasets_by_per_node_budget():
+    result = estimate_memory(
+        _inputs(
+            disk_used_gib=10_000.0,
+            write_buffer_gib=1.0,
+            disk_slo_working_set=0.5,
+            rps_working_set=0.5,
+            effective_page_cache_gib_per_node=26.0,
+        )
+    )
+
+    assert result.page_cache_demand_gib == 5_000
+    assert result.page_cache_capped_demand_gib == 26
 
 
 def test_write_buffer_passthrough():
-    desires = _make_desires()
-    current = _make_current_capacity()
-
-    result = estimate_memory_experimental(
-        current_capacity=current,
-        working_set=0.5,
-        rps_working_set=0.4,
-        disk_used_gib=1000.0,
-        desires=desires,
-        write_buffer_gib=5.0,
+    result = estimate_memory(
+        _inputs(
+            disk_used_gib=1000.0,
+            write_buffer_gib=5.0,
+        )
     )
 
     assert result.write_buffer_gib == 5.0
-
-
-def test_preserve_buffer_keeps_existing_memory():
-    """Memory preserve buffer returns current cluster's total page cache."""
-    desires = _make_desires(
-        buffers=Buffers(
-            derived={
-                "memory": Buffer(
-                    intent=BufferIntent.preserve,
-                    components=[BufferComponent.memory],
-                )
-            }
-        ),
-    )
-    # 128 GiB RAM, heap=30, base=3 → page_cache_per_node=95
-    # 12 instances → total page cache = 95 * 12 = 1140
-    current = _make_current_capacity()
-
-    result = estimate_memory_experimental(
-        current_capacity=current,
-        working_set=0.5,
-        rps_working_set=0.4,
-        disk_used_gib=1000.0,
-        desires=desires,
-        write_buffer_gib=5.0,
-    )
-
-    base = _get_base_memory(desires)
-    heap = _cass_heap(128.0)
-    expected = (128.0 - heap - base) * 12
-    assert result.needed_memory_gib == pytest.approx(expected)
-    assert result.write_buffer_gib == 0

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -1,0 +1,346 @@
+"""Tests for Cassandra cluster-size excuse explainability."""
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import (
+    AccessPattern,
+    Buffer,
+    BufferComponent,
+    BufferIntent,
+    Buffers,
+    CapacityDesires,
+    CurrentClusters,
+    CurrentZoneClusterCapacity,
+    DataShape,
+    Drive,
+    Interval,
+    QueryPattern,
+    certain_float,
+    certain_int,
+)
+
+SMALL_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_cluster_size_excuse_has_resource_bottleneck_details():
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=SMALL_KV,
+        extra_model_arguments={"required_cluster_size": 2, "require_local_disks": True},
+        num_results=5,
+    )
+    excuses = [e for e in explained.excuses if "resource bottleneck:" in e.reason]
+    assert excuses, "Expected cluster_size excuses with count bottleneck details"
+    for e in excuses:
+        counts = e.context["required_nodes_by_type"]
+        assert set(counts.keys()) == {
+            "cpu",
+            "memory",
+            "network",
+            "disk_capacity",
+            "disk_iops",
+            "cluster_size",
+            "min_count",
+        }
+        assert e.context["resource_bottleneck"] in counts
+        assert e.context["resource_bottleneck"] in e.reason
+
+
+def test_count_memory_denominator_capped_at_page_cache():
+    """reserve_memory(ram) should yield denom = page_cache_capacity_gib.
+
+    For all RAM sizes above ~61 GiB, MemoryLayout caps page cache at 28 GiB.
+    The reserve_memory lambda should return ram - 28, so compute_stateful_zone
+    divides needed_memory by 28 — not by the raw uncapped page cache.
+    """
+    from service_capacity_modeling.models.org.netflix.cassandra_memory import (
+        DEFAULT_MAX_PAGE_CACHE_GIB,
+        MemoryLayout,
+    )
+
+    base_mem = 3.0
+
+    def reserve_fn(ram_gib):
+        return (
+            ram_gib
+            - MemoryLayout.for_ram(
+                ram_gib=ram_gib,
+                base_reserves_gib=base_mem,
+            ).page_cache_capacity_gib
+        )
+
+    for ram in [61.04, 122.07, 244.14, 384.0]:
+        denom = ram - reserve_fn(ram)
+        assert denom == DEFAULT_MAX_PAGE_CACHE_GIB, (
+            f"ram={ram}: denominator should be {DEFAULT_MAX_PAGE_CACHE_GIB}, "
+            f"got {denom}"
+        )
+
+
+def test_existing_count_does_not_seed_memory_count():
+    """A large current topology is not itself a page-cache memory demand."""
+    current_cluster = CurrentZoneClusterCapacity(
+        cluster_instance=shapes.instance("r6a.4xlarge"),
+        cluster_instance_name="r6a.4xlarge",
+        cluster_drive=Drive(
+            name="gp3",
+            drive_type="attached-ssd",
+            size_gib=1000,
+        ),
+        cluster_instance_count=certain_int(64),
+        cpu_utilization=certain_float(1),
+        disk_utilization_gib=certain_float(50),
+        network_utilization_mbps=certain_float(1),
+    )
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(100),
+            estimated_write_per_second=certain_int(100),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(100)),
+        current_clusters=CurrentClusters(zonal=[current_cluster] * 3),
+        buffers=Buffers(
+            derived={
+                "storage": Buffer(
+                    ratio=1.0,
+                    intent=BufferIntent.scale_down,
+                    components=[BufferComponent.storage],
+                )
+            }
+        ),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={
+            "require_local_disks": False,
+        },
+        instance_families=["m7a"],
+        num_results=1,
+    )
+
+    params = plans[0].candidate_clusters.zonal[0].cluster_params
+    counts = params["required_nodes_by_type"]
+
+    assert counts["memory"] == 1
+    assert counts["memory"] < current_cluster.cluster_instance_count.mid
+    assert counts["memory"] <= max(
+        counts["cpu"],
+        counts["disk_capacity"],
+        counts["disk_iops"],
+        counts["network"],
+    )
+
+
+def test_memory_scale_up_floors_existing_page_cache_capacity():
+    current_instance = shapes.instance("r6a.4xlarge")
+    current_cluster = CurrentZoneClusterCapacity(
+        cluster_instance=current_instance,
+        cluster_instance_name=current_instance.name,
+        cluster_drive=Drive(
+            name="gp3",
+            drive_type="attached-ssd",
+            size_gib=1000,
+        ),
+        cluster_instance_count=certain_int(2),
+        cluster_type="cassandra",
+        cpu_utilization=certain_float(1),
+        disk_utilization_gib=certain_float(50),
+        network_utilization_mbps=certain_float(1),
+    )
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(100),
+            estimated_write_per_second=certain_int(100),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(100)),
+        current_clusters=CurrentClusters(zonal=[current_cluster]),
+        buffers=Buffers(
+            derived={
+                "memory": Buffer(
+                    intent=BufferIntent.scale_up,
+                    ratio=1.0,
+                    components=[BufferComponent.memory],
+                )
+            }
+        ),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={
+            "require_local_disks": False,
+            "require_attached_disks": True,
+        },
+        instance_families=["m7a"],
+        num_results=1,
+    )
+
+    requirement = plans[0].requirements.zonal[0]
+    counts = (
+        plans[0].candidate_clusters.zonal[0].cluster_params["required_nodes_by_type"]
+    )
+
+    assert requirement.mem_gib.mid > 1
+    assert counts["memory"] > max(
+        counts["cpu"],
+        counts["disk_capacity"],
+        counts["disk_iops"],
+        counts["network"],
+    )
+
+
+def test_normal_page_cache_not_dumped_in_requirement_context():
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(100),
+            estimated_write_per_second=certain_int(100),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(10_000)),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={"require_local_disks": True},
+        instance_families=["m6id"],
+        num_results=1,
+    )
+
+    ctx = plans[0].requirements.zonal[0].context
+    assert not [key for key in ctx if key.startswith("page_cache")]
+
+
+def test_write_buffer_is_hard_memory_pressure():
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(10),
+            estimated_write_per_second=certain_int(100),
+            estimated_mean_write_size_bytes=certain_int(1 << 20),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(100)),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments={"require_local_disks": True},
+        instance_families=["m6id"],
+        num_results=1,
+    )
+
+    params = plans[0].candidate_clusters.zonal[0].cluster_params
+    counts = params["required_nodes_by_type"]
+
+    assert counts["memory"] > max(
+        counts["cpu"],
+        counts["disk_capacity"],
+        counts["disk_iops"],
+        counts["network"],
+    )
+
+
+WRITE_HEAVY_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        estimated_read_per_second=Interval(
+            low=1000, mid=5000, high=10000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=5000, mid=20000, high=40000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=100, mid=200, high=300, confidence=0.98),
+    ),
+)
+
+
+def test_memory_scale_down_caps_write_buffer():
+    """Memory scale_down should not exceed current write-buffer capacity."""
+    i4i_4xl = shapes.instance("i4i.4xlarge")
+    current_cluster = CurrentZoneClusterCapacity(
+        cluster_instance=i4i_4xl,
+        cluster_instance_name="i4i.4xlarge",
+        cluster_instance_count=certain_int(4),
+        cpu_utilization=certain_float(10),
+        memory_utilization_gib=certain_float(10),
+        disk_utilization_gib=certain_float(500),
+        network_utilization_mbps=certain_float(100),
+    )
+
+    uncapped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=WRITE_HEAVY_KV,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert uncapped_plans, "Expected uncapped plan"
+
+    capped_desires = WRITE_HEAVY_KV.model_copy(deep=True)
+    capped_desires.current_clusters = CurrentClusters(zonal=[current_cluster])
+    capped_desires.buffers = Buffers(
+        derived={
+            "memory": Buffer(
+                intent=BufferIntent.scale_down,
+                ratio=1.0,
+                components=[BufferComponent.memory],
+            ),
+        }
+    )
+
+    capped_plans = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=capped_desires,
+        extra_model_arguments={"require_local_disks": True},
+        num_results=1,
+    )
+    assert capped_plans, "Expected capped plan"
+
+    capped_zone = capped_plans[0].candidate_clusters.zonal[0]
+    capped_counts = capped_zone.cluster_params["required_nodes_by_type"]
+
+    assert "memory" in capped_counts
+    assert capped_zone.cluster_params["resource_bottleneck"] is not None
+
+    for plan in uncapped_plans:
+        zone = plan.candidate_clusters.zonal[0]
+        if zone.instance.name == capped_zone.instance.name:
+            uncapped_mem = zone.cluster_params["required_nodes_by_type"]["memory"]
+            assert capped_counts["memory"] <= uncapped_mem, (
+                f"Expected capped memory ({capped_counts['memory']}) "
+                f"<= uncapped ({uncapped_mem}) for {capped_zone.instance.name}"
+            )
+            break

--- a/tests/netflix/test_cassandra_scale_constraints.py
+++ b/tests/netflix/test_cassandra_scale_constraints.py
@@ -586,9 +586,10 @@ class TestStorageAndCPUIntegration:
         result_cores = result.count * result.instance.cpu
         result_storage = result.count * get_drive_size_gib(result)
 
-        # With EBS, planner selects compute-optimized instances with attached storage
+        # With bounded memory sizing, EBS can use the cheaper compute-optimized
+        # shape while still satisfying CPU and storage scale-up requirements.
         assert_similar_compute(
-            shapes.instance("m7i.4xlarge"),
+            shapes.instance("c6a.4xlarge"),
             result.instance,
             CLUSTER_SIZE * 4,
             result.count,
@@ -660,7 +661,10 @@ class TestStorageAndCPUIntegration:
         result_cores = result.count * result.instance.cpu
         result_storage = result.count * get_drive_size_gib(result)
         assert_similar_compute(
-            shapes.instance("m6id.8xlarge"), result.instance, 8, result.count
+            shapes.instance("c6a.4xlarge"),
+            result.instance,
+            CLUSTER_SIZE * 4,
+            result.count,
         )
         assert result_cores >= CLUSTER.total_vcpu * 2
 

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -4,6 +4,7 @@ import pytest
 
 from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import NodeCountContext
 from service_capacity_modeling.interface import NodeCountConstraint
 from service_capacity_modeling.models.common import compute_stateful_zone
 
@@ -44,6 +45,35 @@ def test_count_bottleneck_resource(cores, mem, disk, net, expected_bottleneck):
     assert context is not None
     assert {k.value for k in context.required_nodes_by_type} == EXPECTED_KEYS
     assert context.resource_bottleneck == NodeCountConstraint(expected_bottleneck)
+
+
+def test_memory_tie_does_not_hide_non_memory_bottleneck():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=EBS,
+        needed_cores=32,  # ceil(32/16) = 2 nodes
+        needed_disk_gib=100,
+        needed_memory_gib=122,  # ceil(122/61.04) = 2 nodes
+        needed_network_mbps=100,
+    )
+
+    counts = cluster.cluster_params["required_nodes_by_type"]
+    assert counts["cpu"] == counts["memory"] == 2
+    assert cluster.cluster_params["resource_bottleneck"] == "cpu"
+
+
+def test_non_memory_tie_order_is_stable():
+    context = NodeCountContext.from_counts(
+        count_cpu=1,
+        count_memory=3,
+        count_network=3,
+        count_disk_capacity=3,
+        count_disk_iops=3,
+        cluster_size_count=3,
+        min_count=0,
+    )
+
+    assert context.resource_bottleneck == NodeCountConstraint.network
 
 
 def test_storage_bound_local():


### PR DESCRIPTION
## What am I trying to do?

Fix Cassandra capacity recommendations so memory sizing no longer scales page-cache demand linearly with total state size. This makes 4xlarge-class instances viable for write-heavy workloads when heap, reserves, and useful page cache fit in node RAM.

## Why did I do it this way?

### Bounded Cassandra Memory

Cassandra RAM is partitioned into heap, physical reserves, and effective page cache. Page-cache demand is still driven by working-set bounds, but it is capped by what the planned cluster can usefully serve instead of treating large state size as a requirement to cache a flat percentage of disk.

### Single Memory Path

The old legacy/experimental split is removed. The unified path applies SLO, RPS, and observational bounds consistently, then emits explicit page-cache demand, linear demand, effective budget, and write-buffer demand.

### Reviewability

Memory helper containers are frozen Pydantic models, generated Cassandra baselines were refreshed, and regression coverage checks the m7a.4xlarge/r7a.4xlarge fit behavior.

## Are there any tests?

Yes. Focused Cassandra planner tests cover the memory model, resource counts, and 4xlarge fit regression. `tox -e pre-commit` also passed before push.

## How would I use the new code?

No caller API change is required. Cassandra capacity planning uses the bounded memory model by default when producing recommendations.

## Follow-ups

Unknown RPS/WPS policy and preserve-memory rework are separate follow-ups. PR 267 is stacked on this branch and handles derived buffer normalization.
