### PR TITLE
feat: add explicit derived buffer floor and ceiling intents

### DIFF
--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from pydantic import computed_field
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 from service_capacity_modeling.enum_utils import enum_docstrings
 from service_capacity_modeling.enum_utils import StrEnum
@@ -947,13 +948,26 @@ class BufferIntent(StrEnum):
 
     Example 2: need 20 cores but have 40 → scale down to 20 cores."""
 
+    floor = "floor"
+    """Set a minimum requirement as a fraction of existing capacity. ratio specifies
+    the fraction (e.g. ratio=0.8 means never drop below 80% of current capacity).
+    Only valid in buffers.derived."""
+
+    ceiling = "ceiling"
+    """Set a maximum requirement as a fraction of existing capacity. ratio specifies
+    the fraction (e.g. ratio=1.2 means never exceed 120% of current capacity).
+    Only valid in buffers.derived."""
+
 
 class Buffer(ExcludeUnsetModel):
     """Represents a buffer (headroom) directive for capacity planning"""
 
     ratio: float = 1.0
     """The buffer value expressed as a ratio over normal load (e.g. 1.5 =
-    50% headroom)"""
+    50% headroom).
+
+    For derived buffers with intent=floor or intent=ceiling, ratio is the
+    bound expressed as a fraction of existing capacity."""
 
     intent: BufferIntent = BufferIntent.desired
     """The intent of this buffer directive (almost always 'desired')"""
@@ -1004,14 +1018,33 @@ class Buffers(ExcludeUnsetModel):
     default: Buffer = Buffer(ratio=1.5)
     # Desired compute, storage, cpu, memory, etc... buffers
     desired: Dict[str, Buffer] = {}
-    # Derive these buffers from current clusters or model context
-    # Buffer.intent MUST be set on these Buffers to something other than "desired":
-    #   scale    = ratio on top of existing buffers to ensure. Let the "derived"
-    #              buffer multiplied by this ratio "needed". If the "needed" buffer
-    #              is greater than desired, the needed buffer is created. If the
-    #              "needed" buffer is less than desired, the needed buffer is created.
-    #   preserve = ignore desired buffer entirely, just maintain existing buffers
+    # Derive these buffers from current clusters or model context.
+    # Use intent to specify the policy:
+    #   scale      = ratio * current usage
+    #   scale_up   = scale + floor at 1x existing (sugar)
+    #   scale_down = scale + ceiling at 1x existing (sugar)
+    #   preserve   = floor=1x and ceiling=1x (sugar)
+    #   floor      = ratio = minimum fraction of existing capacity
+    #   ceiling    = ratio = maximum fraction of existing capacity
     derived: Dict[str, Buffer] = {}
+
+    @model_validator(mode="after")
+    def _validate_buffer_contexts(self) -> "Buffers":
+        for name, buf in self.desired.items():
+            if buf.intent != BufferIntent.desired:
+                raise ValueError(
+                    f"desired buffer '{name}' has intent '{buf.intent}' "
+                    "which is only valid in buffers.derived"
+                )
+
+        for name, buf in self.derived.items():
+            if buf.intent == BufferIntent.desired:
+                raise ValueError(
+                    f"derived buffer '{name}' has intent 'desired' - "
+                    "use scale/scale_up/scale_down/preserve/floor/ceiling "
+                    "instead"
+                )
+        return self
 
 
 class CapacityDesires(ExcludeUnsetModel):

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -917,7 +917,6 @@ def merge_plan(
 
 class DerivedBuffers(BaseModel):
     scale: float = Field(default=1, gt=0)
-    preserve: bool = False
     # When present, this is the maximum ratio of the current usage
     ceiling: Optional[float] = Field(
         default=None,
@@ -925,6 +924,15 @@ class DerivedBuffers(BaseModel):
     )
     # When present, this is the minimum ratio of the current usage
     floor: Optional[float] = Field(default=None, gt=0)
+
+    @property
+    def is_preserve(self) -> bool:
+        """True when this policy pins the requirement to existing capacity.
+
+        Equivalent to the old ``preserve=True`` boolean: the requirement is
+        both floored and capped at 1x existing capacity with no scaling.
+        """
+        return self.scale == 1 and self.floor == 1 and self.ceiling == 1
 
     @staticmethod
     def for_components(
@@ -935,30 +943,41 @@ class DerivedBuffers(BaseModel):
         expanded_components = _expand_components(components, component_fallbacks)
 
         scale = 1.0
-        preserve = False
-        ceiling = None
-        floor = None
+        ceiling: Optional[float] = None
+        floor: Optional[float] = None
 
         for bfr in buffer.values():
             if not expanded_components.intersection(bfr.components):
                 continue
 
-            if bfr.intent in [
+            if bfr.intent == BufferIntent.preserve:
+                # Preserve pins both bounds to existing capacity, no scale change
+                floor = max(floor or 0, 1.0)
+                ceiling = min(ceiling if ceiling is not None else float("inf"), 1.0)
+            elif bfr.intent in (
                 BufferIntent.scale,
                 BufferIntent.scale_up,
                 BufferIntent.scale_down,
-            ]:
+            ):
                 scale = combine_buffer_ratios(scale, bfr.ratio)
-            if bfr.intent == BufferIntent.scale_up:
-                floor = 1  # Create a floor of 1.0x the current usage
-            if bfr.intent == BufferIntent.scale_down:
-                ceiling = 1  # Create a ceiling of 1.0x the current usage
-            if bfr.intent == BufferIntent.preserve:
-                preserve = True
+                if bfr.intent == BufferIntent.scale_up:
+                    floor = max(floor or 0, 1.0)
+                elif bfr.intent == BufferIntent.scale_down:
+                    ceiling = min(ceiling if ceiling is not None else float("inf"), 1.0)
+            elif bfr.intent == BufferIntent.floor:
+                floor = max(floor or 0, bfr.ratio)
+            elif bfr.intent == BufferIntent.ceiling:
+                ceiling = min(
+                    ceiling if ceiling is not None else float("inf"), bfr.ratio
+                )
+            # desired intent: no derived policy
 
-        return DerivedBuffers(
-            scale=scale, preserve=preserve, ceiling=ceiling, floor=floor
-        )
+        if floor is not None and ceiling is not None and floor > ceiling:
+            raise ValueError(
+                f"Merged derived policy has floor ({floor}) > ceiling ({ceiling})"
+            )
+
+        return DerivedBuffers(scale=scale, ceiling=ceiling, floor=floor)
 
     def calculate_requirement(
         self,
@@ -966,9 +985,6 @@ class DerivedBuffers(BaseModel):
         existing_capacity: float,
         desired_buffer_ratio: float = 1.0,
     ) -> float:
-        if self.preserve:
-            return existing_capacity
-
         requirement = self.scale * current_usage * desired_buffer_ratio
         if self.ceiling is not None:
             requirement = min(requirement, self.ceiling * existing_capacity)

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,10 +1,12 @@
 import pytest
+from pydantic import ValidationError
 from pytest import approx
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
+from service_capacity_modeling.interface import BufferIntent
 from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import cpu_headroom_target
@@ -272,3 +274,158 @@ def test_derived_buffer_validation():
 
     with pytest.raises(ValueError):
         DerivedBuffers.for_components(derived_buffers, [BufferComponent.storage])
+
+
+def test_desired_rejects_derived_only_intents():
+    """Derived-only intents must not appear in buffers.desired"""
+    for intent in [
+        BufferIntent.scale,
+        BufferIntent.scale_up,
+        BufferIntent.scale_down,
+        BufferIntent.preserve,
+        BufferIntent.floor,
+        BufferIntent.ceiling,
+    ]:
+        with pytest.raises(ValidationError):
+            Buffers(desired={"x": Buffer(intent=intent, components=["memory"])})
+
+
+def test_preserve_with_non_unit_ratio_normalized():
+    """preserve intent ignores ratio; for backward compat, ratio is accepted
+    but the normalization always uses scale=1, floor=1, ceiling=1."""
+    buffers = Buffers(
+        derived={
+            "mem": Buffer(
+                intent=BufferIntent.preserve,
+                ratio=2.0,
+                components=["memory"],
+            )
+        }
+    )
+    db = DerivedBuffers.for_components(buffers.derived, [BufferComponent.memory])
+    assert db.is_preserve  # ratio is ignored, still normalizes to preserve
+
+
+@pytest.mark.parametrize(
+    "intent,ratio,exp_scale,exp_floor,exp_ceiling",
+    [
+        (BufferIntent.preserve, 1.0, 1, 1, 1),
+        (BufferIntent.scale_up, 1.5, 1.5, 1, None),
+        (BufferIntent.scale_down, 0.8, 0.8, None, 1),
+        (BufferIntent.scale, 2.0, 2.0, None, None),
+        (BufferIntent.floor, 0.8, 1.0, 0.8, None),
+        (BufferIntent.ceiling, 1.2, 1.0, None, 1.2),
+    ],
+    ids=["preserve", "scale_up", "scale_down", "scale", "floor", "ceiling"],
+)
+def test_intent_normalization(intent, ratio, exp_scale, exp_floor, exp_ceiling):
+    """Each intent normalizes to the correct (scale, floor, ceiling) triple."""
+    derived = {
+        "x": Buffer(intent=intent, ratio=ratio, components=[BufferComponent.memory])
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.scale == exp_scale
+    assert db.floor == exp_floor
+    assert db.ceiling == exp_ceiling
+
+
+def test_scale_with_floor_and_ceiling_intents_combine():
+    """scale + floor + ceiling as separate entries combine correctly"""
+    derived = {
+        "scale": Buffer(
+            intent=BufferIntent.scale,
+            ratio=1.5,
+            components=[BufferComponent.memory],
+        ),
+        "min": Buffer(
+            intent=BufferIntent.floor,
+            ratio=0.8,
+            components=[BufferComponent.memory],
+        ),
+        "max": Buffer(
+            intent=BufferIntent.ceiling,
+            ratio=1.2,
+            components=[BufferComponent.memory],
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.scale == 1.5
+    assert db.floor == 0.8
+    assert db.ceiling == 1.2
+
+
+def test_multiple_floors_merge_max():
+    """Multiple floor-intent buffers take the max."""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.floor, ratio=0.5, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.floor, ratio=0.8, components=[BufferComponent.memory]
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.floor == 0.8
+
+
+def test_multiple_ceilings_merge_min():
+    """Multiple ceiling-intent buffers take the min."""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.5, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.2, components=[BufferComponent.memory]
+        ),
+    }
+    db = DerivedBuffers.for_components(derived, [BufferComponent.memory])
+    assert db.ceiling == 1.2
+
+
+def test_merged_floor_exceeds_ceiling_rejected():
+    """Merged policy where floor > ceiling raises ValueError"""
+    derived = {
+        "a": Buffer(
+            intent=BufferIntent.floor, ratio=2.0, components=[BufferComponent.memory]
+        ),
+        "b": Buffer(
+            intent=BufferIntent.ceiling, ratio=1.0, components=[BufferComponent.memory]
+        ),
+    }
+    with pytest.raises(ValueError, match="floor.*ceiling"):
+        DerivedBuffers.for_components(derived, [BufferComponent.memory])
+
+
+def test_preserve_calculate_requirement():
+    """Preserve-normalized policy returns existing_capacity"""
+    db = DerivedBuffers(scale=1, floor=1, ceiling=1)
+    assert db.is_preserve
+    # Regardless of current_usage or desired_buffer_ratio, result = existing
+    assert db.calculate_requirement(50, 100) == 100
+    assert db.calculate_requirement(150, 100) == 100
+    assert db.calculate_requirement(50, 100, desired_buffer_ratio=2.0) == 100
+
+
+def test_scale_up_calculate_requirement():
+    """scale_up: floor=1 means never drop below existing capacity"""
+    db = DerivedBuffers(scale=1.5, floor=1)
+    # Under-provisioned: need 150, have 100, scale up to 150.
+    assert db.calculate_requirement(100, 100) == 150
+    # Over-provisioned: need 30, have 100, floor pins to 100.
+    assert db.calculate_requirement(20, 100) == 100
+
+
+def test_scale_down_calculate_requirement():
+    """scale_down: ceiling=1 means never exceed existing capacity"""
+    db = DerivedBuffers(scale=0.8, ceiling=1)
+    # Over-provisioned: need 80, have 100, scale down to 80.
+    assert db.calculate_requirement(100, 100) == 80
+    # Under-provisioned: need 160, have 100, ceiling caps to 100.
+    assert db.calculate_requirement(200, 100) == 100
+
+
+def test_plain_scale_calculate_requirement():
+    """Plain scale with no bounds: just multiply"""
+    db = DerivedBuffers(scale=2.0)
+    assert db.calculate_requirement(50, 100) == 100
+    assert db.calculate_requirement(50, 100, desired_buffer_ratio=1.5) == 150


### PR DESCRIPTION
## What am I trying to do?

Normalize derived buffer behavior so floor and ceiling are explicit intents instead of being implied only through preserve, scale_up, or scale_down.

## Why did I do it this way?

### Explicit Bounds

`BufferIntent.floor` and `BufferIntent.ceiling` let callers state lower and upper bounds directly as a ratio of existing capacity. Existing preserve-style behavior is represented as `scale=1`, `floor=1`, and `ceiling=1`.

### Child PR Scope

This PR is stacked on PR 266. It depends on the Cassandra memory/resource-count cleanup there, but its own diff is limited to buffer intent normalization and related tests.

## Are there any tests?

Yes. Buffer tests cover desired/derived validation, floor and ceiling normalization, preserve semantics, and requirement calculation. Focused Cassandra tests and `tox -e pre-commit` passed after rebasing on PR 266.

## How would I use the new code?

```python
Buffers(
    derived={
        "memory-floor": Buffer(
            intent=BufferIntent.floor,
            ratio=0.8,
            components=[BufferComponent.memory],
        )
    }
)
```
