### PR TITLE
test: capture uncertain planner regression baselines

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -62,6 +62,9 @@ from service_capacity_modeling.stats import interval_percentile
 
 logger = logging.getLogger(__name__)
 
+IntervalSampler = Callable[[Interval, str, int], Sequence[Interval]]
+IntervalPercentileSampler = Callable[[Interval, Sequence[int]], Sequence[Interval]]
+
 
 class PlannerArguments(ExcludeUnsetModel):
     """Planner-level configuration, separate from model-specific extra_model_arguments.
@@ -126,7 +129,9 @@ def simulate_interval(
 # e.g. read_per_second[100, 1000] -> [rps[107, 107], rps[756, 756], ...]
 # num_sims concrete values are generated.
 def model_desires(
-    desires: CapacityDesires, num_sims: int = 1000
+    desires: CapacityDesires,
+    num_sims: int = 1000,
+    interval_sampler: Optional[IntervalSampler] = None,
 ) -> Generator[CapacityDesires, None, None]:
     query_pattern = desires.query_pattern.model_copy(deep=True)
     data_shape = desires.data_shape.model_copy(deep=True)
@@ -135,7 +140,11 @@ def model_desires(
     for field in sorted(QueryPattern.model_fields):
         d = getattr(query_pattern, field)
         if isinstance(d, Interval):
-            query_pattern_simulation[field] = simulate_interval(d, field)(num_sims)
+            query_pattern_simulation[field] = (
+                interval_sampler(d, field, num_sims)
+                if interval_sampler is not None
+                else simulate_interval(d, field)(num_sims)
+            )
         else:
             query_pattern_simulation[field] = [d] * num_sims
 
@@ -143,7 +152,11 @@ def model_desires(
     for field in sorted(DataShape.model_fields):
         d = getattr(data_shape, field)
         if isinstance(d, Interval):
-            data_shape_simulation[field] = simulate_interval(d, field)(num_sims)
+            data_shape_simulation[field] = (
+                interval_sampler(d, field, num_sims)
+                if interval_sampler is not None
+                else simulate_interval(d, field)(num_sims)
+            )
         else:
             data_shape_simulation[field] = [d] * num_sims
 
@@ -167,6 +180,7 @@ def model_desires(
 def model_desires_percentiles(
     desires: CapacityDesires,
     percentiles: Sequence[int] = (5, 25, 50, 75, 95),
+    interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
 ) -> Tuple[Sequence[CapacityDesires], CapacityDesires]:
     query_pattern = desires.query_pattern.model_copy(deep=True)
     data_shape = desires.data_shape.model_copy(deep=True)
@@ -176,7 +190,11 @@ def model_desires_percentiles(
     for field in sorted(QueryPattern.model_fields):
         d = getattr(query_pattern, field)
         if isinstance(d, Interval):
-            query_pattern_simulation[field] = interval_percentile(d, percentiles)
+            query_pattern_simulation[field] = (
+                interval_percentile_sampler(d, percentiles)
+                if interval_percentile_sampler is not None
+                else interval_percentile(d, percentiles)
+            )
             if d.can_simulate:
                 query_pattern_means[field] = certain_float(d.mid)
             else:
@@ -190,7 +208,11 @@ def model_desires_percentiles(
     for field in sorted(DataShape.model_fields):
         d = getattr(data_shape, field)
         if isinstance(d, Interval):
-            data_shape_simulation[field] = interval_percentile(d, percentiles)
+            data_shape_simulation[field] = (
+                interval_percentile_sampler(d, percentiles)
+                if interval_percentile_sampler is not None
+                else interval_percentile(d, percentiles)
+            )
             if d.can_simulate:
                 data_shape_means[field] = certain_float(d.mid)
             else:
@@ -549,6 +571,7 @@ class CapacityPlanner:
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
+        interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
     ) -> Tuple[Sequence[CapacityPlan], Dict[int, Sequence[CapacityPlan]]]:
         if model_name not in self._models:
             raise ValueError(
@@ -573,7 +596,9 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
         ):
             percentile_inputs, mean_desires = model_desires_percentiles(
-                desires=sub_desires, percentiles=sorted_percentiles
+                desires=sub_desires,
+                percentiles=sorted_percentiles,
+                interval_percentile_sampler=interval_percentile_sampler,
             )
             model_mean_desires[sub_model] = mean_desires
             index = 0
@@ -1102,6 +1127,8 @@ class CapacityPlanner:
         explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
+        interval_sampler: Optional[IntervalSampler] = None,
+        interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
@@ -1138,7 +1165,11 @@ class CapacityPlanner:
             desires_by_model[sub_model] = sub_desires
             model_plans: List[Tuple[CapacityDesires, Sequence[CapacityPlan]]] = []
             model_excuses: List[Excuse] = []
-            for sim_desires in model_desires(sub_desires, simulations):
+            for sim_desires in model_desires(
+                sub_desires,
+                simulations,
+                interval_sampler=interval_sampler,
+            ):
                 sim_result = self._plan_certain(
                     model_name=sub_model,
                     region=region,
@@ -1212,6 +1243,7 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
             num_regions=num_regions,
             instance_families=instance_families,
+            interval_percentile_sampler=interval_percentile_sampler,
         )
 
         result = UncertainCapacityPlan(

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -62,9 +62,6 @@ from service_capacity_modeling.stats import interval_percentile
 
 logger = logging.getLogger(__name__)
 
-IntervalSampler = Callable[[Interval, str, int], Sequence[Interval]]
-IntervalPercentileSampler = Callable[[Interval, Sequence[int]], Sequence[Interval]]
-
 
 class PlannerArguments(ExcludeUnsetModel):
     """Planner-level configuration, separate from model-specific extra_model_arguments.
@@ -129,9 +126,7 @@ def simulate_interval(
 # e.g. read_per_second[100, 1000] -> [rps[107, 107], rps[756, 756], ...]
 # num_sims concrete values are generated.
 def model_desires(
-    desires: CapacityDesires,
-    num_sims: int = 1000,
-    interval_sampler: Optional[IntervalSampler] = None,
+    desires: CapacityDesires, num_sims: int = 1000
 ) -> Generator[CapacityDesires, None, None]:
     query_pattern = desires.query_pattern.model_copy(deep=True)
     data_shape = desires.data_shape.model_copy(deep=True)
@@ -140,11 +135,7 @@ def model_desires(
     for field in sorted(QueryPattern.model_fields):
         d = getattr(query_pattern, field)
         if isinstance(d, Interval):
-            query_pattern_simulation[field] = (
-                interval_sampler(d, field, num_sims)
-                if interval_sampler is not None
-                else simulate_interval(d, field)(num_sims)
-            )
+            query_pattern_simulation[field] = simulate_interval(d, field)(num_sims)
         else:
             query_pattern_simulation[field] = [d] * num_sims
 
@@ -152,11 +143,7 @@ def model_desires(
     for field in sorted(DataShape.model_fields):
         d = getattr(data_shape, field)
         if isinstance(d, Interval):
-            data_shape_simulation[field] = (
-                interval_sampler(d, field, num_sims)
-                if interval_sampler is not None
-                else simulate_interval(d, field)(num_sims)
-            )
+            data_shape_simulation[field] = simulate_interval(d, field)(num_sims)
         else:
             data_shape_simulation[field] = [d] * num_sims
 
@@ -180,7 +167,6 @@ def model_desires(
 def model_desires_percentiles(
     desires: CapacityDesires,
     percentiles: Sequence[int] = (5, 25, 50, 75, 95),
-    interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
 ) -> Tuple[Sequence[CapacityDesires], CapacityDesires]:
     query_pattern = desires.query_pattern.model_copy(deep=True)
     data_shape = desires.data_shape.model_copy(deep=True)
@@ -190,11 +176,7 @@ def model_desires_percentiles(
     for field in sorted(QueryPattern.model_fields):
         d = getattr(query_pattern, field)
         if isinstance(d, Interval):
-            query_pattern_simulation[field] = (
-                interval_percentile_sampler(d, percentiles)
-                if interval_percentile_sampler is not None
-                else interval_percentile(d, percentiles)
-            )
+            query_pattern_simulation[field] = interval_percentile(d, percentiles)
             if d.can_simulate:
                 query_pattern_means[field] = certain_float(d.mid)
             else:
@@ -208,11 +190,7 @@ def model_desires_percentiles(
     for field in sorted(DataShape.model_fields):
         d = getattr(data_shape, field)
         if isinstance(d, Interval):
-            data_shape_simulation[field] = (
-                interval_percentile_sampler(d, percentiles)
-                if interval_percentile_sampler is not None
-                else interval_percentile(d, percentiles)
-            )
+            data_shape_simulation[field] = interval_percentile(d, percentiles)
             if d.can_simulate:
                 data_shape_means[field] = certain_float(d.mid)
             else:
@@ -571,7 +549,6 @@ class CapacityPlanner:
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
-        interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
     ) -> Tuple[Sequence[CapacityPlan], Dict[int, Sequence[CapacityPlan]]]:
         if model_name not in self._models:
             raise ValueError(
@@ -596,9 +573,7 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
         ):
             percentile_inputs, mean_desires = model_desires_percentiles(
-                desires=sub_desires,
-                percentiles=sorted_percentiles,
-                interval_percentile_sampler=interval_percentile_sampler,
+                desires=sub_desires, percentiles=sorted_percentiles
             )
             model_mean_desires[sub_model] = mean_desires
             index = 0
@@ -1127,8 +1102,6 @@ class CapacityPlanner:
         explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        interval_sampler: Optional[IntervalSampler] = None,
-        interval_percentile_sampler: Optional[IntervalPercentileSampler] = None,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
@@ -1165,11 +1138,7 @@ class CapacityPlanner:
             desires_by_model[sub_model] = sub_desires
             model_plans: List[Tuple[CapacityDesires, Sequence[CapacityPlan]]] = []
             model_excuses: List[Excuse] = []
-            for sim_desires in model_desires(
-                sub_desires,
-                simulations,
-                interval_sampler=interval_sampler,
-            ):
+            for sim_desires in model_desires(sub_desires, simulations):
                 sim_result = self._plan_certain(
                     model_name=sub_model,
                     region=region,
@@ -1243,7 +1212,6 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
             num_regions=num_regions,
             instance_families=instance_families,
-            interval_percentile_sampler=interval_percentile_sampler,
         )
 
         result = UncertainCapacityPlan(

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -34,6 +34,9 @@ from service_capacity_modeling.interface import (
     QueryPattern,
 )
 
+BASELINE_UNCERTAIN_SIMULATIONS = 16
+BASELINE_UNCERTAIN_NUM_RESULTS = 3
+
 
 def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]:
     """Format a single cluster's details."""
@@ -60,6 +63,43 @@ def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]
     return info
 
 
+def _capture_candidate(candidate: Any) -> dict[str, Any]:
+    """Serialize a candidate cluster set into a stable regression snapshot."""
+    cluster_details = []
+    for zonal_cluster in candidate.zonal:
+        cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
+    for regional_cluster in candidate.regional:
+        cluster_details.append(_format_cluster(regional_cluster, "regional"))
+
+    return {
+        "total_annual_cost": float(candidate.total_annual_cost),
+        "clusters": cluster_details,
+        "annual_costs": dict(
+            sorted((k, float(v)) for k, v in candidate.annual_costs.items())
+        ),
+    }
+
+
+def _capture_plan_sequence(plans: Any) -> list[dict[str, Any]]:
+    return [_capture_candidate(plan.candidate_clusters) for plan in plans]
+
+
+def _capture_error(
+    scenario_name: str,
+    error: Exception,
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+) -> dict[str, Any]:
+    return {
+        "error": str(error),
+        "scenario": scenario_name,
+        "model": model_name,
+        "region": region,
+        "service_tier": desires.service_tier,
+    }
+
+
 def capture_costs(
     model_name: str,
     region: str,
@@ -80,31 +120,53 @@ def capture_costs(
         if not cap_plans:
             return {"error": "No capacity plans generated", "scenario": scenario_name}
 
-        cap_plan = cap_plans[0]
-        candidate = cap_plan.candidate_clusters
-
-        # Build cluster details for each cluster
-        cluster_details = []
-        for zonal_cluster in candidate.zonal:
-            cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
-        for regional_cluster in candidate.regional:
-            cluster_details.append(_format_cluster(regional_cluster, "regional"))
-
         result = {
             "scenario": scenario_name,
             "model": model_name,
             "region": region,
             "service_tier": desires.service_tier,
-            "total_annual_cost": float(candidate.total_annual_cost),
-            "clusters": cluster_details,
-            "annual_costs": dict(
-                sorted((k, float(v)) for k, v in candidate.annual_costs.items())
-            ),
         }
-
+        result.update(_capture_candidate(cap_plans[0].candidate_clusters))
         return result
     except (ValueError, KeyError, AttributeError) as e:
-        return {"error": str(e), "scenario": scenario_name}
+        return _capture_error(scenario_name, e, model_name, region, desires)
+
+
+def capture_uncertain(  # pylint: disable=too-many-positional-arguments
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+    extra_args: dict[str, Any] | None = None,
+    scenario_name: str = "",
+    simulations: int = BASELINE_UNCERTAIN_SIMULATIONS,
+    num_results: int = BASELINE_UNCERTAIN_NUM_RESULTS,
+) -> dict[str, Any]:
+    """Capture a compact snapshot from the stochastic planner."""
+    try:
+        cap_plan = planner.plan(
+            model_name=model_name,
+            region=region,
+            desires=desires,
+            simulations=simulations,
+            num_results=num_results,
+            extra_model_arguments=extra_args or {},
+        )
+        return {
+            "scenario": scenario_name,
+            "model": model_name,
+            "region": region,
+            "service_tier": desires.service_tier,
+            "simulations": simulations,
+            "num_results": num_results,
+            "least_regret": _capture_plan_sequence(cap_plan.least_regret),
+            "mean": _capture_plan_sequence(cap_plan.mean),
+            "percentiles": {
+                str(percentile): _capture_plan_sequence(plans)
+                for percentile, plans in sorted(cap_plan.percentiles.items())
+            },
+        }
+    except (ValueError, KeyError, AttributeError) as e:
+        return _capture_error(scenario_name, e, model_name, region, desires)
 
 
 # Define test scenarios for each service
@@ -654,6 +716,17 @@ SCENARIOS: dict[str, dict[str, Any]] = {
     for model, region, desires, extra_args, name in scenarios
 }
 
+UNCERTAIN_SCENARIOS: dict[str, dict[str, Any]] = {
+    name: SCENARIOS[name]
+    for name in (
+        "cassandra_timeseries_ebs",
+        "cassandra_kv_dense_ebs",
+        "cassandra_kv_compact_ebs",
+        "kafka_100mib_throughput",
+        "evcache_large_with_replication",
+        "kv_with_cache",
+    )
+}
 
 if __name__ == "__main__":
     # Capture all scenarios
@@ -669,12 +742,47 @@ if __name__ == "__main__":
             print(f"  Total cost: ${result['total_annual_cost']:,.2f}")
             print(f"  Cost breakdown: {list(result['annual_costs'].keys())}")
 
-    # Save results
-    output_file = Path(__file__).parent / "data" / "baseline_costs.json"
+    uncertain_results = []
+    for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():
+        print(f"Capturing uncertain: {scenario_name}...")
+        result = capture_uncertain(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+        )
+        uncertain_results.append(result)
+        if "error" in result:
+            print(f"  ERROR: {result['error']}")
+        else:
+            print(
+                "  Least regret families: "
+                + ", ".join(
+                    p["clusters"][0]["instance"]
+                    for p in result["least_regret"]
+                    if p["clusters"]
+                )
+            )
+
+    # Save deterministic results
+    output_dir = Path(__file__).parent / "data"
+    output_file = output_dir / "baseline_costs.json"
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2, sort_keys=True)
         f.write("\n")  # Ensure trailing newline for pre-commit
 
+    uncertain_output_file = output_dir / "baseline_uncertain.json"
+    with open(uncertain_output_file, "w", encoding="utf-8") as f:
+        json.dump(uncertain_results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
     print(f"\nResults saved to: {output_file}")
     success_count = len([r for r in results if "error" not in r])
     print(f"Total scenarios captured: {success_count}/{len(results)}")
+    uncertain_success_count = len([r for r in uncertain_results if "error" not in r])
+    print(f"Uncertain results saved to: {uncertain_output_file}")
+    print(
+        f"Total uncertain scenarios captured: "
+        f"{uncertain_success_count}/{len(uncertain_results)}"
+    )

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -102,7 +102,7 @@ def _preserve_existing_costs(
 
 
 def _load_existing_uncertain_results(path: Path) -> dict[str, dict[str, Any]]:
-    if not path.exists():
+    if os.environ.get("SCM_BASELINE_PRESERVE_COSTS", "1") == "0" or not path.exists():
         return {}
     with open(path, encoding="utf-8") as existing_file:
         existing_results = json.load(existing_file)
@@ -117,7 +117,7 @@ def _stabilize_uncertain_results(
     actual_results: list[dict[str, Any]],
     existing_results: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    if os.environ.get("SCM_BASELINE_PRESERVE_COSTS", "1") == "0":
+    if not existing_results:
         return actual_results
     return [
         _preserve_existing_costs(result, existing_results.get(result["scenario"], {}))

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -12,6 +12,7 @@ Usage:
 import json
 from pathlib import Path
 from typing import Any
+from typing import Sequence
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import (
@@ -36,6 +37,57 @@ from service_capacity_modeling.interface import (
 
 BASELINE_UNCERTAIN_SIMULATIONS = 16
 BASELINE_UNCERTAIN_NUM_RESULTS = 3
+
+
+def _deterministic_interval_value(interval: Interval, probability: float) -> float:
+    confidence = min(max(interval.confidence, 0.01), 0.99)
+    low_p = (1 - confidence) / 2.0
+    high_p = 1 - low_p
+
+    if probability <= low_p:
+        span = low_p or 1.0
+        return interval.minimum + (interval.low - interval.minimum) * (
+            probability / span
+        )
+    if probability <= 0.5:
+        span = 0.5 - low_p
+        return interval.low + (interval.mid - interval.low) * (
+            (probability - low_p) / span
+        )
+    if probability <= high_p:
+        span = high_p - 0.5
+        return interval.mid + (interval.high - interval.mid) * (
+            (probability - 0.5) / span
+        )
+
+    span = 1 - high_p or 1.0
+    return interval.high + (interval.maximum - interval.high) * (
+        (probability - high_p) / span
+    )
+
+
+def _deterministic_interval_samples(
+    interval: Interval,
+    name: str,  # pylint: disable=unused-argument
+    count: int,
+) -> Sequence[Interval]:
+    if not interval.can_simulate:
+        return [interval] * count
+    return [
+        certain_float(_deterministic_interval_value(interval, (index + 0.5) / count))
+        for index in range(count)
+    ]
+
+
+def _deterministic_interval_percentile(
+    interval: Interval, percentiles: Sequence[int]
+) -> list[Interval]:
+    if not interval.can_simulate:
+        return [interval] * len(percentiles)
+    return [
+        certain_float(_deterministic_interval_value(interval, percentile / 100))
+        for percentile in percentiles
+    ]
 
 
 def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]:
@@ -150,6 +202,8 @@ def capture_uncertain(  # pylint: disable=too-many-positional-arguments
             simulations=simulations,
             num_results=num_results,
             extra_model_arguments=extra_args or {},
+            interval_sampler=_deterministic_interval_samples,
+            interval_percentile_sampler=_deterministic_interval_percentile,
         )
         return {
             "scenario": scenario_name,

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """
 Capture current cost outputs for regression testing.
 
@@ -18,8 +19,11 @@ Usage:
 import json
 import math
 import os
+from dataclasses import dataclass
+from difflib import unified_diff
+from itertools import islice
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import (
@@ -47,23 +51,81 @@ BASELINE_UNCERTAIN_NUM_RESULTS = 3
 BASELINE_UNCERTAIN_SNAPSHOT_FORMAT = "seeded-scipy-cost-preserve-v1"
 BASELINE_UNCERTAIN_COST_REL_TOLERANCE = 0.01
 BASELINE_UNCERTAIN_COST_ABS_TOLERANCE = 1.0
+COST_KEYS = frozenset(("annual_cost", "total_annual_cost", "instance_cost"))
 BASELINE_UNCERTAIN_SNAPSHOT_NOTE = (
     "Uses the planner's seeded SciPy uncertainty sampling. When regenerating "
-    "an existing snapshot, cost values within 1% or $1 are preserved because "
-    "scipy.optimize distribution fitting can produce tiny output drift across "
-    "CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "an existing snapshot, cost values are serialized to cents and values "
+    "within 1% or $1 are preserved because scipy.optimize distribution fitting "
+    "can produce tiny output drift across CPU/libm builds. Set "
+    "SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
 )
 
 
-def _preserve_existing_cost(actual: float, existing: Any) -> float:
+@dataclass
+class CostPreservationStats:
+    preserved: int = 0
+    exceeded: int = 0
+    max_abs_delta: float = 0.0
+    max_rel_delta: float = 0.0
+    max_delta_path: str = ""
+
+    def record(
+        self, path: str, actual: float, existing: float, preserved: bool
+    ) -> None:
+        abs_delta = abs(actual - existing)
+        rel_delta = abs_delta / max(abs(existing), 1.0)
+        if preserved:
+            self.preserved += 1
+        else:
+            self.exceeded += 1
+        if abs_delta > self.max_abs_delta:
+            self.max_abs_delta = abs_delta
+            self.max_rel_delta = rel_delta
+            self.max_delta_path = path
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (float, int)) and not isinstance(value, bool)
+
+
+def _is_cost_key(key: str) -> bool:
+    return key in COST_KEYS or key == "annual_costs"
+
+
+def _round_cost(value: Any) -> float:
+    return round(float(value), 2)
+
+
+def _round_cost_leaves(value: Any, cost_context: bool = False) -> Any:
+    if _is_number(value) and cost_context:
+        return _round_cost(value)
+    if isinstance(value, list):
+        return [_round_cost_leaves(item, cost_context) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _round_cost_leaves(item, cost_context or _is_cost_key(key))
+            for key, item in value.items()
+        }
+    return value
+
+
+def _preserve_existing_cost(
+    actual: float,
+    existing: Any,
+    path: str,
+    stats: CostPreservationStats,
+) -> float:
     if not isinstance(existing, (float, int)):
         return actual
-    if math.isclose(
+    existing_float = float(existing)
+    preserved = math.isclose(
         actual,
-        float(existing),
+        existing_float,
         rel_tol=BASELINE_UNCERTAIN_COST_REL_TOLERANCE,
         abs_tol=BASELINE_UNCERTAIN_COST_ABS_TOLERANCE,
-    ):
+    )
+    stats.record(path, actual, existing_float, preserved)
+    if preserved:
         return existing
     return actual
 
@@ -71,17 +133,25 @@ def _preserve_existing_cost(actual: float, existing: Any) -> float:
 def _preserve_existing_costs(
     actual: Any,
     existing: Any,
+    stats: CostPreservationStats,
+    path: str = "$",
     cost_context: bool = False,
 ) -> Any:
-    if isinstance(actual, (float, int)) and cost_context:
-        return _preserve_existing_cost(float(actual), existing)
+    if _is_number(actual) and cost_context:
+        return _preserve_existing_cost(float(actual), existing, path, stats)
 
     if isinstance(actual, list) and isinstance(existing, list):
         if len(actual) != len(existing):
             return actual
         return [
-            _preserve_existing_costs(actual_item, existing_item, cost_context)
-            for actual_item, existing_item in zip(actual, existing)
+            _preserve_existing_costs(
+                actual_item,
+                existing_item,
+                stats,
+                f"{path}[{idx}]",
+                cost_context,
+            )
+            for idx, (actual_item, existing_item) in enumerate(zip(actual, existing))
         ]
 
     if isinstance(actual, dict) and isinstance(existing, dict):
@@ -91,9 +161,9 @@ def _preserve_existing_costs(
             key: _preserve_existing_costs(
                 value,
                 existing[key],
-                cost_context
-                or key in ("annual_cost", "total_annual_cost")
-                or key == "annual_costs",
+                stats,
+                f"{path}.{key}",
+                cost_context or _is_cost_key(key),
             )
             for key, value in actual.items()
         }
@@ -116,13 +186,64 @@ def _load_existing_uncertain_results(path: Path) -> dict[str, dict[str, Any]]:
 def _stabilize_uncertain_results(
     actual_results: list[dict[str, Any]],
     existing_results: dict[str, dict[str, Any]],
+    stats: CostPreservationStats,
 ) -> list[dict[str, Any]]:
     if not existing_results:
         return actual_results
     return [
-        _preserve_existing_costs(result, existing_results.get(result["scenario"], {}))
+        _preserve_existing_costs(
+            result,
+            existing_results.get(result["scenario"], {}),
+            stats,
+            f"$.{result['scenario']}",
+        )
         for result in actual_results
     ]
+
+
+def _print_text_diff_preview(old_text: str, new_text: str, path: Path) -> None:
+    diff_lines = unified_diff(
+        old_text.splitlines(),
+        new_text.splitlines(),
+        fromfile=f"{path} before",
+        tofile=f"{path} after",
+        lineterm="",
+    )
+    preview = list(islice(diff_lines, 80))
+    if preview:
+        print("  Diff preview:")
+        for line in preview:
+            print(f"    {line}")
+
+
+def _write_json_snapshot(path: Path, data: Any) -> bool:
+    old_text = path.read_text(encoding="utf-8") if path.exists() else None
+    new_text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+    if old_text == new_text:
+        return False
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"Snapshot changed: {path}")
+    if old_text is not None:
+        _print_text_diff_preview(old_text, new_text, path)
+    return True
+
+
+def _print_cost_preservation_summary(stats: CostPreservationStats) -> None:
+    if stats.preserved == 0 and stats.exceeded == 0:
+        return
+    print(
+        "Uncertain cost preservation: "
+        f"preserved {stats.preserved} cost value(s), "
+        f"left {stats.exceeded} beyond tolerance."
+    )
+    if stats.max_delta_path:
+        print(
+            "  Largest regenerated cost drift: "
+            f"${stats.max_abs_delta:,.2f} ({stats.max_rel_delta:.4%}) at "
+            f"{stats.max_delta_path}"
+        )
 
 
 def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]:
@@ -145,9 +266,11 @@ def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]
 
     # Add cluster_params if present (e.g., replica_count, partitions_per_node)
     if cluster.cluster_params:
-        info["cluster_params"] = dict(sorted(cluster.cluster_params.items()))
+        info["cluster_params"] = _round_cost_leaves(
+            dict(sorted(cluster.cluster_params.items()))
+        )
 
-    return info
+    return cast(dict[str, Any], _round_cost_leaves(info))
 
 
 def _capture_candidate(candidate: Any) -> dict[str, Any]:
@@ -158,13 +281,18 @@ def _capture_candidate(candidate: Any) -> dict[str, Any]:
     for regional_cluster in candidate.regional:
         cluster_details.append(_format_cluster(regional_cluster, "regional"))
 
-    return {
-        "total_annual_cost": float(candidate.total_annual_cost),
-        "clusters": cluster_details,
-        "annual_costs": dict(
-            sorted((k, float(v)) for k, v in candidate.annual_costs.items())
+    return cast(
+        dict[str, Any],
+        _round_cost_leaves(
+            {
+                "total_annual_cost": float(candidate.total_annual_cost),
+                "clusters": cluster_details,
+                "annual_costs": dict(
+                    sorted((k, float(v)) for k, v in candidate.annual_costs.items())
+                ),
+            },
         ),
-    }
+    )
 
 
 def _capture_plan_sequence(plans: Any) -> list[dict[str, Any]]:
@@ -832,9 +960,10 @@ if __name__ == "__main__":
     uncertain_results = []
     print(
         "\nCapturing uncertain baselines with seeded SciPy sampling. "
-        "Existing snapshot costs within 1% or $1 are preserved while writing "
-        "to avoid platform-specific noise from scipy.optimize distribution "
-        "fitting. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+        "Costs are serialized to cents; existing snapshot costs within 1% "
+        "or $1 are preserved while writing to avoid platform-specific noise "
+        "from scipy.optimize distribution fitting. Set "
+        "SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
     )
     for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():
         print(f"Capturing uncertain: {scenario_name}...")
@@ -861,18 +990,17 @@ if __name__ == "__main__":
     # Save regression snapshots
     output_dir = Path(__file__).parent / "data"
     output_file = output_dir / "baseline_costs.json"
-    with open(output_file, "w", encoding="utf-8") as f:
-        json.dump(results, f, indent=2, sort_keys=True)
-        f.write("\n")  # Ensure trailing newline for pre-commit
+    _write_json_snapshot(output_file, results)
 
     uncertain_output_file = output_dir / "baseline_uncertain.json"
+    cost_preservation_stats = CostPreservationStats()
     uncertain_results = _stabilize_uncertain_results(
         uncertain_results,
         _load_existing_uncertain_results(uncertain_output_file),
+        cost_preservation_stats,
     )
-    with open(uncertain_output_file, "w", encoding="utf-8") as f:
-        json.dump(uncertain_results, f, indent=2, sort_keys=True)
-        f.write("\n")
+    _print_cost_preservation_summary(cost_preservation_stats)
+    _write_json_snapshot(uncertain_output_file, uncertain_results)
 
     print(f"\nResults saved to: {output_file}")
     success_count = len([r for r in results if "error" not in r])

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -7,10 +7,11 @@ This script runs capacity planning for various scenarios and captures
 the cost breakdowns to use as baselines for regression tests.
 
 Uncertain baselines intentionally exercise the planner's seeded SciPy sampling
-path. SciPy's numeric fitting can converge to slightly different beta/gamma
-parameters on different CPU/libm builds, so the writer preserves existing cost
-values when a regenerated value is within the documented drift tolerance. The
-snapshot should catch recommendation shape changes, not tiny platform noise.
+path. SciPy's numeric fitting can converge to different beta/gamma parameters
+across SciPy releases and CPU/libm builds, so test environments pin the
+supported SciPy range and the writer preserves existing cost values when a
+regenerated value is within the documented drift tolerance. The snapshot should
+catch recommendation shape changes, not tiny platform noise.
 
 Usage:
     python -m service_capacity_modeling.tools.capture_baseline_costs
@@ -56,7 +57,9 @@ BASELINE_UNCERTAIN_SNAPSHOT_NOTE = (
     "Uses the planner's seeded SciPy uncertainty sampling. When regenerating "
     "an existing snapshot, cost values are serialized to cents and values "
     "within 1% or $1 are preserved because scipy.optimize distribution fitting "
-    "can produce tiny output drift across CPU/libm builds. Set "
+    "can produce output drift across SciPy releases and CPU/libm builds. The "
+    "test environments pin the supported SciPy range; widen it only with an "
+    "intentional baseline refresh. Set "
     "SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
 )
 
@@ -962,7 +965,8 @@ if __name__ == "__main__":
         "\nCapturing uncertain baselines with seeded SciPy sampling. "
         "Costs are serialized to cents; existing snapshot costs within 1% "
         "or $1 are preserved while writing to avoid platform-specific noise "
-        "from scipy.optimize distribution fitting. Set "
+        "from scipy.optimize distribution fitting. The tested SciPy range is "
+        "pinned to avoid optimizer-version churn. Set "
         "SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
     )
     for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -5,14 +5,21 @@ Capture current cost outputs for regression testing.
 This script runs capacity planning for various scenarios and captures
 the cost breakdowns to use as baselines for regression tests.
 
+Uncertain baselines intentionally exercise the planner's seeded SciPy sampling
+path. SciPy's numeric fitting can converge to slightly different beta/gamma
+parameters on different CPU/libm builds, so the writer preserves existing cost
+values when a regenerated value is within the documented drift tolerance. The
+snapshot should catch recommendation shape changes, not tiny platform noise.
+
 Usage:
     python -m service_capacity_modeling.tools.capture_baseline_costs
 """
 
 import json
+import math
+import os
 from pathlib import Path
 from typing import Any
-from typing import Sequence
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import (
@@ -37,56 +44,84 @@ from service_capacity_modeling.interface import (
 
 BASELINE_UNCERTAIN_SIMULATIONS = 16
 BASELINE_UNCERTAIN_NUM_RESULTS = 3
+BASELINE_UNCERTAIN_SNAPSHOT_FORMAT = "seeded-scipy-cost-preserve-v1"
+BASELINE_UNCERTAIN_COST_REL_TOLERANCE = 0.01
+BASELINE_UNCERTAIN_COST_ABS_TOLERANCE = 1.0
+BASELINE_UNCERTAIN_SNAPSHOT_NOTE = (
+    "Uses the planner's seeded SciPy uncertainty sampling. When regenerating "
+    "an existing snapshot, cost values within 1% or $1 are preserved because "
+    "scipy.optimize distribution fitting can produce tiny output drift across "
+    "CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+)
 
 
-def _deterministic_interval_value(interval: Interval, probability: float) -> float:
-    confidence = min(max(interval.confidence, 0.01), 0.99)
-    low_p = (1 - confidence) / 2.0
-    high_p = 1 - low_p
-
-    if probability <= low_p:
-        span = low_p or 1.0
-        return interval.minimum + (interval.low - interval.minimum) * (
-            probability / span
-        )
-    if probability <= 0.5:
-        span = 0.5 - low_p
-        return interval.low + (interval.mid - interval.low) * (
-            (probability - low_p) / span
-        )
-    if probability <= high_p:
-        span = high_p - 0.5
-        return interval.mid + (interval.high - interval.mid) * (
-            (probability - 0.5) / span
-        )
-
-    span = 1 - high_p or 1.0
-    return interval.high + (interval.maximum - interval.high) * (
-        (probability - high_p) / span
-    )
+def _preserve_existing_cost(actual: float, existing: Any) -> float:
+    if not isinstance(existing, (float, int)):
+        return actual
+    if math.isclose(
+        actual,
+        float(existing),
+        rel_tol=BASELINE_UNCERTAIN_COST_REL_TOLERANCE,
+        abs_tol=BASELINE_UNCERTAIN_COST_ABS_TOLERANCE,
+    ):
+        return existing
+    return actual
 
 
-def _deterministic_interval_samples(
-    interval: Interval,
-    name: str,  # pylint: disable=unused-argument
-    count: int,
-) -> Sequence[Interval]:
-    if not interval.can_simulate:
-        return [interval] * count
+def _preserve_existing_costs(
+    actual: Any,
+    existing: Any,
+    cost_context: bool = False,
+) -> Any:
+    if isinstance(actual, (float, int)) and cost_context:
+        return _preserve_existing_cost(float(actual), existing)
+
+    if isinstance(actual, list) and isinstance(existing, list):
+        if len(actual) != len(existing):
+            return actual
+        return [
+            _preserve_existing_costs(actual_item, existing_item, cost_context)
+            for actual_item, existing_item in zip(actual, existing)
+        ]
+
+    if isinstance(actual, dict) and isinstance(existing, dict):
+        if set(actual) != set(existing):
+            return actual
+        return {
+            key: _preserve_existing_costs(
+                value,
+                existing[key],
+                cost_context
+                or key in ("annual_cost", "total_annual_cost")
+                or key == "annual_costs",
+            )
+            for key, value in actual.items()
+        }
+
+    return actual
+
+
+def _load_existing_uncertain_results(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as existing_file:
+        existing_results = json.load(existing_file)
+    return {
+        result["scenario"]: result
+        for result in existing_results
+        if isinstance(result, dict) and "scenario" in result
+    }
+
+
+def _stabilize_uncertain_results(
+    actual_results: list[dict[str, Any]],
+    existing_results: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if os.environ.get("SCM_BASELINE_PRESERVE_COSTS", "1") == "0":
+        return actual_results
     return [
-        certain_float(_deterministic_interval_value(interval, (index + 0.5) / count))
-        for index in range(count)
-    ]
-
-
-def _deterministic_interval_percentile(
-    interval: Interval, percentiles: Sequence[int]
-) -> list[Interval]:
-    if not interval.can_simulate:
-        return [interval] * len(percentiles)
-    return [
-        certain_float(_deterministic_interval_value(interval, percentile / 100))
-        for percentile in percentiles
+        _preserve_existing_costs(result, existing_results.get(result["scenario"], {}))
+        for result in actual_results
     ]
 
 
@@ -202,8 +237,6 @@ def capture_uncertain(  # pylint: disable=too-many-positional-arguments
             simulations=simulations,
             num_results=num_results,
             extra_model_arguments=extra_args or {},
-            interval_sampler=_deterministic_interval_samples,
-            interval_percentile_sampler=_deterministic_interval_percentile,
         )
         return {
             "scenario": scenario_name,
@@ -212,6 +245,8 @@ def capture_uncertain(  # pylint: disable=too-many-positional-arguments
             "service_tier": desires.service_tier,
             "simulations": simulations,
             "num_results": num_results,
+            "snapshot_format": BASELINE_UNCERTAIN_SNAPSHOT_FORMAT,
+            "snapshot_note": BASELINE_UNCERTAIN_SNAPSHOT_NOTE,
             "least_regret": _capture_plan_sequence(cap_plan.least_regret),
             "mean": _capture_plan_sequence(cap_plan.mean),
             "percentiles": {
@@ -770,11 +805,12 @@ SCENARIOS: dict[str, dict[str, Any]] = {
 UNCERTAIN_SCENARIOS: dict[str, dict[str, Any]] = {
     name: SCENARIOS[name]
     for name in (
+        # Keep this list intentionally small: the pre-commit hook regenerates
+        # it on every run. These cover state-heavy Cassandra, Kafka throughput,
+        # and composed KV/cache uncertainty without turning the hook into a
+        # broad stochastic benchmark.
         "cassandra_timeseries_ebs",
-        "cassandra_kv_dense_ebs",
-        "cassandra_kv_compact_ebs",
         "kafka_100mib_throughput",
-        "evcache_large_with_replication",
         "kv_with_cache",
     )
 }
@@ -794,6 +830,12 @@ if __name__ == "__main__":
             print(f"  Cost breakdown: {list(result['annual_costs'].keys())}")
 
     uncertain_results = []
+    print(
+        "\nCapturing uncertain baselines with seeded SciPy sampling. "
+        "Existing snapshot costs within 1% or $1 are preserved while writing "
+        "to avoid platform-specific noise from scipy.optimize distribution "
+        "fitting. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    )
     for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():
         print(f"Capturing uncertain: {scenario_name}...")
         result = capture_uncertain(
@@ -816,7 +858,7 @@ if __name__ == "__main__":
                 )
             )
 
-    # Save deterministic results
+    # Save regression snapshots
     output_dir = Path(__file__).parent / "data"
     output_file = output_dir / "baseline_costs.json"
     with open(output_file, "w", encoding="utf-8") as f:
@@ -824,6 +866,10 @@ if __name__ == "__main__":
         f.write("\n")  # Ensure trailing newline for pre-commit
 
     uncertain_output_file = output_dir / "baseline_uncertain.json"
+    uncertain_results = _stabilize_uncertain_results(
+        uncertain_results,
+        _load_existing_uncertain_results(uncertain_output_file),
+    )
     with open(uncertain_output_file, "w", encoding="utf-8") as f:
         json.dump(uncertain_results, f, indent=2, sort_keys=True)
         f.write("\n")

--- a/service_capacity_modeling/tools/capture_baseline_costs.py
+++ b/service_capacity_modeling/tools/capture_baseline_costs.py
@@ -34,6 +34,9 @@ from service_capacity_modeling.interface import (
     QueryPattern,
 )
 
+BASELINE_UNCERTAIN_SIMULATIONS = 16
+BASELINE_UNCERTAIN_NUM_RESULTS = 3
+
 
 def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]:
     """Format a single cluster's details."""
@@ -60,6 +63,43 @@ def _format_cluster(cluster: ClusterCapacity, deployment: str) -> dict[str, Any]
     return info
 
 
+def _capture_candidate(candidate: Any) -> dict[str, Any]:
+    """Serialize a candidate cluster set into a stable regression snapshot."""
+    cluster_details = []
+    for zonal_cluster in candidate.zonal:
+        cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
+    for regional_cluster in candidate.regional:
+        cluster_details.append(_format_cluster(regional_cluster, "regional"))
+
+    return {
+        "total_annual_cost": float(candidate.total_annual_cost),
+        "clusters": cluster_details,
+        "annual_costs": dict(
+            sorted((k, float(v)) for k, v in candidate.annual_costs.items())
+        ),
+    }
+
+
+def _capture_plan_sequence(plans: Any) -> list[dict[str, Any]]:
+    return [_capture_candidate(plan.candidate_clusters) for plan in plans]
+
+
+def _capture_error(
+    scenario_name: str,
+    error: Exception,
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+) -> dict[str, Any]:
+    return {
+        "error": str(error),
+        "scenario": scenario_name,
+        "model": model_name,
+        "region": region,
+        "service_tier": desires.service_tier,
+    }
+
+
 def capture_costs(
     model_name: str,
     region: str,
@@ -80,31 +120,53 @@ def capture_costs(
         if not cap_plans:
             return {"error": "No capacity plans generated", "scenario": scenario_name}
 
-        cap_plan = cap_plans[0]
-        candidate = cap_plan.candidate_clusters
-
-        # Build cluster details for each cluster
-        cluster_details = []
-        for zonal_cluster in candidate.zonal:
-            cluster_details.append(_format_cluster(zonal_cluster, "zonal"))
-        for regional_cluster in candidate.regional:
-            cluster_details.append(_format_cluster(regional_cluster, "regional"))
-
         result = {
             "scenario": scenario_name,
             "model": model_name,
             "region": region,
             "service_tier": desires.service_tier,
-            "total_annual_cost": float(candidate.total_annual_cost),
-            "clusters": cluster_details,
-            "annual_costs": dict(
-                sorted((k, float(v)) for k, v in candidate.annual_costs.items())
-            ),
         }
-
+        result.update(_capture_candidate(cap_plans[0].candidate_clusters))
         return result
     except (ValueError, KeyError, AttributeError) as e:
-        return {"error": str(e), "scenario": scenario_name}
+        return _capture_error(scenario_name, e, model_name, region, desires)
+
+
+def capture_uncertain(  # pylint: disable=too-many-positional-arguments
+    model_name: str,
+    region: str,
+    desires: CapacityDesires,
+    extra_args: dict[str, Any] | None = None,
+    scenario_name: str = "",
+    simulations: int = BASELINE_UNCERTAIN_SIMULATIONS,
+    num_results: int = BASELINE_UNCERTAIN_NUM_RESULTS,
+) -> dict[str, Any]:
+    """Capture a compact snapshot from the stochastic planner."""
+    try:
+        cap_plan = planner.plan(
+            model_name=model_name,
+            region=region,
+            desires=desires,
+            simulations=simulations,
+            num_results=num_results,
+            extra_model_arguments=extra_args or {},
+        )
+        return {
+            "scenario": scenario_name,
+            "model": model_name,
+            "region": region,
+            "service_tier": desires.service_tier,
+            "simulations": simulations,
+            "num_results": num_results,
+            "least_regret": _capture_plan_sequence(cap_plan.least_regret),
+            "mean": _capture_plan_sequence(cap_plan.mean),
+            "percentiles": {
+                str(percentile): _capture_plan_sequence(plans)
+                for percentile, plans in sorted(cap_plan.percentiles.items())
+            },
+        }
+    except (ValueError, KeyError, AttributeError) as e:
+        return _capture_error(scenario_name, e, model_name, region, desires)
 
 
 # Define test scenarios for each service
@@ -651,6 +713,17 @@ SCENARIOS: dict[str, dict[str, Any]] = {
     for model, region, desires, extra_args, name in scenarios
 }
 
+UNCERTAIN_SCENARIOS: dict[str, dict[str, Any]] = {
+    name: SCENARIOS[name]
+    for name in (
+        "cassandra_timeseries_ebs",
+        "cassandra_kv_dense_ebs",
+        "cassandra_kv_compact_ebs",
+        "kafka_100mib_throughput",
+        "evcache_large_with_replication",
+        "kv_with_cache",
+    )
+}
 
 if __name__ == "__main__":
     # Capture all scenarios
@@ -666,12 +739,47 @@ if __name__ == "__main__":
             print(f"  Total cost: ${result['total_annual_cost']:,.2f}")
             print(f"  Cost breakdown: {list(result['annual_costs'].keys())}")
 
-    # Save results
-    output_file = Path(__file__).parent / "data" / "baseline_costs.json"
+    uncertain_results = []
+    for scenario_name, scenario in UNCERTAIN_SCENARIOS.items():
+        print(f"Capturing uncertain: {scenario_name}...")
+        result = capture_uncertain(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+        )
+        uncertain_results.append(result)
+        if "error" in result:
+            print(f"  ERROR: {result['error']}")
+        else:
+            print(
+                "  Least regret families: "
+                + ", ".join(
+                    p["clusters"][0]["instance"]
+                    for p in result["least_regret"]
+                    if p["clusters"]
+                )
+            )
+
+    # Save deterministic results
+    output_dir = Path(__file__).parent / "data"
+    output_file = output_dir / "baseline_costs.json"
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2, sort_keys=True)
         f.write("\n")  # Ensure trailing newline for pre-commit
 
+    uncertain_output_file = output_dir / "baseline_uncertain.json"
+    with open(uncertain_output_file, "w", encoding="utf-8") as f:
+        json.dump(uncertain_results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
     print(f"\nResults saved to: {output_file}")
     success_count = len([r for r in results if "error" not in r])
     print(f"Total scenarios captured: {success_count}/{len(results)}")
+    uncertain_success_count = len([r for r in uncertain_results if "error" not in r])
+    print(f"Uncertain results saved to: {uncertain_output_file}")
+    print(
+        f"Total uncertain scenarios captured: "
+        f"{uncertain_success_count}/{len(uncertain_results)}"
+    )

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -45,11 +45,11 @@
   },
   {
     "annual_costs": {
-      "aurora-cluster.regional-clusters": 3447.644
+      "aurora-cluster.regional-clusters": 3447.64
     },
     "clusters": [
       {
-        "annual_cost": 1862.3139999999999,
+        "annual_cost": 1862.31,
         "attached_drives": [
           "aurora : 60GB"
         ],
@@ -70,11 +70,11 @@
   },
   {
     "annual_costs": {
-      "aurora-cluster.regional-clusters": 2204.4579999999996
+      "aurora-cluster.regional-clusters": 2204.46
     },
     "clusters": [
       {
-        "annual_cost": 2204.4579999999996,
+        "annual_cost": 2204.46,
         "attached_drives": [
           "aurora : 240GB"
         ],
@@ -95,9 +95,9 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 35857.951769805906,
-      "cassandra.net.inter.region": 148476.65107995272,
-      "cassandra.net.intra.region": 445429.95323985815,
+      "cassandra.backup.s3-standard": 35857.95,
+      "cassandra.net.inter.region": 148476.65,
+      "cassandra.net.intra.region": 445429.95,
       "cassandra.zonal-clusters": 29508.0
     },
     "clusters": [
@@ -191,9 +191,9 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 179339.15084902954,
-      "cassandra.net.inter.region": 742383.2553997636,
-      "cassandra.net.intra.region": 1113574.8830996454,
+      "cassandra.backup.s3-standard": 179339.15,
+      "cassandra.net.inter.region": 742383.26,
+      "cassandra.net.intra.region": 1113574.88,
       "cassandra.zonal-clusters": 69031.92
     },
     "clusters": [
@@ -296,9 +296,9 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 11239.234730941773,
-      "cassandra.net.inter.region": 44542.995323985815,
-      "cassandra.net.intra.region": 133628.98597195745,
+      "cassandra.backup.s3-standard": 11239.23,
+      "cassandra.net.inter.region": 44543.0,
+      "cassandra.net.intra.region": 133628.99,
       "cassandra.zonal-clusters": 61656.0
     },
     "clusters": [
@@ -392,10 +392,10 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 353277.0672346802,
-      "cassandra.net.inter.region": 1009641.2273436785,
-      "cassandra.net.intra.region": 3028923.6820310354,
-      "cassandra.zonal-clusters": 1478336.6400000001
+      "cassandra.backup.s3-standard": 353277.07,
+      "cassandra.net.inter.region": 1009641.23,
+      "cassandra.net.intra.region": 3028923.68,
+      "cassandra.zonal-clusters": 1478336.64
     },
     "clusters": [
       {
@@ -506,9 +506,9 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 37961.555153961184,
-      "cassandra.net.inter.region": 29695.330215990543,
-      "cassandra.net.intra.region": 89085.99064797163,
+      "cassandra.backup.s3-standard": 37961.56,
+      "cassandra.net.inter.region": 29695.33,
+      "cassandra.net.intra.region": 89085.99,
       "cassandra.zonal-clusters": 459327.36
     },
     "clusters": [
@@ -611,9 +611,9 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 15626.777788490295,
-      "cassandra.net.inter.region": 7423.832553997636,
-      "cassandra.net.intra.region": 22271.497661992908,
+      "cassandra.backup.s3-standard": 15626.78,
+      "cassandra.net.inter.region": 7423.83,
+      "cassandra.net.intra.region": 22271.5,
       "cassandra.zonal-clusters": 202015.68
     },
     "clusters": [
@@ -716,11 +716,11 @@
   },
   {
     "annual_costs": {
-      "kafka.zonal-clusters": 13494.059999999998
+      "kafka.zonal-clusters": 13494.06
     },
     "clusters": [
       {
-        "annual_cost": 4498.0199999999995,
+        "annual_cost": 4498.02,
         "cluster_params": {
           "effective_disk_per_node_gib": 1164,
           "kafka.copies": 2,
@@ -741,7 +741,7 @@
         "instance": "i3en.large"
       },
       {
-        "annual_cost": 4498.0199999999995,
+        "annual_cost": 4498.02,
         "cluster_params": {
           "effective_disk_per_node_gib": 1164,
           "kafka.copies": 2,
@@ -762,7 +762,7 @@
         "instance": "i3en.large"
       },
       {
-        "annual_cost": 4498.0199999999995,
+        "annual_cost": 4498.02,
         "cluster_params": {
           "effective_disk_per_node_gib": 1164,
           "kafka.copies": 2,
@@ -791,11 +791,11 @@
   },
   {
     "annual_costs": {
-      "kafka.zonal-clusters": 98036.72999999998
+      "kafka.zonal-clusters": 98036.73
     },
     "clusters": [
       {
-        "annual_cost": 32678.909999999996,
+        "annual_cost": 32678.91,
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
           "kafka.copies": 2,
@@ -816,7 +816,7 @@
         "instance": "i4i.xlarge"
       },
       {
-        "annual_cost": 32678.909999999996,
+        "annual_cost": 32678.91,
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
           "kafka.copies": 2,
@@ -837,7 +837,7 @@
         "instance": "i4i.xlarge"
       },
       {
-        "annual_cost": 32678.909999999996,
+        "annual_cost": 32678.91,
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
           "kafka.copies": 2,
@@ -950,7 +950,7 @@
   },
   {
     "annual_costs": {
-      "evcache.zonal-clusters": 31265.129999999997
+      "evcache.zonal-clusters": 31265.13
     },
     "clusters": [
       {
@@ -1025,13 +1025,13 @@
   },
   {
     "annual_costs": {
-      "evcache.net.inter.region": 30095.029830932617,
-      "evcache.net.intra.region": 45142.544746398926,
-      "evcache.zonal-clusters": 100204.26000000001
+      "evcache.net.inter.region": 30095.03,
+      "evcache.net.intra.region": 45142.54,
+      "evcache.zonal-clusters": 100204.26
     },
     "clusters": [
       {
-        "annual_cost": 50102.130000000005,
+        "annual_cost": 50102.13,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "evcache.copies": 2,
@@ -1052,7 +1052,7 @@
         "instance": "c6id.2xlarge"
       },
       {
-        "annual_cost": 50102.130000000005,
+        "annual_cost": 50102.13,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "evcache.copies": 2,
@@ -1081,16 +1081,16 @@
   },
   {
     "annual_costs": {
-      "cassandra.backup.s3-standard": 18088.365884902953,
-      "cassandra.net.inter.region": 74238.32553997636,
-      "cassandra.net.intra.region": 222714.97661992908,
-      "cassandra.zonal-clusters": 44260.020000000004,
+      "cassandra.backup.s3-standard": 18088.37,
+      "cassandra.net.inter.region": 74238.33,
+      "cassandra.net.intra.region": 222714.98,
+      "cassandra.zonal-clusters": 44260.02,
       "evcache.zonal-clusters": 150306.39,
       "nflx-java-app.regional-clusters": 108432.87
     },
     "clusters": [
       {
-        "annual_cost": 50102.130000000005,
+        "annual_cost": 50102.13,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "evcache.copies": 3,
@@ -1111,7 +1111,7 @@
         "instance": "c6id.2xlarge"
       },
       {
-        "annual_cost": 50102.130000000005,
+        "annual_cost": 50102.13,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "evcache.copies": 3,
@@ -1132,7 +1132,7 @@
         "instance": "c6id.2xlarge"
       },
       {
-        "annual_cost": 50102.130000000005,
+        "annual_cost": 50102.13,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "evcache.copies": 3,

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -1,0 +1,3723 @@
+[
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 557646.2308536151,
+          "cassandra.net.inter.region": 1820976.4156216348,
+          "cassandra.net.intra.region": 5462929.246864905,
+          "cassandra.zonal-clusters": 1752128.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 584042.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 9593680.53
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1772864.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          },
+          {
+            "annual_cost": 590954.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 6164706.62
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1978688.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          },
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          },
+          {
+            "annual_cost": 659562.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 6370530.62
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1703744.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 567914.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 4195926.6
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1909568.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 636522.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 4401750.6
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1765952.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            },
+            {
+              "annual_cost": 588650.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 5980921.69
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1971776.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            },
+            {
+              "annual_cost": 657258.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 6186745.69
+        }
+      ],
+      "95": []
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_timeseries_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 40171.45723201238,
+          "cassandra.net.inter.region": 37083.08698451795,
+          "cassandra.net.intra.region": 111249.26095355384,
+          "cassandra.zonal-clusters": 618240.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 206080.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          }
+        ],
+        "total_annual_cost": 806743.81
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 627456.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          },
+          {
+            "annual_cost": 209152.0,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.2xlarge"
+          }
+        ],
+        "total_annual_cost": 784198.88
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 645183.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          },
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          },
+          {
+            "annual_cost": 215061.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 29.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r4.2xlarge"
+          }
+        ],
+        "total_annual_cost": 801926.24
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 440896.32
+          },
+          "clusters": [
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 146965.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 527674.02
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 492352.32
+          },
+          "clusters": [
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 164117.44,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 579130.02
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 620544.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 206848.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            }
+          ],
+          "total_annual_cost": 767357.1
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 638271.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 212757.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            }
+          ],
+          "total_annual_cost": 785084.46
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 682752.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            },
+            {
+              "annual_cost": 227584.0,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.2xlarge"
+            }
+          ],
+          "total_annual_cost": 959428.42
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 700479.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            },
+            {
+              "annual_cost": 233493.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 29.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r4.2xlarge"
+            }
+          ],
+          "total_annual_cost": 977155.78
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_dense_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18190.38781758377,
+          "cassandra.net.inter.region": 13948.159874031106,
+          "cassandra.net.intra.region": 41844.47962209332,
+          "cassandra.zonal-clusters": 265791.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 88597.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 339774.39
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 270399.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 90133.12,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 315721.47
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 279168.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 93056.0,
+            "attached_drives": [
+              "gp3 : 500GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          }
+        ],
+        "total_annual_cost": 324490.11
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 192800.16
+          },
+          "clusters": [
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            },
+            {
+              "annual_cost": 64266.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 219767.5
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 218528.16
+          },
+          "clusters": [
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            },
+            {
+              "annual_cost": 72842.72,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 245495.5
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 265791.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 88597.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 308607.15
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 274560.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 91520.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 317375.79
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 298047.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 99349.12,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 374269.38
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 306816.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 102272.0,
+              "attached_drives": [
+                "gp3 : 500GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 383038.02
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_compact_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 4705.9800000000005
+        },
+        "clusters": [
+          {
+            "annual_cost": 1568.66,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 1568.66,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 1568.66,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 4705.98
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 13494.059999999998
+        },
+        "clusters": [
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          }
+        ],
+        "total_annual_cost": 13494.06
+      },
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 18529.98
+        },
+        "clusters": [
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 18529.98
+      }
+    ],
+    "model": "org.netflix.kafka",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 12711.93
+          },
+          "clusters": [
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            }
+          ],
+          "total_annual_cost": 12711.93
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 17953.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 17953.98
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 15743.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            }
+          ],
+          "total_annual_cost": 15743.07
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 26473.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 26473.98
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kafka_100mib_throughput",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 110481.62000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 55240.810000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 43,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 55240.810000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 43,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 185719.19
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 100204.26000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 175441.83
+      },
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 113098.35999999999
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          }
+        ],
+        "total_annual_cost": 188335.93
+      }
+    ],
+    "model": "org.netflix.evcache",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 127287.4
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 140181.5
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 169256.37
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 182150.47
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 238343.12
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 251237.22
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "evcache_large_with_replication",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 23576.876923782347,
+          "cassandra.net.inter.region": 95634.01081040502,
+          "cassandra.net.intra.region": 286902.03243121505,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 165722.43000000002,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 55240.810000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 43,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 55240.810000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 43,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 55240.810000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 43,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 724528.24
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 618040.95
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 46243.979999999996,
+          "evcache.zonal-clusters": 169647.53999999998,
+          "nflx-java-app.regional-clusters": 110355.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              }
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 110355.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 105,
+            "deployment": "regional",
+            "instance": "c6a.2xlarge"
+          }
+        ],
+        "total_annual_cost": 641288.19
+      }
+    ],
+    "model": "org.netflix.key-value",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 104049.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 104049.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 99,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 537454.21
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 105150.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 105150.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 75,
+              "deployment": "regional",
+              "instance": "c7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 564586.36
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 108432.87
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 108432.87,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 39,
+              "deployment": "regional",
+              "instance": "c7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 593889.53
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 110355.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 110355.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 105,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 621842.81
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 116270.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 116270.07,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 21,
+              "deployment": "regional",
+              "instance": "c7a.8xlarge"
+            }
+          ],
+          "total_annual_cost": 721578.8
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 46243.979999999996,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 116661.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                }
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 116661.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 111,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 743294.84
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kv_with_cache",
+    "service_tier": 1,
+    "simulations": 16
+  }
+]

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -3,14 +3,14 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 405481.92149738566,
-          "cassandra.net.inter.region": 1190853.6608613518,
-          "cassandra.net.intra.region": 3572560.9825840555,
-          "cassandra.zonal-clusters": 1457600.6400000001
+          "cassandra.backup.s3-standard": 275074.04119547654,
+          "cassandra.net.inter.region": 706033.6823295535,
+          "cassandra.net.intra.region": 2118101.0469886605,
+          "cassandra.zonal-clusters": 1441472.6400000001
         },
         "clusters": [
           {
-            "annual_cost": 485866.88,
+            "annual_cost": 480490.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -31,7 +31,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 5,
+                "memory": 4,
                 "min_count": 64,
                 "network": 3
               },
@@ -43,7 +43,7 @@
             "instance": "m7a.2xlarge"
           },
           {
-            "annual_cost": 485866.88,
+            "annual_cost": 480490.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -64,7 +64,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 5,
+                "memory": 4,
                 "min_count": 64,
                 "network": 3
               },
@@ -76,7 +76,7 @@
             "instance": "m7a.2xlarge"
           },
           {
-            "annual_cost": 485866.88,
+            "annual_cost": 480490.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -97,7 +97,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 5,
+                "memory": 4,
                 "min_count": 64,
                 "network": 3
               },
@@ -109,7 +109,7 @@
             "instance": "m7a.2xlarge"
           }
         ],
-        "total_annual_cost": 6626497.2
+        "total_annual_cost": 4540681.41
       }
     ],
     "mean": [
@@ -340,14 +340,14 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 233074.95698382912,
-            "cassandra.net.inter.region": 564776.7496072351,
-            "cassandra.net.intra.region": 1694330.248821705,
-            "cassandra.zonal-clusters": 1409216.6400000001
+            "cassandra.backup.s3-standard": 204334.39471810914,
+            "cassandra.net.inter.region": 434489.7957120319,
+            "cassandra.net.intra.region": 1303469.3871360957,
+            "cassandra.zonal-clusters": 1400000.6400000001
           },
           "clusters": [
             {
-              "annual_cost": 469738.88,
+              "annual_cost": 466666.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -380,7 +380,7 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 469738.88,
+              "annual_cost": 466666.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -413,7 +413,7 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 469738.88,
+              "annual_cost": 466666.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -446,18 +446,18 @@
               "instance": "m7a.2xlarge"
             }
           ],
-          "total_annual_cost": 3901398.6
+          "total_annual_cost": 3342294.22
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 233074.95698382912,
-            "cassandra.net.inter.region": 564776.7496072351,
-            "cassandra.net.intra.region": 1694330.248821705,
-            "cassandra.zonal-clusters": 1495743.3599999999
+            "cassandra.backup.s3-standard": 204334.39471810914,
+            "cassandra.net.inter.region": 434489.7957120319,
+            "cassandra.net.intra.region": 1303469.3871360957,
+            "cassandra.zonal-clusters": 1486527.3599999999
           },
           "clusters": [
             {
-              "annual_cost": 498581.12,
+              "annual_cost": 495509.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -490,7 +490,7 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 498581.12,
+              "annual_cost": 495509.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -523,7 +523,7 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 498581.12,
+              "annual_cost": 495509.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -556,25 +556,25 @@
               "instance": "c6a.4xlarge"
             }
           ],
-          "total_annual_cost": 3987925.32
+          "total_annual_cost": 3428820.94
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 342869.5600652009,
-            "cassandra.net.inter.region": 968024.8720495387,
-            "cassandra.net.intra.region": 2904074.616148616,
-            "cassandra.zonal-clusters": 1471424.6400000001
+            "cassandra.backup.s3-standard": 353277.0672346802,
+            "cassandra.net.inter.region": 1009641.2273436785,
+            "cassandra.net.intra.region": 3028923.6820310354,
+            "cassandra.zonal-clusters": 1478336.6400000001
           },
           "clusters": [
             {
-              "annual_cost": 490474.88,
+              "annual_cost": 492778.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -590,7 +590,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
@@ -602,12 +602,12 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 490474.88,
+              "annual_cost": 492778.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -623,7 +623,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
@@ -635,12 +635,12 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 490474.88,
+              "annual_cost": 492778.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -656,7 +656,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
@@ -668,23 +668,23 @@
               "instance": "m7a.2xlarge"
             }
           ],
-          "total_annual_cost": 5686393.69
+          "total_annual_cost": 5870178.62
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 342869.5600652009,
-            "cassandra.net.inter.region": 968024.8720495387,
-            "cassandra.net.intra.region": 2904074.616148616,
-            "cassandra.zonal-clusters": 1557951.3599999999
+            "cassandra.backup.s3-standard": 353277.0672346802,
+            "cassandra.net.inter.region": 1009641.2273436785,
+            "cassandra.net.intra.region": 3028923.6820310354,
+            "cassandra.zonal-clusters": 1564863.3599999999
           },
           "clusters": [
             {
-              "annual_cost": 519317.12,
+              "annual_cost": 521621.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -700,7 +700,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 2
                 },
@@ -712,12 +712,12 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 519317.12,
+              "annual_cost": 521621.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -733,7 +733,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 2
                 },
@@ -745,12 +745,12 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 519317.12,
+              "annual_cost": 521621.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compaction.min_threshold": 8,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -766,7 +766,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 6,
+                  "memory": 2,
                   "min_count": 64,
                   "network": 2
                 },
@@ -778,7 +778,7 @@
               "instance": "c6a.4xlarge"
             }
           ],
-          "total_annual_cost": 5772920.41
+          "total_annual_cost": 5956705.34
         }
       ],
       "95": []
@@ -792,14 +792,14 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 36792.02039092105,
-          "cassandra.net.inter.region": 23088.6091673735,
-          "cassandra.net.intra.region": 69265.82750212049,
-          "cassandra.zonal-clusters": 450111.36
+          "cassandra.backup.s3-standard": 34425.12512873268,
+          "cassandra.net.inter.region": 23182.06784570285,
+          "cassandra.net.intra.region": 69546.20353710855,
+          "cassandra.zonal-clusters": 438591.36
         },
         "clusters": [
           {
-            "annual_cost": 150037.12,
+            "annual_cost": 146197.12,
             "attached_drives": [
               "gp3 : 1200GB"
             ],
@@ -829,7 +829,7 @@
             "instance": "r6a.xlarge"
           },
           {
-            "annual_cost": 150037.12,
+            "annual_cost": 146197.12,
             "attached_drives": [
               "gp3 : 1200GB"
             ],
@@ -859,7 +859,7 @@
             "instance": "r6a.xlarge"
           },
           {
-            "annual_cost": 150037.12,
+            "annual_cost": 146197.12,
             "attached_drives": [
               "gp3 : 1200GB"
             ],
@@ -889,7 +889,7 @@
             "instance": "r6a.xlarge"
           }
         ],
-        "total_annual_cost": 579257.82
+        "total_annual_cost": 565744.76
       }
     ],
     "mean": [
@@ -1111,14 +1111,14 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 29891.97447918801,
-            "cassandra.net.inter.region": 14221.43169220214,
-            "cassandra.net.intra.region": 42664.295076606424,
-            "cassandra.zonal-clusters": 410943.36
+            "cassandra.backup.s3-standard": 28221.18184465027,
+            "cassandra.net.inter.region": 12779.111638589173,
+            "cassandra.net.intra.region": 38337.33491576752,
+            "cassandra.zonal-clusters": 404031.36
           },
           "clusters": [
             {
-              "annual_cost": 136981.12,
+              "annual_cost": 134677.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1148,7 +1148,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 136981.12,
+              "annual_cost": 134677.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1178,7 +1178,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 136981.12,
+              "annual_cost": 134677.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1208,18 +1208,18 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 497721.06
+          "total_annual_cost": 483368.99
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 29891.97447918801,
-            "cassandra.net.inter.region": 14221.43169220214,
-            "cassandra.net.intra.region": 42664.295076606424,
-            "cassandra.zonal-clusters": 405055.68
+            "cassandra.backup.s3-standard": 28221.18184465027,
+            "cassandra.net.inter.region": 12779.111638589173,
+            "cassandra.net.intra.region": 38337.33491576752,
+            "cassandra.zonal-clusters": 396991.68
           },
           "clusters": [
             {
-              "annual_cost": 135018.56,
+              "annual_cost": 132330.56,
               "attached_drives": [
                 "gp3 : 2400GB"
               ],
@@ -1252,7 +1252,7 @@
               "instance": "m6a.2xlarge"
             },
             {
-              "annual_cost": 135018.56,
+              "annual_cost": 132330.56,
               "attached_drives": [
                 "gp3 : 2400GB"
               ],
@@ -1285,7 +1285,7 @@
               "instance": "m6a.2xlarge"
             },
             {
-              "annual_cost": 135018.56,
+              "annual_cost": 132330.56,
               "attached_drives": [
                 "gp3 : 2400GB"
               ],
@@ -1318,20 +1318,20 @@
               "instance": "m6a.2xlarge"
             }
           ],
-          "total_annual_cost": 491833.38
+          "total_annual_cost": 476329.31
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 37283.805858515196,
-            "cassandra.net.inter.region": 27382.32302858961,
-            "cassandra.net.intra.region": 82146.96908576883,
-            "cassandra.zonal-clusters": 452415.36
+            "cassandra.backup.s3-standard": 37961.555153961184,
+            "cassandra.net.inter.region": 29695.330215990543,
+            "cassandra.net.intra.region": 89085.99064797163,
+            "cassandra.zonal-clusters": 459327.36
           },
           "clusters": [
             {
-              "annual_cost": 150805.12,
+              "annual_cost": 153109.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1361,7 +1361,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 150805.12,
+              "annual_cost": 153109.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1391,7 +1391,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 150805.12,
+              "annual_cost": 153109.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1421,18 +1421,18 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 599228.46
+          "total_annual_cost": 616070.24
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 37283.805858515196,
-            "cassandra.net.inter.region": 27382.32302858961,
-            "cassandra.net.intra.region": 82146.96908576883,
-            "cassandra.zonal-clusters": 503871.36
+            "cassandra.backup.s3-standard": 37961.555153961184,
+            "cassandra.net.inter.region": 29695.330215990543,
+            "cassandra.net.intra.region": 89085.99064797163,
+            "cassandra.zonal-clusters": 510783.36
           },
           "clusters": [
             {
-              "annual_cost": 167957.12,
+              "annual_cost": 170261.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1465,7 +1465,7 @@
               "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 167957.12,
+              "annual_cost": 170261.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1498,7 +1498,7 @@
               "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 167957.12,
+              "annual_cost": 170261.12,
               "attached_drives": [
                 "gp3 : 1200GB"
               ],
@@ -1531,222 +1531,10 @@
               "instance": "r7a.xlarge"
             }
           ],
-          "total_annual_cost": 650684.46
+          "total_annual_cost": 667526.24
         }
       ],
-      "95": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 49127.45948389998,
-            "cassandra.net.inter.region": 56887.240607232845,
-            "cassandra.net.intra.region": 170661.72182169853,
-            "cassandra.zonal-clusters": 514623.36
-          },
-          "clusters": [
-            {
-              "annual_cost": 171541.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 171541.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 171541.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 791299.78
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 49127.45948389998,
-            "cassandra.net.inter.region": 56887.240607232845,
-            "cassandra.net.intra.region": 170661.72182169853,
-            "cassandra.zonal-clusters": 566079.36
-          },
-          "clusters": [
-            {
-              "annual_cost": 188693.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 188693.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 188693.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            }
-          ],
-          "total_annual_cost": 842755.78
-        }
-      ]
+      "95": []
     },
     "region": "us-east-1",
     "scenario": "cassandra_kv_dense_ebs",
@@ -1757,14 +1545,14 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 17072.467730616816,
-          "cassandra.net.inter.region": 9318.776756651392,
-          "cassandra.net.intra.region": 27956.330269954175,
-          "cassandra.zonal-clusters": 198559.68
+          "cassandra.backup.s3-standard": 15368.224603275776,
+          "cassandra.net.inter.region": 7084.674175374913,
+          "cassandra.net.intra.region": 21254.02252612474,
+          "cassandra.zonal-clusters": 199711.68
         },
         "clusters": [
           {
-            "annual_cost": 66186.56,
+            "annual_cost": 66570.56,
             "attached_drives": [
               "gp3 : 900GB"
             ],
@@ -1794,7 +1582,7 @@
             "instance": "r6a.xlarge"
           },
           {
-            "annual_cost": 66186.56,
+            "annual_cost": 66570.56,
             "attached_drives": [
               "gp3 : 900GB"
             ],
@@ -1824,7 +1612,7 @@
             "instance": "r6a.xlarge"
           },
           {
-            "annual_cost": 66186.56,
+            "annual_cost": 66570.56,
             "attached_drives": [
               "gp3 : 900GB"
             ],
@@ -1854,7 +1642,7 @@
             "instance": "r6a.xlarge"
           }
         ],
-        "total_annual_cost": 252907.25
+        "total_annual_cost": 243418.6
       }
     ],
     "mean": [
@@ -2076,14 +1864,14 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 12745.904619797004,
-            "cassandra.net.inter.region": 3555.357923050535,
-            "cassandra.net.intra.region": 10666.073769151606,
-            "cassandra.zonal-clusters": 177823.68
+            "cassandra.backup.s3-standard": 12064.362461162567,
+            "cassandra.net.inter.region": 3194.777909647293,
+            "cassandra.net.intra.region": 9584.33372894188,
+            "cassandra.zonal-clusters": 174367.68
           },
           "clusters": [
             {
-              "annual_cost": 59274.56,
+              "annual_cost": 58122.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2113,7 +1901,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 59274.56,
+              "annual_cost": 58122.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2143,7 +1931,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 59274.56,
+              "annual_cost": 58122.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2173,18 +1961,18 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 204791.02
+          "total_annual_cost": 199211.15
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 12745.904619797004,
-            "cassandra.net.inter.region": 3555.357923050535,
-            "cassandra.net.intra.region": 10666.073769151606,
-            "cassandra.zonal-clusters": 168015.84
+            "cassandra.backup.s3-standard": 12064.362461162567,
+            "cassandra.net.inter.region": 3194.777909647293,
+            "cassandra.net.intra.region": 9584.33372894188,
+            "cassandra.zonal-clusters": 163983.84
           },
           "clusters": [
             {
-              "annual_cost": 56005.28,
+              "annual_cost": 54661.28,
               "attached_drives": [
                 "gp3 : 1800GB"
               ],
@@ -2217,7 +2005,7 @@
               "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 56005.28,
+              "annual_cost": 54661.28,
               "attached_drives": [
                 "gp3 : 1800GB"
               ],
@@ -2250,7 +2038,7 @@
               "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 56005.28,
+              "annual_cost": 54661.28,
               "attached_drives": [
                 "gp3 : 1800GB"
               ],
@@ -2283,20 +2071,20 @@
               "instance": "r7a.xlarge"
             }
           ],
-          "total_annual_cost": 194983.18
+          "total_annual_cost": 188827.31
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 15433.4634646288,
-            "cassandra.net.inter.region": 6845.580757147402,
-            "cassandra.net.intra.region": 20536.742271442206,
-            "cassandra.zonal-clusters": 198559.68
+            "cassandra.backup.s3-standard": 15626.777788490295,
+            "cassandra.net.inter.region": 7423.832553997636,
+            "cassandra.net.intra.region": 22271.497661992908,
+            "cassandra.zonal-clusters": 202015.68
           },
           "clusters": [
             {
-              "annual_cost": 66186.56,
+              "annual_cost": 67338.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2326,7 +2114,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 66186.56,
+              "annual_cost": 67338.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2356,7 +2144,7 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 66186.56,
+              "annual_cost": 67338.56,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2386,18 +2174,18 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 241375.47
+          "total_annual_cost": 247337.79
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 15433.4634646288,
-            "cassandra.net.inter.region": 6845.580757147402,
-            "cassandra.net.intra.region": 20536.742271442206,
-            "cassandra.zonal-clusters": 202944.0
+            "cassandra.backup.s3-standard": 15626.777788490295,
+            "cassandra.net.inter.region": 7423.832553997636,
+            "cassandra.net.intra.region": 22271.497661992908,
+            "cassandra.zonal-clusters": 206400.0
           },
           "clusters": [
             {
-              "annual_cost": 67648.0,
+              "annual_cost": 68800.0,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2430,7 +2218,7 @@
               "instance": "r5.xlarge"
             },
             {
-              "annual_cost": 67648.0,
+              "annual_cost": 68800.0,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2463,7 +2251,7 @@
               "instance": "r5.xlarge"
             },
             {
-              "annual_cost": 67648.0,
+              "annual_cost": 68800.0,
               "attached_drives": [
                 "gp3 : 900GB"
               ],
@@ -2496,222 +2284,10 @@
               "instance": "r5.xlarge"
             }
           ],
-          "total_annual_cost": 245759.79
+          "total_annual_cost": 251722.11
         }
       ],
-      "95": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 19334.777870974995,
-            "cassandra.net.inter.region": 14221.810151808211,
-            "cassandra.net.intra.region": 42665.430455424634,
-            "cassandra.zonal-clusters": 229663.68
-          },
-          "clusters": [
-            {
-              "annual_cost": 76554.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 76554.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 76554.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 305885.7
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 19334.777870974995,
-            "cassandra.net.inter.region": 14221.810151808211,
-            "cassandra.net.intra.region": 42665.430455424634,
-            "cassandra.zonal-clusters": 234048.0
-          },
-          "clusters": [
-            {
-              "annual_cost": 78016.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            },
-            {
-              "annual_cost": 78016.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            },
-            {
-              "annual_cost": 78016.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            }
-          ],
-          "total_annual_cost": 310270.02
-        }
-      ]
+      "95": []
     },
     "region": "us-east-1",
     "scenario": "cassandra_kv_compact_ebs",
@@ -2722,74 +2298,74 @@
     "least_regret": [
       {
         "annual_costs": {
-          "kafka.zonal-clusters": 13494.059999999998
+          "kafka.zonal-clusters": 13497.03
         },
         "clusters": [
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4499.01,
             "cluster_params": {
-              "effective_disk_per_node_gib": 1164,
+              "effective_disk_per_node_gib": 2328,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 6,
-                "cpu": 2,
-                "disk_capacity": 6,
+                "cluster_size": 3,
+                "cpu": 3,
+                "disk_capacity": 3,
                 "disk_iops": 0,
-                "memory": 6,
-                "min_count": 6,
+                "memory": 2,
+                "min_count": 3,
                 "network": 1
               },
-              "resource_bottleneck": "disk_capacity"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "kafka",
-            "count": 6,
+            "count": 3,
             "deployment": "zonal",
-            "instance": "i3en.large"
+            "instance": "i3en.xlarge"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4499.01,
             "cluster_params": {
-              "effective_disk_per_node_gib": 1164,
+              "effective_disk_per_node_gib": 2328,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 6,
-                "cpu": 2,
-                "disk_capacity": 6,
+                "cluster_size": 3,
+                "cpu": 3,
+                "disk_capacity": 3,
                 "disk_iops": 0,
-                "memory": 6,
-                "min_count": 6,
+                "memory": 2,
+                "min_count": 3,
                 "network": 1
               },
-              "resource_bottleneck": "disk_capacity"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "kafka",
-            "count": 6,
+            "count": 3,
             "deployment": "zonal",
-            "instance": "i3en.large"
+            "instance": "i3en.xlarge"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4499.01,
             "cluster_params": {
-              "effective_disk_per_node_gib": 1164,
+              "effective_disk_per_node_gib": 2328,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 6,
-                "cpu": 2,
-                "disk_capacity": 6,
+                "cluster_size": 3,
+                "cpu": 3,
+                "disk_capacity": 3,
                 "disk_iops": 0,
-                "memory": 6,
-                "min_count": 6,
+                "memory": 2,
+                "min_count": 3,
                 "network": 1
               },
-              "resource_bottleneck": "disk_capacity"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "kafka",
-            "count": 6,
+            "count": 3,
             "deployment": "zonal",
-            "instance": "i3en.large"
+            "instance": "i3en.xlarge"
           }
         ],
-        "total_annual_cost": 13494.06
+        "total_annual_cost": 13497.03
       }
     ],
     "mean": [
@@ -2964,7 +2540,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
                   "network": 1
                 },
@@ -2985,7 +2561,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
                   "network": 1
                 },
@@ -3006,7 +2582,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
                   "network": 1
                 },
@@ -3022,157 +2598,157 @@
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 12711.93
+            "kafka.zonal-clusters": 10404.0
           },
           "clusters": [
             {
-              "annual_cost": 4237.31,
+              "annual_cost": 3468.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 436,
+                "effective_disk_per_node_gib": 885,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
+                  "cluster_size": 3,
                   "cpu": 1,
-                  "disk_capacity": 7,
+                  "disk_capacity": 3,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 7,
+                  "memory": 2,
+                  "min_count": 3,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 3,
               "deployment": "zonal",
-              "instance": "i4i.large"
+              "instance": "i3.xlarge"
             },
             {
-              "annual_cost": 4237.31,
+              "annual_cost": 3468.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 436,
+                "effective_disk_per_node_gib": 885,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
+                  "cluster_size": 3,
                   "cpu": 1,
-                  "disk_capacity": 7,
+                  "disk_capacity": 3,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 7,
+                  "memory": 2,
+                  "min_count": 3,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 3,
               "deployment": "zonal",
-              "instance": "i4i.large"
+              "instance": "i3.xlarge"
             },
             {
-              "annual_cost": 4237.31,
+              "annual_cost": 3468.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 436,
+                "effective_disk_per_node_gib": 885,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
+                  "cluster_size": 3,
                   "cpu": 1,
-                  "disk_capacity": 7,
+                  "disk_capacity": 3,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 7,
+                  "memory": 2,
+                  "min_count": 3,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 3,
               "deployment": "zonal",
-              "instance": "i4i.large"
+              "instance": "i3.xlarge"
             }
           ],
-          "total_annual_cost": 12711.93
+          "total_annual_cost": 10404.0
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 8998.02
+            "kafka.zonal-clusters": 13494.059999999998
           },
           "clusters": [
             {
-              "annual_cost": 2999.34,
+              "annual_cost": 4498.0199999999995,
               "cluster_params": {
-                "effective_disk_per_node_gib": 2328,
+                "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 2,
+                  "cluster_size": 6,
+                  "cpu": 4,
+                  "disk_capacity": 5,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 2,
+                  "memory": 6,
+                  "min_count": 5,
                   "network": 1
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 2,
+              "count": 6,
               "deployment": "zonal",
-              "instance": "i3en.xlarge"
+              "instance": "i3en.large"
             },
             {
-              "annual_cost": 2999.34,
+              "annual_cost": 4498.0199999999995,
               "cluster_params": {
-                "effective_disk_per_node_gib": 2328,
+                "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 2,
+                  "cluster_size": 6,
+                  "cpu": 4,
+                  "disk_capacity": 5,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 2,
+                  "memory": 6,
+                  "min_count": 5,
                   "network": 1
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 2,
+              "count": 6,
               "deployment": "zonal",
-              "instance": "i3en.xlarge"
+              "instance": "i3en.large"
             },
             {
-              "annual_cost": 2999.34,
+              "annual_cost": 4498.0199999999995,
               "cluster_params": {
-                "effective_disk_per_node_gib": 2328,
+                "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 2,
+                  "cluster_size": 6,
+                  "cpu": 4,
+                  "disk_capacity": 5,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 2,
+                  "memory": 6,
+                  "min_count": 5,
                   "network": 1
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 2,
+              "count": 6,
               "deployment": "zonal",
-              "instance": "i3en.xlarge"
+              "instance": "i3en.large"
             }
           ],
-          "total_annual_cost": 8998.02
+          "total_annual_cost": 13494.06
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 17953.98
+            "kafka.zonal-clusters": 18529.98
           },
           "clusters": [
             {
-              "annual_cost": 5984.66,
+              "annual_cost": 6176.66,
               "attached_drives": [
-                "gp3 : 2300GB"
+                "gp3 : 2400GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3194,9 +2770,9 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 5984.66,
+              "annual_cost": 6176.66,
               "attached_drives": [
-                "gp3 : 2300GB"
+                "gp3 : 2400GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3218,9 +2794,9 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 5984.66,
+              "annual_cost": 6176.66,
               "attached_drives": [
-                "gp3 : 2300GB"
+                "gp3 : 2400GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3242,90 +2818,90 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 17953.98
+          "total_annual_cost": 18529.98
         }
       ],
       "95": [
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 15743.07
+            "kafka.zonal-clusters": 26988.119999999995
           },
           "clusters": [
             {
-              "annual_cost": 5247.69,
+              "annual_cost": 8996.039999999999,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
-                  "cpu": 7,
-                  "disk_capacity": 6,
+                  "cluster_size": 12,
+                  "cpu": 11,
+                  "disk_capacity": 8,
                   "disk_iops": 0,
-                  "memory": 7,
-                  "min_count": 6,
-                  "network": 1
+                  "memory": 12,
+                  "min_count": 8,
+                  "network": 2
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 12,
               "deployment": "zonal",
               "instance": "i3en.large"
             },
             {
-              "annual_cost": 5247.69,
+              "annual_cost": 8996.039999999999,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
-                  "cpu": 7,
-                  "disk_capacity": 6,
+                  "cluster_size": 12,
+                  "cpu": 11,
+                  "disk_capacity": 8,
                   "disk_iops": 0,
-                  "memory": 7,
-                  "min_count": 6,
-                  "network": 1
+                  "memory": 12,
+                  "min_count": 8,
+                  "network": 2
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 12,
               "deployment": "zonal",
               "instance": "i3en.large"
             },
             {
-              "annual_cost": 5247.69,
+              "annual_cost": 8996.039999999999,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 7,
-                  "cpu": 7,
-                  "disk_capacity": 6,
+                  "cluster_size": 12,
+                  "cpu": 11,
+                  "disk_capacity": 8,
                   "disk_iops": 0,
-                  "memory": 7,
-                  "min_count": 6,
-                  "network": 1
+                  "memory": 12,
+                  "min_count": 8,
+                  "network": 2
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "memory"
               },
               "cluster_type": "kafka",
-              "count": 7,
+              "count": 12,
               "deployment": "zonal",
               "instance": "i3en.large"
             }
           ],
-          "total_annual_cost": 15743.07
+          "total_annual_cost": 26988.12
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 26473.98
+            "kafka.zonal-clusters": 34248.0
           },
           "clusters": [
             {
-              "annual_cost": 8824.66,
+              "annual_cost": 11416.0,
               "attached_drives": [
-                "gp3 : 3500GB"
+                "gp3 : 4500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3344,12 +2920,12 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r7a.xlarge"
+              "instance": "m6i.2xlarge"
             },
             {
-              "annual_cost": 8824.66,
+              "annual_cost": 11416.0,
               "attached_drives": [
-                "gp3 : 3500GB"
+                "gp3 : 4500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3368,12 +2944,12 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r7a.xlarge"
+              "instance": "m6i.2xlarge"
             },
             {
-              "annual_cost": 8824.66,
+              "annual_cost": 11416.0,
               "attached_drives": [
-                "gp3 : 3500GB"
+                "gp3 : 4500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -3392,10 +2968,10 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r7a.xlarge"
+              "instance": "m6i.2xlarge"
             }
           ],
-          "total_annual_cost": 26473.98
+          "total_annual_cost": 34248.0
         }
       ]
     },
@@ -3408,55 +2984,55 @@
     "least_regret": [
       {
         "annual_costs": {
-          "evcache.net.inter.region": 32829.10006879722,
-          "evcache.net.intra.region": 49243.65010319583,
-          "evcache.zonal-clusters": 100204.26000000001
+          "evcache.net.inter.region": 43954.583042546314,
+          "evcache.net.intra.region": 65931.87456381947,
+          "evcache.zonal-clusters": 107898.0
         },
         "clusters": [
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 53949.0,
             "cluster_params": {
-              "effective_disk_per_node_gib": 441,
+              "effective_disk_per_node_gib": 885,
               "evcache.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
+                "cluster_size": 21,
+                "cpu": 20,
+                "disk_capacity": 1,
+                "disk_iops": 21,
                 "memory": 1,
-                "min_count": 2,
-                "network": 1
+                "min_count": 1,
+                "network": 20
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_iops"
             },
             "cluster_type": "evcache",
-            "count": 39,
+            "count": 21,
             "deployment": "zonal",
-            "instance": "c6id.2xlarge"
+            "instance": "c6id.4xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 53949.0,
             "cluster_params": {
-              "effective_disk_per_node_gib": 441,
+              "effective_disk_per_node_gib": 885,
               "evcache.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
+                "cluster_size": 21,
+                "cpu": 20,
+                "disk_capacity": 1,
+                "disk_iops": 21,
                 "memory": 1,
-                "min_count": 2,
-                "network": 1
+                "min_count": 1,
+                "network": 20
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_iops"
             },
             "cluster_type": "evcache",
-            "count": 39,
+            "count": 21,
             "deployment": "zonal",
-            "instance": "c6id.2xlarge"
+            "instance": "c6id.4xlarge"
           }
         ],
-        "total_annual_cost": 182277.01
+        "total_annual_cost": 217784.46
       }
     ],
     "mean": [
@@ -3571,8 +3147,8 @@
       "5": [
         {
           "annual_costs": {
-            "evcache.net.inter.region": 10833.257924090358,
-            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.net.inter.region": 5147.834050027946,
+            "evcache.net.intra.region": 7721.75107504192,
             "evcache.zonal-clusters": 100204.26000000001
           },
           "clusters": [
@@ -3619,12 +3195,12 @@
               "instance": "c6id.2xlarge"
             }
           ],
-          "total_annual_cost": 127287.4
+          "total_annual_cost": 113073.85
         },
         {
           "annual_costs": {
-            "evcache.net.inter.region": 10833.257924090358,
-            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.net.inter.region": 5147.834050027946,
+            "evcache.net.intra.region": 7721.75107504192,
             "evcache.zonal-clusters": 113098.35999999999
           },
           "clusters": [
@@ -3671,14 +3247,14 @@
               "instance": "c5d.2xlarge"
             }
           ],
-          "total_annual_cost": 140181.5
+          "total_annual_cost": 125967.95
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "evcache.net.inter.region": 27620.842314355657,
-            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.net.inter.region": 30095.029830932617,
+            "evcache.net.intra.region": 45142.544746398926,
             "evcache.zonal-clusters": 100204.26000000001
           },
           "clusters": [
@@ -3725,12 +3301,12 @@
               "instance": "c6id.2xlarge"
             }
           ],
-          "total_annual_cost": 169256.37
+          "total_annual_cost": 175441.83
         },
         {
           "annual_costs": {
-            "evcache.net.inter.region": 27620.842314355657,
-            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.net.inter.region": 30095.029830932617,
+            "evcache.net.intra.region": 45142.544746398926,
             "evcache.zonal-clusters": 113098.35999999999
           },
           "clusters": [
@@ -3743,7 +3319,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 2,
+                  "disk_iops": 3,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -3764,7 +3340,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 2,
+                  "disk_iops": 3,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -3777,113 +3353,113 @@
               "instance": "c5d.2xlarge"
             }
           ],
-          "total_annual_cost": 182150.47
+          "total_annual_cost": 188335.93
         }
       ],
       "95": [
         {
           "annual_costs": {
-            "evcache.net.inter.region": 55255.54215255931,
-            "evcache.net.intra.region": 82883.31322883896,
-            "evcache.zonal-clusters": 100204.26000000001
+            "evcache.net.inter.region": 58606.1107233951,
+            "evcache.net.intra.region": 87909.16608509264,
+            "evcache.zonal-clusters": 215796.0
           },
           "clusters": [
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 107898.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 441,
+                "effective_disk_per_node_gib": 885,
                 "evcache.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 4,
+                  "cluster_size": 42,
+                  "cpu": 20,
+                  "disk_capacity": 1,
+                  "disk_iops": 42,
                   "memory": 1,
-                  "min_count": 2,
-                  "network": 4
+                  "min_count": 1,
+                  "network": 40
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 39,
+              "count": 42,
               "deployment": "zonal",
-              "instance": "c6id.2xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 107898.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 441,
+                "effective_disk_per_node_gib": 885,
                 "evcache.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 4,
+                  "cluster_size": 42,
+                  "cpu": 20,
+                  "disk_capacity": 1,
+                  "disk_iops": 42,
                   "memory": 1,
-                  "min_count": 2,
-                  "network": 4
+                  "min_count": 1,
+                  "network": 40
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 39,
+              "count": 42,
               "deployment": "zonal",
-              "instance": "c6id.2xlarge"
+              "instance": "c6id.4xlarge"
             }
           ],
-          "total_annual_cost": 238343.12
+          "total_annual_cost": 362311.28
         },
         {
           "annual_costs": {
-            "evcache.net.inter.region": 55255.54215255931,
-            "evcache.net.intra.region": 82883.31322883896,
-            "evcache.zonal-clusters": 113098.35999999999
+            "evcache.net.inter.region": 58606.1107233951,
+            "evcache.net.intra.region": 87909.16608509264,
+            "evcache.zonal-clusters": 261074.44
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 130537.22,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 221,
                 "evcache.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
+                  "cluster_size": 167,
+                  "cpu": 78,
                   "disk_capacity": 3,
-                  "disk_iops": 6,
-                  "memory": 2,
+                  "disk_iops": 167,
+                  "memory": 1,
                   "min_count": 3,
-                  "network": 5
+                  "network": 160
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 167,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "m6id.xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 130537.22,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 221,
                 "evcache.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
+                  "cluster_size": 167,
+                  "cpu": 78,
                   "disk_capacity": 3,
-                  "disk_iops": 6,
-                  "memory": 2,
+                  "disk_iops": 167,
+                  "memory": 1,
                   "min_count": 3,
-                  "network": 5
+                  "network": 160
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 167,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "m6id.xlarge"
             }
           ],
-          "total_annual_cost": 251237.22
+          "total_annual_cost": 407589.72
         }
       ]
     },
@@ -3896,9 +3472,185 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 19184.434642913817,
-          "cassandra.net.inter.region": 78646.77717536688,
-          "cassandra.net.intra.region": 235940.33152610064,
+          "cassandra.backup.s3-standard": 17836.397382980347,
+          "cassandra.net.inter.region": 73180.29714748263,
+          "cassandra.net.intra.region": 219540.8914424479,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 161847.0,
+          "nflx-java-app.regional-clusters": 111150.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 53949.0,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 885,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 21,
+                "cpu": 20,
+                "disk_capacity": 1,
+                "disk_iops": 21,
+                "memory": 1,
+                "min_count": 1,
+                "network": 20
+              },
+              "resource_bottleneck": "disk_iops"
+            },
+            "cluster_type": "evcache",
+            "count": 21,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 53949.0,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 885,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 21,
+                "cpu": 20,
+                "disk_capacity": 1,
+                "disk_iops": 21,
+                "memory": 1,
+                "min_count": 1,
+                "network": 20
+              },
+              "resource_bottleneck": "disk_iops"
+            },
+            "cluster_type": "evcache",
+            "count": 21,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 53949.0,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 885,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 21,
+                "cpu": 20,
+                "disk_capacity": 1,
+                "disk_iops": 21,
+                "memory": 1,
+                "min_count": 1,
+                "network": 20
+              },
+              "resource_bottleneck": "disk_iops"
+            },
+            "cluster_type": "evcache",
+            "count": 21,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 111150.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 9,
+            "deployment": "regional",
+            "instance": "c6a.24xlarge"
+          }
+        ],
+        "total_annual_cost": 627814.61
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 21121.733657867433,
+          "cassandra.net.inter.region": 86875.88689476252,
+          "cassandra.net.intra.region": 260627.66068428755,
           "cassandra.zonal-clusters": 44260.020000000004,
           "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 108432.87
@@ -3913,10 +3665,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -3934,10 +3686,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -3955,10 +3707,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -3988,7 +3740,7 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
@@ -4018,7 +3770,7 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
@@ -4048,7 +3800,7 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
@@ -4068,16 +3820,16 @@
             "instance": "c7a.4xlarge"
           }
         ],
-        "total_annual_cost": 636770.82
+        "total_annual_cost": 671624.56
       },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 18441.540387680056,
-          "cassandra.net.inter.region": 75766.5887735784,
-          "cassandra.net.intra.region": 227299.76632073522,
-          "cassandra.zonal-clusters": 44260.020000000004,
+          "cassandra.backup.s3-standard": 23155.87767324829,
+          "cassandra.net.inter.region": 95340.11403471231,
+          "cassandra.net.intra.region": 286020.34210413694,
+          "cassandra.zonal-clusters": 46243.979999999996,
           "evcache.zonal-clusters": 150306.39,
-          "nflx-java-app.regional-clusters": 105994.83
+          "nflx-java-app.regional-clusters": 108432.87
         },
         "clusters": [
           {
@@ -4089,10 +3841,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -4110,10 +3862,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -4131,10 +3883,10 @@
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 3,
+                "disk_iops": 1,
                 "memory": 1,
                 "min_count": 2,
-                "network": 3
+                "network": 1
               },
               "resource_bottleneck": "cpu"
             },
@@ -4144,7 +3896,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 15414.66,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
@@ -4153,7 +3905,7 @@
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
+              "effective_disk_per_node_gib": 2654,
               "rank_penalties": {
                 "large_instance": 0.1
               },
@@ -4164,17 +3916,17 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
             "count": 2,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.12xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 15414.66,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
@@ -4183,7 +3935,7 @@
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
+              "effective_disk_per_node_gib": 2654,
               "rank_penalties": {
                 "large_instance": 0.1
               },
@@ -4194,17 +3946,17 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
             "count": 2,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.12xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 15414.66,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
@@ -4213,7 +3965,7 @@
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
+              "effective_disk_per_node_gib": 2654,
               "rank_penalties": {
                 "large_instance": 0.1
               },
@@ -4224,194 +3976,27 @@
                 "disk_iops": 0,
                 "memory": 1,
                 "min_count": 2,
-                "network": 1
+                "network": 2
               },
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
             "count": 2,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.12xlarge"
           },
           {
-            "annual_cost": 105994.83,
+            "annual_cost": 108432.87,
             "attached_drives": [
               "gp2 : 20GB"
             ],
             "cluster_type": "dgwkv",
-            "count": 51,
+            "count": 39,
             "deployment": "regional",
-            "instance": "c6a.4xlarge"
+            "instance": "c7a.4xlarge"
           }
         ],
-        "total_annual_cost": 622069.14
-      },
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 16085.217869522095,
-          "cassandra.net.inter.region": 65774.09840002656,
-          "cassandra.net.intra.region": 197322.29520007968,
-          "cassandra.zonal-clusters": 30828.0,
-          "evcache.zonal-clusters": 150306.39,
-          "nflx-java-app.regional-clusters": 111150.0
-        },
-        "clusters": [
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 2,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 2,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 2,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 10276.0,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 885,
-              "required_nodes_by_type": {
-                "cluster_size": 4,
-                "cpu": 4,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 4,
-            "deployment": "zonal",
-            "instance": "c6id.4xlarge"
-          },
-          {
-            "annual_cost": 10276.0,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 885,
-              "required_nodes_by_type": {
-                "cluster_size": 4,
-                "cpu": 4,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 4,
-            "deployment": "zonal",
-            "instance": "c6id.4xlarge"
-          },
-          {
-            "annual_cost": 10276.0,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 885,
-              "required_nodes_by_type": {
-                "cluster_size": 4,
-                "cpu": 4,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 4,
-            "deployment": "zonal",
-            "instance": "c6id.4xlarge"
-          },
-          {
-            "annual_cost": 111150.0,
-            "attached_drives": [
-              "gp2 : 20GB"
-            ],
-            "cluster_type": "dgwkv",
-            "count": 9,
-            "deployment": "regional",
-            "instance": "c6a.24xlarge"
-          }
-        ],
-        "total_annual_cost": 571466.0
+        "total_annual_cost": 709499.57
       }
     ],
     "mean": [
@@ -4774,12 +4359,12 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 14567.10685798645,
-            "cassandra.net.inter.region": 59425.92804506421,
-            "cassandra.net.intra.region": 178277.78413519263,
-            "cassandra.zonal-clusters": 30828.0,
+            "cassandra.backup.s3-standard": 14497.313357345582,
+            "cassandra.net.inter.region": 59073.25191423297,
+            "cassandra.net.intra.region": 177219.7557426989,
+            "cassandra.zonal-clusters": 29508.0,
             "evcache.zonal-clusters": 150306.39,
-            "nflx-java-app.regional-clusters": 104049.0
+            "nflx-java-app.regional-clusters": 99299.01
           },
           "clusters": [
             {
@@ -4846,6 +4431,173 @@
               "instance": "c6id.2xlarge"
             },
             {
+              "annual_cost": 9836.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 373,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 3,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 4,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c5d.4xlarge"
+            },
+            {
+              "annual_cost": 9836.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 373,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 3,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 4,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c5d.4xlarge"
+            },
+            {
+              "annual_cost": 9836.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 373,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 3,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 4,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c5d.4xlarge"
+            },
+            {
+              "annual_cost": 99299.01,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 3,
+              "deployment": "regional",
+              "instance": "c7a.48xlarge"
+            }
+          ],
+          "total_annual_cost": 529903.72
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14497.313357345582,
+            "cassandra.net.inter.region": 59073.25191423297,
+            "cassandra.net.intra.region": 177219.7557426989,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 104049.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
               "annual_cost": 10276.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
@@ -4859,7 +4611,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 1,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4886,7 +4638,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 1,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4913,7 +4665,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 1,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4937,183 +4689,16 @@
               "instance": "c6a.2xlarge"
             }
           ],
-          "total_annual_cost": 537454.21
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 14567.10685798645,
-            "cassandra.net.inter.region": 59425.92804506421,
-            "cassandra.net.intra.region": 178277.78413519263,
-            "cassandra.zonal-clusters": 37518.0,
-            "evcache.zonal-clusters": 169647.53999999998,
-            "nflx-java-app.regional-clusters": 105150.0
-          },
-          "clusters": [
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            },
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            },
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            },
-            {
-              "annual_cost": 12506.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
-                "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 1,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 2,
-              "deployment": "zonal",
-              "instance": "m6id.8xlarge"
-            },
-            {
-              "annual_cost": 12506.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
-                "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 1,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 2,
-              "deployment": "zonal",
-              "instance": "m6id.8xlarge"
-            },
-            {
-              "annual_cost": 12506.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
-                "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
-                  "disk_capacity": 1,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 2,
-              "deployment": "zonal",
-              "instance": "m6id.8xlarge"
-            },
-            {
-              "annual_cost": 105150.0,
-              "attached_drives": [
-                "gp2 : 20GB"
-              ],
-              "cluster_type": "dgwkv",
-              "count": 75,
-              "deployment": "regional",
-              "instance": "c7a.2xlarge"
-            }
-          ],
-          "total_annual_cost": 564586.36
+          "total_annual_cost": 555314.86
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 17479.02113031006,
-            "cassandra.net.inter.region": 71710.81326901913,
-            "cassandra.net.intra.region": 215132.43980705738,
-            "cassandra.zonal-clusters": 30828.0,
+            "cassandra.backup.s3-standard": 18088.365884902953,
+            "cassandra.net.inter.region": 74238.32553997636,
+            "cassandra.net.intra.region": 222714.97661992908,
+            "cassandra.zonal-clusters": 44260.020000000004,
             "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 108432.87
           },
@@ -5182,19 +4767,22 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 10276.0,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.gib": 30.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
+                  "cluster_size": 2,
+                  "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -5204,24 +4792,27 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 4,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
-              "annual_cost": 10276.0,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.gib": 30.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
+                  "cluster_size": 2,
+                  "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -5231,24 +4822,27 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 4,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
-              "annual_cost": 10276.0,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.gib": 30.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
+                  "cluster_size": 2,
+                  "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -5258,9 +4852,9 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 4,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
               "annual_cost": 108432.87,
@@ -5273,14 +4867,14 @@
               "instance": "c7a.4xlarge"
             }
           ],
-          "total_annual_cost": 593889.53
+          "total_annual_cost": 618040.95
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 17479.02113031006,
-            "cassandra.net.inter.region": 71710.81326901913,
-            "cassandra.net.intra.region": 215132.43980705738,
-            "cassandra.zonal-clusters": 37518.0,
+            "cassandra.backup.s3-standard": 18088.365884902953,
+            "cassandra.net.inter.region": 74238.32553997636,
+            "cassandra.net.intra.region": 222714.97661992908,
+            "cassandra.zonal-clusters": 46243.979999999996,
             "evcache.zonal-clusters": 169647.53999999998,
             "nflx-java-app.regional-clusters": 110355.0
           },
@@ -5294,7 +4888,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 2,
+                  "disk_iops": 3,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -5315,7 +4909,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 2,
+                  "disk_iops": 3,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -5336,7 +4930,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 2,
+                  "disk_iops": 3,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -5349,7 +4943,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 12506.0,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5358,7 +4952,10 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -5373,10 +4970,10 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6id.8xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
-              "annual_cost": 12506.0,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5385,7 +4982,10 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -5400,10 +5000,10 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6id.8xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
-              "annual_cost": 12506.0,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5412,7 +5012,10 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1770,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -5427,7 +5030,7 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6id.8xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
               "annual_cost": 110355.0,
@@ -5440,85 +5043,85 @@
               "instance": "c6a.2xlarge"
             }
           ],
-          "total_annual_cost": 621842.81
+          "total_annual_cost": 641288.19
         }
       ],
       "95": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 23503.92992591858,
-            "cassandra.net.inter.region": 96809.59791317582,
-            "cassandra.net.intra.region": 290428.79373952746,
-            "cassandra.zonal-clusters": 44260.020000000004,
-            "evcache.zonal-clusters": 150306.39,
-            "nflx-java-app.regional-clusters": 116270.07
+            "cassandra.backup.s3-standard": 32689.79024523926,
+            "cassandra.net.inter.region": 134957.39939808846,
+            "cassandra.net.intra.region": 404872.19819426537,
+            "cassandra.zonal-clusters": 67924.02,
+            "evcache.zonal-clusters": 323694.0,
+            "nflx-java-app.regional-clusters": 166704.0
           },
           "clusters": [
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 107898.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 441,
+                "effective_disk_per_node_gib": 885,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 4,
+                  "cluster_size": 42,
+                  "cpu": 20,
+                  "disk_capacity": 1,
+                  "disk_iops": 42,
                   "memory": 1,
-                  "min_count": 2,
-                  "network": 4
+                  "min_count": 1,
+                  "network": 40
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 39,
+              "count": 42,
               "deployment": "zonal",
-              "instance": "c6id.2xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 107898.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 441,
+                "effective_disk_per_node_gib": 885,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 4,
+                  "cluster_size": 42,
+                  "cpu": 20,
+                  "disk_capacity": 1,
+                  "disk_iops": 42,
                   "memory": 1,
-                  "min_count": 2,
-                  "network": 4
+                  "min_count": 1,
+                  "network": 40
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 39,
+              "count": 42,
               "deployment": "zonal",
-              "instance": "c6id.2xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 107898.0,
               "cluster_params": {
-                "effective_disk_per_node_gib": 441,
+                "effective_disk_per_node_gib": 885,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 4,
+                  "cluster_size": 42,
+                  "cpu": 20,
+                  "disk_capacity": 1,
+                  "disk_iops": 42,
                   "memory": 1,
-                  "min_count": 2,
-                  "network": 4
+                  "min_count": 1,
+                  "network": 40
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 39,
+              "count": 42,
               "deployment": "zonal",
-              "instance": "c6id.2xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 22641.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5527,7 +5130,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
+                "effective_disk_per_node_gib": 2654,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5536,19 +5139,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "m6idn.12xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 22641.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5557,7 +5160,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
+                "effective_disk_per_node_gib": 2654,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5566,19 +5169,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "m6idn.12xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 22641.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5587,7 +5190,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
+                "effective_disk_per_node_gib": 2654,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5596,105 +5199,105 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "m6idn.12xlarge"
             },
             {
-              "annual_cost": 116270.07,
+              "annual_cost": 166704.0,
               "attached_drives": [
                 "gp2 : 20GB"
               ],
               "cluster_type": "dgwkv",
-              "count": 21,
+              "count": 69,
               "deployment": "regional",
-              "instance": "c7a.8xlarge"
+              "instance": "c5n.4xlarge"
             }
           ],
-          "total_annual_cost": 721578.8
+          "total_annual_cost": 1130841.41
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 23503.92992591858,
-            "cassandra.net.inter.region": 96809.59791317582,
-            "cassandra.net.intra.region": 290428.79373952746,
-            "cassandra.zonal-clusters": 46243.979999999996,
-            "evcache.zonal-clusters": 169647.53999999998,
-            "nflx-java-app.regional-clusters": 116661.0
+            "cassandra.backup.s3-standard": 32689.79024523926,
+            "cassandra.net.inter.region": 134957.39939808846,
+            "cassandra.net.intra.region": 404872.19819426537,
+            "cassandra.zonal-clusters": 87346.02,
+            "evcache.zonal-clusters": 391611.66000000003,
+            "nflx-java-app.regional-clusters": 194298.39
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 130537.22,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 221,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
+                  "cluster_size": 167,
+                  "cpu": 78,
                   "disk_capacity": 3,
-                  "disk_iops": 6,
-                  "memory": 2,
+                  "disk_iops": 167,
+                  "memory": 1,
                   "min_count": 3,
-                  "network": 5
+                  "network": 160
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 167,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "m6id.xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 130537.22,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 221,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
+                  "cluster_size": 167,
+                  "cpu": 78,
                   "disk_capacity": 3,
-                  "disk_iops": 6,
-                  "memory": 2,
+                  "disk_iops": 167,
+                  "memory": 1,
                   "min_count": 3,
-                  "network": 5
+                  "network": 160
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 167,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "m6id.xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 130537.22,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 221,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
+                  "cluster_size": 167,
+                  "cpu": 78,
                   "disk_capacity": 3,
-                  "disk_iops": 6,
-                  "memory": 2,
+                  "disk_iops": 167,
+                  "memory": 1,
                   "min_count": 3,
-                  "network": 5
+                  "network": 160
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_iops"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 167,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "m6id.xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 29115.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5712,19 +5315,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "r6idn.12xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 29115.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5742,19 +5345,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "r6idn.12xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 29115.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5772,29 +5375,29 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 1,
+                  "memory": 2,
                   "min_count": 2,
-                  "network": 1
+                  "network": 2
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "r6idn.12xlarge"
             },
             {
-              "annual_cost": 116661.0,
+              "annual_cost": 194298.39,
               "attached_drives": [
                 "gp2 : 20GB"
               ],
               "cluster_type": "dgwkv",
-              "count": 111,
+              "count": 117,
               "deployment": "regional",
-              "instance": "c6a.2xlarge"
+              "instance": "m6in.2xlarge"
             }
           ],
-          "total_annual_cost": 743294.84
+          "total_annual_cost": 1245775.46
         }
       ]
     },

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -1,0 +1,5806 @@
+[
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 405481.92149738566,
+          "cassandra.net.inter.region": 1190853.6608613518,
+          "cassandra.net.intra.region": 3572560.9825840555,
+          "cassandra.zonal-clusters": 1457600.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 485866.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 5,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          },
+          {
+            "annual_cost": 485866.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 5,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          },
+          {
+            "annual_cost": 485866.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 5,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          }
+        ],
+        "total_annual_cost": 6626497.2
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1478336.6400000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 492778.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          },
+          {
+            "annual_cost": 492778.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          },
+          {
+            "annual_cost": 492778.88,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 50,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 3
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "m7a.2xlarge"
+          }
+        ],
+        "total_annual_cost": 5870178.62
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 353277.0672346802,
+          "cassandra.net.inter.region": 1009641.2273436785,
+          "cassandra.net.intra.region": 3028923.6820310354,
+          "cassandra.zonal-clusters": 1564863.3599999999
+        },
+        "clusters": [
+          {
+            "annual_cost": 521621.12,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 32,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 2
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "c6a.4xlarge"
+          },
+          {
+            "annual_cost": 521621.12,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 32,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 2
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "c6a.4xlarge"
+          },
+          {
+            "annual_cost": 521621.12,
+            "attached_drives": [
+              "gp3 : 5600GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 8,
+              "cassandra.compute_buffer_ratio": 1.32,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.2,
+              "cassandra.heap.write.percent": 0.5,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.17,
+              "effective_disk_per_node_gib": 6600,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 32,
+                "disk_capacity": 56,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 64,
+                "network": 2
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "c6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 5956705.34
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1409216.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 469738.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            },
+            {
+              "annual_cost": 469738.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            },
+            {
+              "annual_cost": 469738.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 3901398.6
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1495743.3599999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 498581.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            },
+            {
+              "annual_cost": 498581.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            },
+            {
+              "annual_cost": 498581.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 3987925.32
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1471424.6400000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 490474.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            },
+            {
+              "annual_cost": 490474.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            },
+            {
+              "annual_cost": 490474.88,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 50,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 3
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "m7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 5686393.69
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1557951.3599999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 519317.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            },
+            {
+              "annual_cost": 519317.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            },
+            {
+              "annual_cost": 519317.12,
+              "attached_drives": [
+                "gp3 : 5600GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.32,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.2,
+                "cassandra.heap.write.percent": 0.5,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.17,
+                "effective_disk_per_node_gib": 6600,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 32,
+                  "disk_capacity": 56,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 64,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "c6a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 5772920.41
+        }
+      ],
+      "95": []
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_timeseries_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 36792.02039092105,
+          "cassandra.net.inter.region": 23088.6091673735,
+          "cassandra.net.intra.region": 69265.82750212049,
+          "cassandra.zonal-clusters": 450111.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 150037.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 150037.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 150037.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 579257.82
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 459327.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 153109.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 153109.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 153109.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 56,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 616070.24
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 37961.555153961184,
+          "cassandra.net.inter.region": 29695.330215990543,
+          "cassandra.net.intra.region": 89085.99064797163,
+          "cassandra.zonal-clusters": 510783.36
+        },
+        "clusters": [
+          {
+            "annual_cost": 170261.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 39,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.xlarge"
+          },
+          {
+            "annual_cost": 170261.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 39,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.xlarge"
+          },
+          {
+            "annual_cost": 170261.12,
+            "attached_drives": [
+              "gp3 : 1200GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.37,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.44,
+              "effective_disk_per_node_gib": 5100,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 64,
+                "cpu": 39,
+                "disk_capacity": 15,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 16,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 64,
+            "deployment": "zonal",
+            "instance": "r7a.xlarge"
+          }
+        ],
+        "total_annual_cost": 667526.24
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 410943.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 136981.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 136981.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 136981.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 497721.06
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 29891.97447918801,
+            "cassandra.net.inter.region": 14221.43169220214,
+            "cassandra.net.intra.region": 42664.295076606424,
+            "cassandra.zonal-clusters": 405055.68
+          },
+          "clusters": [
+            {
+              "annual_cost": 135018.56,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 29,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "m6a.2xlarge"
+            },
+            {
+              "annual_cost": 135018.56,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 29,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "m6a.2xlarge"
+            },
+            {
+              "annual_cost": 135018.56,
+              "attached_drives": [
+                "gp3 : 2400GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 29,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "m6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 491833.38
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 452415.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 150805.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 150805.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 150805.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 599228.46
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 37283.805858515196,
+            "cassandra.net.inter.region": 27382.32302858961,
+            "cassandra.net.intra.region": 82146.96908576883,
+            "cassandra.zonal-clusters": 503871.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 167957.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 167957.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 167957.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 650684.46
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 514623.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 171541.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 171541.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 171541.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 56,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 791299.78
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 49127.45948389998,
+            "cassandra.net.inter.region": 56887.240607232845,
+            "cassandra.net.intra.region": 170661.72182169853,
+            "cassandra.zonal-clusters": 566079.36
+          },
+          "clusters": [
+            {
+              "annual_cost": 188693.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 188693.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 188693.12,
+              "attached_drives": [
+                "gp3 : 1200GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.37,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.44,
+                "effective_disk_per_node_gib": 5100,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 64,
+                  "cpu": 39,
+                  "disk_capacity": 15,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 16,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 64,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 842755.78
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_dense_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 17072.467730616816,
+          "cassandra.net.inter.region": 9318.776756651392,
+          "cassandra.net.intra.region": 27956.330269954175,
+          "cassandra.zonal-clusters": 198559.68
+        },
+        "clusters": [
+          {
+            "annual_cost": 66186.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 66186.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 66186.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 252907.25
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 202015.68
+        },
+        "clusters": [
+          {
+            "annual_cost": 67338.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 67338.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 67338.56,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 18,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 247337.79
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 15626.777788490295,
+          "cassandra.net.inter.region": 7423.832553997636,
+          "cassandra.net.intra.region": 22271.497661992908,
+          "cassandra.zonal-clusters": 206400.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 68800.0,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 24,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 68800.0,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 24,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          },
+          {
+            "annual_cost": 68800.0,
+            "attached_drives": [
+              "gp3 : 900GB"
+            ],
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.4,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 2.74,
+              "effective_disk_per_node_gib": 5700,
+              "rank_penalties": {
+                "family_migration": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 32,
+                "cpu": 24,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 8,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 32,
+            "deployment": "zonal",
+            "instance": "r5.xlarge"
+          }
+        ],
+        "total_annual_cost": 251722.11
+      }
+    ],
+    "model": "org.netflix.cassandra",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 177823.68
+          },
+          "clusters": [
+            {
+              "annual_cost": 59274.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 59274.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 59274.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 204791.02
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 12745.904619797004,
+            "cassandra.net.inter.region": 3555.357923050535,
+            "cassandra.net.intra.region": 10666.073769151606,
+            "cassandra.zonal-clusters": 168015.84
+          },
+          "clusters": [
+            {
+              "annual_cost": 56005.28,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 16,
+                  "cpu": 12,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 56005.28,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 16,
+                  "cpu": 12,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 56005.28,
+              "attached_drives": [
+                "gp3 : 1800GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 16,
+                  "cpu": 12,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 16,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 194983.18
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 198559.68
+          },
+          "clusters": [
+            {
+              "annual_cost": 66186.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 66186.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 66186.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 241375.47
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 15433.4634646288,
+            "cassandra.net.inter.region": 6845.580757147402,
+            "cassandra.net.intra.region": 20536.742271442206,
+            "cassandra.zonal-clusters": 202944.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 67648.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 67648.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 67648.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 245759.79
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 229663.68
+          },
+          "clusters": [
+            {
+              "annual_cost": 76554.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 76554.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 76554.56,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 18,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 305885.7
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 19334.777870974995,
+            "cassandra.net.inter.region": 14221.810151808211,
+            "cassandra.net.intra.region": 42665.430455424634,
+            "cassandra.zonal-clusters": 234048.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 78016.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 78016.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            },
+            {
+              "annual_cost": 78016.0,
+              "attached_drives": [
+                "gp3 : 900GB"
+              ],
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.4,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 2.74,
+                "effective_disk_per_node_gib": 5700,
+                "rank_penalties": {
+                  "family_migration": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 32,
+                  "cpu": 24,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 8,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 32,
+              "deployment": "zonal",
+              "instance": "r5.xlarge"
+            }
+          ],
+          "total_annual_cost": 310270.02
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "cassandra_kv_compact_ebs",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 13494.059999999998
+        },
+        "clusters": [
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 6,
+                "network": 1
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 6,
+                "network": 1
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 6,
+                "network": 1
+              },
+              "resource_bottleneck": "disk_capacity"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          }
+        ],
+        "total_annual_cost": 13494.06
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 13494.059999999998
+        },
+        "clusters": [
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 4,
+                "disk_capacity": 5,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 5,
+                "network": 1
+              },
+              "resource_bottleneck": "memory"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 4,
+                "disk_capacity": 5,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 5,
+                "network": 1
+              },
+              "resource_bottleneck": "memory"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          },
+          {
+            "annual_cost": 4498.0199999999995,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 1164,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 6,
+                "cpu": 4,
+                "disk_capacity": 5,
+                "disk_iops": 0,
+                "memory": 6,
+                "min_count": 5,
+                "network": 1
+              },
+              "resource_bottleneck": "memory"
+            },
+            "cluster_type": "kafka",
+            "count": 6,
+            "deployment": "zonal",
+            "instance": "i3en.large"
+          }
+        ],
+        "total_annual_cost": 13494.06
+      },
+      {
+        "annual_costs": {
+          "kafka.zonal-clusters": 18529.98
+        },
+        "clusters": [
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          },
+          {
+            "annual_cost": 6176.66,
+            "attached_drives": [
+              "gp3 : 2400GB"
+            ],
+            "cluster_params": {
+              "effective_disk_per_node_gib": 5200,
+              "kafka.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 2,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "kafka",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "r6a.xlarge"
+          }
+        ],
+        "total_annual_cost": 18529.98
+      }
+    ],
+    "model": "org.netflix.kafka",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 1,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 1,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 1,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 12711.93
+          },
+          "clusters": [
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 1,
+                  "disk_capacity": 7,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 7,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 1,
+                  "disk_capacity": 7,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 7,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            },
+            {
+              "annual_cost": 4237.31,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 436,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 1,
+                  "disk_capacity": 7,
+                  "disk_iops": 0,
+                  "memory": 6,
+                  "min_count": 7,
+                  "network": 2
+                },
+                "resource_bottleneck": "disk_capacity"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i4i.large"
+            }
+          ],
+          "total_annual_cost": 12711.93
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 8998.02
+          },
+          "clusters": [
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            },
+            {
+              "annual_cost": 2999.34,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 2328,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "i3en.xlarge"
+            }
+          ],
+          "total_annual_cost": 8998.02
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 17953.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            },
+            {
+              "annual_cost": 5984.66,
+              "attached_drives": [
+                "gp3 : 2300GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r6a.xlarge"
+            }
+          ],
+          "total_annual_cost": 17953.98
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 15743.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            },
+            {
+              "annual_cost": 5247.69,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 1164,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
+                  "disk_iops": 0,
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 7,
+              "deployment": "zonal",
+              "instance": "i3en.large"
+            }
+          ],
+          "total_annual_cost": 15743.07
+        },
+        {
+          "annual_costs": {
+            "kafka.zonal-clusters": 26473.98
+          },
+          "clusters": [
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            },
+            {
+              "annual_cost": 8824.66,
+              "attached_drives": [
+                "gp3 : 3500GB"
+              ],
+              "cluster_params": {
+                "effective_disk_per_node_gib": 5200,
+                "kafka.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
+                  "disk_iops": 0,
+                  "memory": 2,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "kafka",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "r7a.xlarge"
+            }
+          ],
+          "total_annual_cost": 26473.98
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kafka_100mib_throughput",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 32829.10006879722,
+          "evcache.net.intra.region": 49243.65010319583,
+          "evcache.zonal-clusters": 100204.26000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 1,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 1,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 182277.01
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 100204.26000000001
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          }
+        ],
+        "total_annual_cost": 175441.83
+      },
+      {
+        "annual_costs": {
+          "evcache.net.inter.region": 30095.029830932617,
+          "evcache.net.intra.region": 45142.544746398926,
+          "evcache.zonal-clusters": 113098.35999999999
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 46,
+                "cpu": 46,
+                "disk_capacity": 3,
+                "disk_iops": 3,
+                "memory": 2,
+                "min_count": 3,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 2,
+              "required_nodes_by_type": {
+                "cluster_size": 46,
+                "cpu": 46,
+                "disk_capacity": 3,
+                "disk_iops": 3,
+                "memory": 2,
+                "min_count": 3,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          }
+        ],
+        "total_annual_cost": 188335.93
+      }
+    ],
+    "model": "org.netflix.evcache",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 1,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 1,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 127287.4
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 10833.257924090358,
+            "evcache.net.intra.region": 16249.886886135537,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 140181.5
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 2,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 2,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 169256.37
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 27620.842314355657,
+            "evcache.net.intra.region": 41431.263471533486,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 2,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 2,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 182150.47
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 100204.26000000001
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 4
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 4
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            }
+          ],
+          "total_annual_cost": 238343.12
+        },
+        {
+          "annual_costs": {
+            "evcache.net.inter.region": 55255.54215255931,
+            "evcache.net.intra.region": 82883.31322883896,
+            "evcache.zonal-clusters": 113098.35999999999
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 6,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 5
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 2,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 6,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 5
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            }
+          ],
+          "total_annual_cost": 251237.22
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "evcache_large_with_replication",
+    "service_tier": 1,
+    "simulations": 16
+  },
+  {
+    "least_regret": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 19184.434642913817,
+          "cassandra.net.inter.region": 78646.77717536688,
+          "cassandra.net.intra.region": 235940.33152610064,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 636770.82
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18441.540387680056,
+          "cassandra.net.inter.region": 75766.5887735784,
+          "cassandra.net.intra.region": 227299.76632073522,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 105994.83
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 105994.83,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 51,
+            "deployment": "regional",
+            "instance": "c6a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 622069.14
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 16085.217869522095,
+          "cassandra.net.inter.region": 65774.09840002656,
+          "cassandra.net.intra.region": 197322.29520007968,
+          "cassandra.zonal-clusters": 30828.0,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 111150.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885,
+              "required_nodes_by_type": {
+                "cluster_size": 4,
+                "cpu": 4,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885,
+              "required_nodes_by_type": {
+                "cluster_size": 4,
+                "cpu": 4,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 10276.0,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 15.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 885,
+              "required_nodes_by_type": {
+                "cluster_size": 4,
+                "cpu": 4,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 4,
+            "deployment": "zonal",
+            "instance": "c6id.4xlarge"
+          },
+          {
+            "annual_cost": 111150.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 9,
+            "deployment": "regional",
+            "instance": "c6a.24xlarge"
+          }
+        ],
+        "total_annual_cost": 571466.0
+      }
+    ],
+    "mean": [
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
+        },
+        "clusters": [
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
+                "memory": 1,
+                "min_count": 2,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
+          }
+        ],
+        "total_annual_cost": 618040.95
+      },
+      {
+        "annual_costs": {
+          "cassandra.backup.s3-standard": 18088.365884902953,
+          "cassandra.net.inter.region": 74238.32553997636,
+          "cassandra.net.intra.region": 222714.97661992908,
+          "cassandra.zonal-clusters": 46243.979999999996,
+          "evcache.zonal-clusters": 169647.53999999998,
+          "nflx-java-app.regional-clusters": 110355.0
+        },
+        "clusters": [
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 46,
+                "cpu": 46,
+                "disk_capacity": 3,
+                "disk_iops": 3,
+                "memory": 2,
+                "min_count": 3,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 46,
+                "cpu": 46,
+                "disk_capacity": 3,
+                "disk_iops": 3,
+                "memory": 2,
+                "min_count": 3,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 56549.17999999999,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 186,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 46,
+                "cpu": 46,
+                "disk_capacity": 3,
+                "disk_iops": 3,
+                "memory": 2,
+                "min_count": 3,
+                "network": 2
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 46,
+            "deployment": "zonal",
+            "instance": "c5d.2xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 15414.66,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 2654,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c6id.12xlarge"
+          },
+          {
+            "annual_cost": 110355.0,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 105,
+            "deployment": "regional",
+            "instance": "c6a.2xlarge"
+          }
+        ],
+        "total_annual_cost": 641288.19
+      }
+    ],
+    "model": "org.netflix.key-value",
+    "num_results": 3,
+    "percentiles": {
+      "5": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 104049.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 1,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 1,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 1,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 104049.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 99,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 537454.21
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 105150.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 105150.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 75,
+              "deployment": "regional",
+              "instance": "c7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 564586.36
+        }
+      ],
+      "50": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 30828.0,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 108432.87
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 2,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 2,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 2,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 10276.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 15.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 885,
+                "required_nodes_by_type": {
+                  "cluster_size": 4,
+                  "cpu": 4,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 4,
+              "deployment": "zonal",
+              "instance": "c6id.4xlarge"
+            },
+            {
+              "annual_cost": 108432.87,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 39,
+              "deployment": "regional",
+              "instance": "c7a.4xlarge"
+            }
+          ],
+          "total_annual_cost": 593889.53
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 110355.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 2,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 2,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 2,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 2
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 110355.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 105,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 621842.81
+        }
+      ],
+      "95": [
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 116270.07
+          },
+          "clusters": [
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 4
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 4
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 50102.130000000005,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 441,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 4
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 39,
+              "deployment": "zonal",
+              "instance": "c6id.2xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 14753.34,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1676,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c5d.12xlarge"
+            },
+            {
+              "annual_cost": 116270.07,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 21,
+              "deployment": "regional",
+              "instance": "c7a.8xlarge"
+            }
+          ],
+          "total_annual_cost": 721578.8
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 46243.979999999996,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 116661.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 6,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 5
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 6,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 5
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 6,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 5
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 15414.66,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 2654,
+                "rank_penalties": {
+                  "large_instance": 0.1
+                },
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "c6id.12xlarge"
+            },
+            {
+              "annual_cost": 116661.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 111,
+              "deployment": "regional",
+              "instance": "c6a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 743294.84
+        }
+      ]
+    },
+    "region": "us-east-1",
+    "scenario": "kv_with_cache",
+    "service_tier": 1,
+    "simulations": 16
+  }
+]

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -788,7 +788,7 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce output drift across SciPy releases and CPU/libm builds. The test environments pin the supported SciPy range; widen it only with an intentional baseline refresh. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
@@ -1476,7 +1476,7 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce output drift across SciPy releases and CPU/libm builds. The test environments pin the supported SciPy range; widen it only with an intentional baseline refresh. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
@@ -3389,6 +3389,6 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce output drift across SciPy releases and CPU/libm builds. The test environments pin the supported SciPy range; widen it only with an intentional baseline refresh. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   }
 ]

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -3,14 +3,14 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 275074.04119547654,
-          "cassandra.net.inter.region": 706033.6823295535,
-          "cassandra.net.intra.region": 2118101.0469886605,
-          "cassandra.zonal-clusters": 1441472.6400000001
+          "cassandra.backup.s3-standard": 405481.92149738566,
+          "cassandra.net.inter.region": 1190853.6608613518,
+          "cassandra.net.intra.region": 3572560.9825840555,
+          "cassandra.zonal-clusters": 1457600.6400000001
         },
         "clusters": [
           {
-            "annual_cost": 480490.88,
+            "annual_cost": 485866.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -31,7 +31,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 4,
+                "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
@@ -43,7 +43,7 @@
             "instance": "m7a.2xlarge"
           },
           {
-            "annual_cost": 480490.88,
+            "annual_cost": 485866.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -64,7 +64,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 4,
+                "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
@@ -76,7 +76,7 @@
             "instance": "m7a.2xlarge"
           },
           {
-            "annual_cost": 480490.88,
+            "annual_cost": 485866.88,
             "attached_drives": [
               "gp3 : 5600GB"
             ],
@@ -97,7 +97,7 @@
                 "cpu": 50,
                 "disk_capacity": 56,
                 "disk_iops": 0,
-                "memory": 4,
+                "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
@@ -109,7 +109,7 @@
             "instance": "m7a.2xlarge"
           }
         ],
-        "total_annual_cost": 4540681.41
+        "total_annual_cost": 6626497.2
       }
     ],
     "mean": [
@@ -340,14 +340,14 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 204334.39471810914,
-            "cassandra.net.inter.region": 434489.7957120319,
-            "cassandra.net.intra.region": 1303469.3871360957,
-            "cassandra.zonal-clusters": 1400000.6400000001
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1409216.6400000001
           },
           "clusters": [
             {
-              "annual_cost": 466666.88,
+              "annual_cost": 469738.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -380,7 +380,7 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 466666.88,
+              "annual_cost": 469738.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -413,7 +413,7 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 466666.88,
+              "annual_cost": 469738.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -446,18 +446,18 @@
               "instance": "m7a.2xlarge"
             }
           ],
-          "total_annual_cost": 3342294.22
+          "total_annual_cost": 3901398.6
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 204334.39471810914,
-            "cassandra.net.inter.region": 434489.7957120319,
-            "cassandra.net.intra.region": 1303469.3871360957,
-            "cassandra.zonal-clusters": 1486527.3599999999
+            "cassandra.backup.s3-standard": 233074.95698382912,
+            "cassandra.net.inter.region": 564776.7496072351,
+            "cassandra.net.intra.region": 1694330.248821705,
+            "cassandra.zonal-clusters": 1495743.3599999999
           },
           "clusters": [
             {
-              "annual_cost": 495509.12,
+              "annual_cost": 498581.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -490,7 +490,7 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 495509.12,
+              "annual_cost": 498581.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -523,7 +523,7 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 495509.12,
+              "annual_cost": 498581.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
@@ -556,25 +556,25 @@
               "instance": "c6a.4xlarge"
             }
           ],
-          "total_annual_cost": 3428820.94
+          "total_annual_cost": 3987925.32
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 353277.0672346802,
-            "cassandra.net.inter.region": 1009641.2273436785,
-            "cassandra.net.intra.region": 3028923.6820310354,
-            "cassandra.zonal-clusters": 1478336.6400000001
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1471424.6400000001
           },
           "clusters": [
             {
-              "annual_cost": 492778.88,
+              "annual_cost": 490474.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -590,7 +590,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
@@ -602,12 +602,12 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 492778.88,
+              "annual_cost": 490474.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -623,7 +623,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
@@ -635,12 +635,12 @@
               "instance": "m7a.2xlarge"
             },
             {
-              "annual_cost": 492778.88,
+              "annual_cost": 490474.88,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -656,7 +656,7 @@
                   "cpu": 50,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
@@ -668,23 +668,23 @@
               "instance": "m7a.2xlarge"
             }
           ],
-          "total_annual_cost": 5870178.62
+          "total_annual_cost": 5686393.69
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 353277.0672346802,
-            "cassandra.net.inter.region": 1009641.2273436785,
-            "cassandra.net.intra.region": 3028923.6820310354,
-            "cassandra.zonal-clusters": 1564863.3599999999
+            "cassandra.backup.s3-standard": 342869.5600652009,
+            "cassandra.net.inter.region": 968024.8720495387,
+            "cassandra.net.intra.region": 2904074.616148616,
+            "cassandra.zonal-clusters": 1557951.3599999999
           },
           "clusters": [
             {
-              "annual_cost": 521621.12,
+              "annual_cost": 519317.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -700,7 +700,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 2
                 },
@@ -712,12 +712,12 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 521621.12,
+              "annual_cost": 519317.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -733,7 +733,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 2
                 },
@@ -745,12 +745,12 @@
               "instance": "c6a.4xlarge"
             },
             {
-              "annual_cost": 521621.12,
+              "annual_cost": 519317.12,
               "attached_drives": [
                 "gp3 : 5600GB"
               ],
               "cluster_params": {
-                "cassandra.compaction.min_threshold": 8,
+                "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.32,
                 "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.2,
@@ -766,7 +766,7 @@
                   "cpu": 32,
                   "disk_capacity": 56,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 6,
                   "min_count": 64,
                   "network": 2
                 },
@@ -778,7 +778,7 @@
               "instance": "c6a.4xlarge"
             }
           ],
-          "total_annual_cost": 5956705.34
+          "total_annual_cost": 5772920.41
         }
       ],
       "95": []
@@ -786,1586 +786,82 @@
     "region": "us-east-1",
     "scenario": "cassandra_timeseries_ebs",
     "service_tier": 1,
-    "simulations": 16
+    "simulations": 16,
+    "snapshot_format": "seeded-scipy-cost-preserve-v1",
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 34425.12512873268,
-          "cassandra.net.inter.region": 23182.06784570285,
-          "cassandra.net.intra.region": 69546.20353710855,
-          "cassandra.zonal-clusters": 438591.36
+          "kafka.zonal-clusters": 13494.059999999998
         },
         "clusters": [
           {
-            "annual_cost": 146197.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
+            "annual_cost": 4498.0199999999995,
             "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 146197.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 146197.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          }
-        ],
-        "total_annual_cost": 565744.76
-      }
-    ],
-    "mean": [
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 37961.555153961184,
-          "cassandra.net.inter.region": 29695.330215990543,
-          "cassandra.net.intra.region": 89085.99064797163,
-          "cassandra.zonal-clusters": 459327.36
-        },
-        "clusters": [
-          {
-            "annual_cost": 153109.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 153109.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 153109.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 56,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          }
-        ],
-        "total_annual_cost": 616070.24
-      },
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 37961.555153961184,
-          "cassandra.net.inter.region": 29695.330215990543,
-          "cassandra.net.intra.region": 89085.99064797163,
-          "cassandra.zonal-clusters": 510783.36
-        },
-        "clusters": [
-          {
-            "annual_cost": 170261.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 39,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r7a.xlarge"
-          },
-          {
-            "annual_cost": 170261.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 39,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r7a.xlarge"
-          },
-          {
-            "annual_cost": 170261.12,
-            "attached_drives": [
-              "gp3 : 1200GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.37,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.44,
-              "effective_disk_per_node_gib": 5100,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 64,
-                "cpu": 39,
-                "disk_capacity": 15,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 16,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 64,
-            "deployment": "zonal",
-            "instance": "r7a.xlarge"
-          }
-        ],
-        "total_annual_cost": 667526.24
-      }
-    ],
-    "model": "org.netflix.cassandra",
-    "num_results": 3,
-    "percentiles": {
-      "5": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 28221.18184465027,
-            "cassandra.net.inter.region": 12779.111638589173,
-            "cassandra.net.intra.region": 38337.33491576752,
-            "cassandra.zonal-clusters": 404031.36
-          },
-          "clusters": [
-            {
-              "annual_cost": 134677.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 134677.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 134677.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 483368.99
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 28221.18184465027,
-            "cassandra.net.inter.region": 12779.111638589173,
-            "cassandra.net.intra.region": 38337.33491576752,
-            "cassandra.zonal-clusters": 396991.68
-          },
-          "clusters": [
-            {
-              "annual_cost": 132330.56,
-              "attached_drives": [
-                "gp3 : 2400GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 29,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "m6a.2xlarge"
-            },
-            {
-              "annual_cost": 132330.56,
-              "attached_drives": [
-                "gp3 : 2400GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 29,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "m6a.2xlarge"
-            },
-            {
-              "annual_cost": 132330.56,
-              "attached_drives": [
-                "gp3 : 2400GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 29,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "m6a.2xlarge"
-            }
-          ],
-          "total_annual_cost": 476329.31
-        }
-      ],
-      "50": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 37961.555153961184,
-            "cassandra.net.inter.region": 29695.330215990543,
-            "cassandra.net.intra.region": 89085.99064797163,
-            "cassandra.zonal-clusters": 459327.36
-          },
-          "clusters": [
-            {
-              "annual_cost": 153109.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 153109.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 153109.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 56,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 616070.24
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 37961.555153961184,
-            "cassandra.net.inter.region": 29695.330215990543,
-            "cassandra.net.intra.region": 89085.99064797163,
-            "cassandra.zonal-clusters": 510783.36
-          },
-          "clusters": [
-            {
-              "annual_cost": 170261.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 170261.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 170261.12,
-              "attached_drives": [
-                "gp3 : 1200GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.37,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.44,
-                "effective_disk_per_node_gib": 5100,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 64,
-                  "cpu": 39,
-                  "disk_capacity": 15,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 16,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 64,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            }
-          ],
-          "total_annual_cost": 667526.24
-        }
-      ],
-      "95": []
-    },
-    "region": "us-east-1",
-    "scenario": "cassandra_kv_dense_ebs",
-    "service_tier": 1,
-    "simulations": 16
-  },
-  {
-    "least_regret": [
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 15368.224603275776,
-          "cassandra.net.inter.region": 7084.674175374913,
-          "cassandra.net.intra.region": 21254.02252612474,
-          "cassandra.zonal-clusters": 199711.68
-        },
-        "clusters": [
-          {
-            "annual_cost": 66570.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 66570.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 66570.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          }
-        ],
-        "total_annual_cost": 243418.6
-      }
-    ],
-    "mean": [
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 15626.777788490295,
-          "cassandra.net.inter.region": 7423.832553997636,
-          "cassandra.net.intra.region": 22271.497661992908,
-          "cassandra.zonal-clusters": 202015.68
-        },
-        "clusters": [
-          {
-            "annual_cost": 67338.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 67338.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          },
-          {
-            "annual_cost": 67338.56,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 18,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r6a.xlarge"
-          }
-        ],
-        "total_annual_cost": 247337.79
-      },
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 15626.777788490295,
-          "cassandra.net.inter.region": 7423.832553997636,
-          "cassandra.net.intra.region": 22271.497661992908,
-          "cassandra.zonal-clusters": 206400.0
-        },
-        "clusters": [
-          {
-            "annual_cost": 68800.0,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 24,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r5.xlarge"
-          },
-          {
-            "annual_cost": 68800.0,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 24,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r5.xlarge"
-          },
-          {
-            "annual_cost": 68800.0,
-            "attached_drives": [
-              "gp3 : 900GB"
-            ],
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.4,
-              "cassandra.heap.gib": 15.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 2.74,
-              "effective_disk_per_node_gib": 5700,
-              "rank_penalties": {
-                "family_migration": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 32,
-                "cpu": 24,
-                "disk_capacity": 6,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 8,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 32,
-            "deployment": "zonal",
-            "instance": "r5.xlarge"
-          }
-        ],
-        "total_annual_cost": 251722.11
-      }
-    ],
-    "model": "org.netflix.cassandra",
-    "num_results": 3,
-    "percentiles": {
-      "5": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 12064.362461162567,
-            "cassandra.net.inter.region": 3194.777909647293,
-            "cassandra.net.intra.region": 9584.33372894188,
-            "cassandra.zonal-clusters": 174367.68
-          },
-          "clusters": [
-            {
-              "annual_cost": 58122.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 58122.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 58122.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 199211.15
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 12064.362461162567,
-            "cassandra.net.inter.region": 3194.777909647293,
-            "cassandra.net.intra.region": 9584.33372894188,
-            "cassandra.zonal-clusters": 163983.84
-          },
-          "clusters": [
-            {
-              "annual_cost": 54661.28,
-              "attached_drives": [
-                "gp3 : 1800GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 16,
-                  "cpu": 12,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 16,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 54661.28,
-              "attached_drives": [
-                "gp3 : 1800GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 16,
-                  "cpu": 12,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 16,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            },
-            {
-              "annual_cost": 54661.28,
-              "attached_drives": [
-                "gp3 : 1800GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 16,
-                  "cpu": 12,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 16,
-              "deployment": "zonal",
-              "instance": "r7a.xlarge"
-            }
-          ],
-          "total_annual_cost": 188827.31
-        }
-      ],
-      "50": [
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 15626.777788490295,
-            "cassandra.net.inter.region": 7423.832553997636,
-            "cassandra.net.intra.region": 22271.497661992908,
-            "cassandra.zonal-clusters": 202015.68
-          },
-          "clusters": [
-            {
-              "annual_cost": 67338.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 67338.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            },
-            {
-              "annual_cost": 67338.56,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 18,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r6a.xlarge"
-            }
-          ],
-          "total_annual_cost": 247337.79
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 15626.777788490295,
-            "cassandra.net.inter.region": 7423.832553997636,
-            "cassandra.net.intra.region": 22271.497661992908,
-            "cassandra.zonal-clusters": 206400.0
-          },
-          "clusters": [
-            {
-              "annual_cost": 68800.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            },
-            {
-              "annual_cost": 68800.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            },
-            {
-              "annual_cost": 68800.0,
-              "attached_drives": [
-                "gp3 : 900GB"
-              ],
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.4,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 2.74,
-                "effective_disk_per_node_gib": 5700,
-                "rank_penalties": {
-                  "family_migration": 0.1
-                },
-                "required_nodes_by_type": {
-                  "cluster_size": 32,
-                  "cpu": 24,
-                  "disk_capacity": 6,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 8,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 32,
-              "deployment": "zonal",
-              "instance": "r5.xlarge"
-            }
-          ],
-          "total_annual_cost": 251722.11
-        }
-      ],
-      "95": []
-    },
-    "region": "us-east-1",
-    "scenario": "cassandra_kv_compact_ebs",
-    "service_tier": 1,
-    "simulations": 16
-  },
-  {
-    "least_regret": [
-      {
-        "annual_costs": {
-          "kafka.zonal-clusters": 13497.03
-        },
-        "clusters": [
-          {
-            "annual_cost": 4499.01,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 2328,
+              "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 3,
-                "cpu": 3,
-                "disk_capacity": 3,
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
                 "disk_iops": 0,
-                "memory": 2,
-                "min_count": 3,
+                "memory": 6,
+                "min_count": 6,
                 "network": 1
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "kafka",
-            "count": 3,
+            "count": 6,
             "deployment": "zonal",
-            "instance": "i3en.xlarge"
+            "instance": "i3en.large"
           },
           {
-            "annual_cost": 4499.01,
+            "annual_cost": 4498.0199999999995,
             "cluster_params": {
-              "effective_disk_per_node_gib": 2328,
+              "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 3,
-                "cpu": 3,
-                "disk_capacity": 3,
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
                 "disk_iops": 0,
-                "memory": 2,
-                "min_count": 3,
+                "memory": 6,
+                "min_count": 6,
                 "network": 1
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "kafka",
-            "count": 3,
+            "count": 6,
             "deployment": "zonal",
-            "instance": "i3en.xlarge"
+            "instance": "i3en.large"
           },
           {
-            "annual_cost": 4499.01,
+            "annual_cost": 4498.0199999999995,
             "cluster_params": {
-              "effective_disk_per_node_gib": 2328,
+              "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
               "required_nodes_by_type": {
-                "cluster_size": 3,
-                "cpu": 3,
-                "disk_capacity": 3,
+                "cluster_size": 6,
+                "cpu": 2,
+                "disk_capacity": 6,
                 "disk_iops": 0,
-                "memory": 2,
-                "min_count": 3,
+                "memory": 6,
+                "min_count": 6,
                 "network": 1
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "kafka",
-            "count": 3,
+            "count": 6,
             "deployment": "zonal",
-            "instance": "i3en.xlarge"
+            "instance": "i3en.large"
           }
         ],
-        "total_annual_cost": 13497.03
+        "total_annual_cost": 13494.06
       }
     ],
     "mean": [
@@ -2540,7 +1036,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
                   "network": 1
                 },
@@ -2561,7 +1057,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
                   "network": 1
                 },
@@ -2582,7 +1078,7 @@
                   "cpu": 1,
                   "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
                   "network": 1
                 },
@@ -2598,157 +1094,157 @@
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 10404.0
+            "kafka.zonal-clusters": 12711.93
           },
           "clusters": [
             {
-              "annual_cost": 3468.0,
+              "annual_cost": 4237.31,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 436,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 3,
+                  "cluster_size": 7,
                   "cpu": 1,
-                  "disk_capacity": 3,
+                  "disk_capacity": 7,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 6,
+                  "min_count": 7,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 3,
+              "count": 7,
               "deployment": "zonal",
-              "instance": "i3.xlarge"
+              "instance": "i4i.large"
             },
             {
-              "annual_cost": 3468.0,
+              "annual_cost": 4237.31,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 436,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 3,
+                  "cluster_size": 7,
                   "cpu": 1,
-                  "disk_capacity": 3,
+                  "disk_capacity": 7,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 6,
+                  "min_count": 7,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 3,
+              "count": 7,
               "deployment": "zonal",
-              "instance": "i3.xlarge"
+              "instance": "i4i.large"
             },
             {
-              "annual_cost": 3468.0,
+              "annual_cost": 4237.31,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 436,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 3,
+                  "cluster_size": 7,
                   "cpu": 1,
-                  "disk_capacity": 3,
+                  "disk_capacity": 7,
                   "disk_iops": 0,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 6,
+                  "min_count": 7,
                   "network": 2
                 },
                 "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "kafka",
-              "count": 3,
+              "count": 7,
               "deployment": "zonal",
-              "instance": "i3.xlarge"
+              "instance": "i4i.large"
             }
           ],
-          "total_annual_cost": 10404.0
+          "total_annual_cost": 12711.93
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 13494.059999999998
+            "kafka.zonal-clusters": 8998.02
           },
           "clusters": [
             {
-              "annual_cost": 4498.0199999999995,
+              "annual_cost": 2999.34,
               "cluster_params": {
-                "effective_disk_per_node_gib": 1164,
+                "effective_disk_per_node_gib": 2328,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 6,
-                  "cpu": 4,
-                  "disk_capacity": 5,
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 5,
+                  "memory": 2,
+                  "min_count": 2,
                   "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 6,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "i3en.large"
+              "instance": "i3en.xlarge"
             },
             {
-              "annual_cost": 4498.0199999999995,
+              "annual_cost": 2999.34,
               "cluster_params": {
-                "effective_disk_per_node_gib": 1164,
+                "effective_disk_per_node_gib": 2328,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 6,
-                  "cpu": 4,
-                  "disk_capacity": 5,
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 5,
+                  "memory": 2,
+                  "min_count": 2,
                   "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 6,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "i3en.large"
+              "instance": "i3en.xlarge"
             },
             {
-              "annual_cost": 4498.0199999999995,
+              "annual_cost": 2999.34,
               "cluster_params": {
-                "effective_disk_per_node_gib": 1164,
+                "effective_disk_per_node_gib": 2328,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 6,
-                  "cpu": 4,
-                  "disk_capacity": 5,
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 2,
                   "disk_iops": 0,
-                  "memory": 6,
-                  "min_count": 5,
+                  "memory": 2,
+                  "min_count": 2,
                   "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 6,
+              "count": 2,
               "deployment": "zonal",
-              "instance": "i3en.large"
+              "instance": "i3en.xlarge"
             }
           ],
-          "total_annual_cost": 13494.06
+          "total_annual_cost": 8998.02
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 18529.98
+            "kafka.zonal-clusters": 17953.98
           },
           "clusters": [
             {
-              "annual_cost": 6176.66,
+              "annual_cost": 5984.66,
               "attached_drives": [
-                "gp3 : 2400GB"
+                "gp3 : 2300GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2770,9 +1266,9 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 6176.66,
+              "annual_cost": 5984.66,
               "attached_drives": [
-                "gp3 : 2400GB"
+                "gp3 : 2300GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2794,9 +1290,9 @@
               "instance": "r6a.xlarge"
             },
             {
-              "annual_cost": 6176.66,
+              "annual_cost": 5984.66,
               "attached_drives": [
-                "gp3 : 2400GB"
+                "gp3 : 2300GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2818,90 +1314,90 @@
               "instance": "r6a.xlarge"
             }
           ],
-          "total_annual_cost": 18529.98
+          "total_annual_cost": 17953.98
         }
       ],
       "95": [
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 26988.119999999995
+            "kafka.zonal-clusters": 15743.07
           },
           "clusters": [
             {
-              "annual_cost": 8996.039999999999,
+              "annual_cost": 5247.69,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 12,
-                  "cpu": 11,
-                  "disk_capacity": 8,
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
                   "disk_iops": 0,
-                  "memory": 12,
-                  "min_count": 8,
-                  "network": 2
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 12,
+              "count": 7,
               "deployment": "zonal",
               "instance": "i3en.large"
             },
             {
-              "annual_cost": 8996.039999999999,
+              "annual_cost": 5247.69,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 12,
-                  "cpu": 11,
-                  "disk_capacity": 8,
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
                   "disk_iops": 0,
-                  "memory": 12,
-                  "min_count": 8,
-                  "network": 2
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 12,
+              "count": 7,
               "deployment": "zonal",
               "instance": "i3en.large"
             },
             {
-              "annual_cost": 8996.039999999999,
+              "annual_cost": 5247.69,
               "cluster_params": {
                 "effective_disk_per_node_gib": 1164,
                 "kafka.copies": 2,
                 "required_nodes_by_type": {
-                  "cluster_size": 12,
-                  "cpu": 11,
-                  "disk_capacity": 8,
+                  "cluster_size": 7,
+                  "cpu": 7,
+                  "disk_capacity": 6,
                   "disk_iops": 0,
-                  "memory": 12,
-                  "min_count": 8,
-                  "network": 2
+                  "memory": 7,
+                  "min_count": 6,
+                  "network": 1
                 },
-                "resource_bottleneck": "memory"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "kafka",
-              "count": 12,
+              "count": 7,
               "deployment": "zonal",
               "instance": "i3en.large"
             }
           ],
-          "total_annual_cost": 26988.12
+          "total_annual_cost": 15743.07
         },
         {
           "annual_costs": {
-            "kafka.zonal-clusters": 34248.0
+            "kafka.zonal-clusters": 26473.98
           },
           "clusters": [
             {
-              "annual_cost": 11416.0,
+              "annual_cost": 8824.66,
               "attached_drives": [
-                "gp3 : 4500GB"
+                "gp3 : 3500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2920,12 +1416,12 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6i.2xlarge"
+              "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 11416.0,
+              "annual_cost": 8824.66,
               "attached_drives": [
-                "gp3 : 4500GB"
+                "gp3 : 3500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2944,12 +1440,12 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6i.2xlarge"
+              "instance": "r7a.xlarge"
             },
             {
-              "annual_cost": 11416.0,
+              "annual_cost": 8824.66,
               "attached_drives": [
-                "gp3 : 4500GB"
+                "gp3 : 3500GB"
               ],
               "cluster_params": {
                 "effective_disk_per_node_gib": 5200,
@@ -2968,94 +1464,45 @@
               "cluster_type": "kafka",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6i.2xlarge"
+              "instance": "r7a.xlarge"
             }
           ],
-          "total_annual_cost": 34248.0
+          "total_annual_cost": 26473.98
         }
       ]
     },
     "region": "us-east-1",
     "scenario": "kafka_100mib_throughput",
     "service_tier": 1,
-    "simulations": 16
+    "simulations": 16,
+    "snapshot_format": "seeded-scipy-cost-preserve-v1",
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
       {
         "annual_costs": {
-          "evcache.net.inter.region": 43954.583042546314,
-          "evcache.net.intra.region": 65931.87456381947,
-          "evcache.zonal-clusters": 107898.0
-        },
-        "clusters": [
-          {
-            "annual_cost": 53949.0,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 885,
-              "evcache.copies": 2,
-              "required_nodes_by_type": {
-                "cluster_size": 21,
-                "cpu": 20,
-                "disk_capacity": 1,
-                "disk_iops": 21,
-                "memory": 1,
-                "min_count": 1,
-                "network": 20
-              },
-              "resource_bottleneck": "disk_iops"
-            },
-            "cluster_type": "evcache",
-            "count": 21,
-            "deployment": "zonal",
-            "instance": "c6id.4xlarge"
-          },
-          {
-            "annual_cost": 53949.0,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 885,
-              "evcache.copies": 2,
-              "required_nodes_by_type": {
-                "cluster_size": 21,
-                "cpu": 20,
-                "disk_capacity": 1,
-                "disk_iops": 21,
-                "memory": 1,
-                "min_count": 1,
-                "network": 20
-              },
-              "resource_bottleneck": "disk_iops"
-            },
-            "cluster_type": "evcache",
-            "count": 21,
-            "deployment": "zonal",
-            "instance": "c6id.4xlarge"
-          }
-        ],
-        "total_annual_cost": 217784.46
-      }
-    ],
-    "mean": [
-      {
-        "annual_costs": {
-          "evcache.net.inter.region": 30095.029830932617,
-          "evcache.net.intra.region": 45142.544746398926,
-          "evcache.zonal-clusters": 100204.26000000001
+          "cassandra.backup.s3-standard": 19184.434642913817,
+          "cassandra.net.inter.region": 78646.77717536688,
+          "cassandra.net.intra.region": 235940.33152610064,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 108432.87
         },
         "clusters": [
           {
             "annual_cost": 50102.130000000005,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
-              "evcache.copies": 2,
+              "evcache.copies": 3,
               "required_nodes_by_type": {
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 2,
+                "disk_iops": 3,
                 "memory": 1,
                 "min_count": 2,
-                "network": 2
+                "network": 3
               },
               "resource_bottleneck": "cpu"
             },
@@ -3068,15 +1515,15 @@
             "annual_cost": 50102.130000000005,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
-              "evcache.copies": 2,
+              "evcache.copies": 3,
               "required_nodes_by_type": {
                 "cluster_size": 39,
                 "cpu": 39,
                 "disk_capacity": 2,
-                "disk_iops": 2,
+                "disk_iops": 3,
                 "memory": 1,
                 "min_count": 2,
-                "network": 2
+                "network": 3
               },
               "resource_bottleneck": "cpu"
             },
@@ -3084,482 +1531,394 @@
             "count": 39,
             "deployment": "zonal",
             "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 108432.87,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 39,
+            "deployment": "regional",
+            "instance": "c7a.4xlarge"
           }
         ],
-        "total_annual_cost": 175441.83
+        "total_annual_cost": 636770.82
       },
       {
         "annual_costs": {
-          "evcache.net.inter.region": 30095.029830932617,
-          "evcache.net.intra.region": 45142.544746398926,
-          "evcache.zonal-clusters": 113098.35999999999
+          "cassandra.backup.s3-standard": 18441.540387680056,
+          "cassandra.net.inter.region": 75766.5887735784,
+          "cassandra.net.intra.region": 227299.76632073522,
+          "cassandra.zonal-clusters": 44260.020000000004,
+          "evcache.zonal-clusters": 150306.39,
+          "nflx-java-app.regional-clusters": 105994.83
         },
         "clusters": [
           {
-            "annual_cost": 56549.17999999999,
+            "annual_cost": 50102.130000000005,
             "cluster_params": {
-              "effective_disk_per_node_gib": 186,
-              "evcache.copies": 2,
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
               "required_nodes_by_type": {
-                "cluster_size": 46,
-                "cpu": 46,
-                "disk_capacity": 3,
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
                 "disk_iops": 3,
-                "memory": 2,
-                "min_count": 3,
-                "network": 2
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
               },
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "evcache",
-            "count": 46,
+            "count": 39,
             "deployment": "zonal",
-            "instance": "c5d.2xlarge"
+            "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 56549.17999999999,
+            "annual_cost": 50102.130000000005,
             "cluster_params": {
-              "effective_disk_per_node_gib": 186,
-              "evcache.copies": 2,
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
               "required_nodes_by_type": {
-                "cluster_size": 46,
-                "cpu": 46,
-                "disk_capacity": 3,
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
                 "disk_iops": 3,
-                "memory": 2,
-                "min_count": 3,
-                "network": 2
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
               },
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "evcache",
-            "count": 46,
+            "count": 39,
             "deployment": "zonal",
-            "instance": "c5d.2xlarge"
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 50102.130000000005,
+            "cluster_params": {
+              "effective_disk_per_node_gib": 441,
+              "evcache.copies": 3,
+              "required_nodes_by_type": {
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 3,
+                "memory": 1,
+                "min_count": 2,
+                "network": 3
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "evcache",
+            "count": 39,
+            "deployment": "zonal",
+            "instance": "c6id.2xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 14753.34,
+            "cluster_params": {
+              "cassandra.compaction.min_threshold": 4,
+              "cassandra.compute_buffer_ratio": 1.38,
+              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.table.percent": 0.11,
+              "cassandra.heap.write.percent": 0.25,
+              "cassandra.keyspace.rf": 3,
+              "cassandra.storage_buffer_ratio": 3.83,
+              "effective_disk_per_node_gib": 1676,
+              "rank_penalties": {
+                "large_instance": 0.1
+              },
+              "required_nodes_by_type": {
+                "cluster_size": 2,
+                "cpu": 2,
+                "disk_capacity": 1,
+                "disk_iops": 0,
+                "memory": 1,
+                "min_count": 2,
+                "network": 1
+              },
+              "resource_bottleneck": "cpu"
+            },
+            "cluster_type": "cassandra",
+            "count": 2,
+            "deployment": "zonal",
+            "instance": "c5d.12xlarge"
+          },
+          {
+            "annual_cost": 105994.83,
+            "attached_drives": [
+              "gp2 : 20GB"
+            ],
+            "cluster_type": "dgwkv",
+            "count": 51,
+            "deployment": "regional",
+            "instance": "c6a.4xlarge"
           }
         ],
-        "total_annual_cost": 188335.93
-      }
-    ],
-    "model": "org.netflix.evcache",
-    "num_results": 3,
-    "percentiles": {
-      "5": [
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 5147.834050027946,
-            "evcache.net.intra.region": 7721.75107504192,
-            "evcache.zonal-clusters": 100204.26000000001
-          },
-          "clusters": [
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 1,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            },
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 1,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            }
-          ],
-          "total_annual_cost": 113073.85
-        },
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 5147.834050027946,
-            "evcache.net.intra.region": 7721.75107504192,
-            "evcache.zonal-clusters": 113098.35999999999
-          },
-          "clusters": [
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            },
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            }
-          ],
-          "total_annual_cost": 125967.95
-        }
-      ],
-      "50": [
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 30095.029830932617,
-            "evcache.net.intra.region": 45142.544746398926,
-            "evcache.zonal-clusters": 100204.26000000001
-          },
-          "clusters": [
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 2,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            },
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 2,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            }
-          ],
-          "total_annual_cost": 175441.83
-        },
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 30095.029830932617,
-            "evcache.net.intra.region": 45142.544746398926,
-            "evcache.zonal-clusters": 113098.35999999999
-          },
-          "clusters": [
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 3,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            },
-            {
-              "annual_cost": 56549.17999999999,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 186,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
-                  "disk_iops": 3,
-                  "memory": 2,
-                  "min_count": 3,
-                  "network": 2
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 46,
-              "deployment": "zonal",
-              "instance": "c5d.2xlarge"
-            }
-          ],
-          "total_annual_cost": 188335.93
-        }
-      ],
-      "95": [
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 58606.1107233951,
-            "evcache.net.intra.region": 87909.16608509264,
-            "evcache.zonal-clusters": 215796.0
-          },
-          "clusters": [
-            {
-              "annual_cost": 107898.0,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 885,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 42,
-                  "cpu": 20,
-                  "disk_capacity": 1,
-                  "disk_iops": 42,
-                  "memory": 1,
-                  "min_count": 1,
-                  "network": 40
-                },
-                "resource_bottleneck": "disk_iops"
-              },
-              "cluster_type": "evcache",
-              "count": 42,
-              "deployment": "zonal",
-              "instance": "c6id.4xlarge"
-            },
-            {
-              "annual_cost": 107898.0,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 885,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 42,
-                  "cpu": 20,
-                  "disk_capacity": 1,
-                  "disk_iops": 42,
-                  "memory": 1,
-                  "min_count": 1,
-                  "network": 40
-                },
-                "resource_bottleneck": "disk_iops"
-              },
-              "cluster_type": "evcache",
-              "count": 42,
-              "deployment": "zonal",
-              "instance": "c6id.4xlarge"
-            }
-          ],
-          "total_annual_cost": 362311.28
-        },
-        {
-          "annual_costs": {
-            "evcache.net.inter.region": 58606.1107233951,
-            "evcache.net.intra.region": 87909.16608509264,
-            "evcache.zonal-clusters": 261074.44
-          },
-          "clusters": [
-            {
-              "annual_cost": 130537.22,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 221,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 167,
-                  "cpu": 78,
-                  "disk_capacity": 3,
-                  "disk_iops": 167,
-                  "memory": 1,
-                  "min_count": 3,
-                  "network": 160
-                },
-                "resource_bottleneck": "disk_iops"
-              },
-              "cluster_type": "evcache",
-              "count": 167,
-              "deployment": "zonal",
-              "instance": "m6id.xlarge"
-            },
-            {
-              "annual_cost": 130537.22,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 221,
-                "evcache.copies": 2,
-                "required_nodes_by_type": {
-                  "cluster_size": 167,
-                  "cpu": 78,
-                  "disk_capacity": 3,
-                  "disk_iops": 167,
-                  "memory": 1,
-                  "min_count": 3,
-                  "network": 160
-                },
-                "resource_bottleneck": "disk_iops"
-              },
-              "cluster_type": "evcache",
-              "count": 167,
-              "deployment": "zonal",
-              "instance": "m6id.xlarge"
-            }
-          ],
-          "total_annual_cost": 407589.72
-        }
-      ]
-    },
-    "region": "us-east-1",
-    "scenario": "evcache_large_with_replication",
-    "service_tier": 1,
-    "simulations": 16
-  },
-  {
-    "least_regret": [
+        "total_annual_cost": 622069.14
+      },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 17836.397382980347,
-          "cassandra.net.inter.region": 73180.29714748263,
-          "cassandra.net.intra.region": 219540.8914424479,
-          "cassandra.zonal-clusters": 44260.020000000004,
-          "evcache.zonal-clusters": 161847.0,
+          "cassandra.backup.s3-standard": 16085.217869522095,
+          "cassandra.net.inter.region": 65774.09840002656,
+          "cassandra.net.intra.region": 197322.29520007968,
+          "cassandra.zonal-clusters": 30828.0,
+          "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 111150.0
         },
         "clusters": [
           {
-            "annual_cost": 53949.0,
+            "annual_cost": 50102.130000000005,
             "cluster_params": {
-              "effective_disk_per_node_gib": 885,
+              "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
               "required_nodes_by_type": {
-                "cluster_size": 21,
-                "cpu": 20,
-                "disk_capacity": 1,
-                "disk_iops": 21,
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
                 "memory": 1,
-                "min_count": 1,
-                "network": 20
+                "min_count": 2,
+                "network": 2
               },
-              "resource_bottleneck": "disk_iops"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "evcache",
-            "count": 21,
+            "count": 39,
             "deployment": "zonal",
-            "instance": "c6id.4xlarge"
+            "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 53949.0,
+            "annual_cost": 50102.130000000005,
             "cluster_params": {
-              "effective_disk_per_node_gib": 885,
+              "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
               "required_nodes_by_type": {
-                "cluster_size": 21,
-                "cpu": 20,
-                "disk_capacity": 1,
-                "disk_iops": 21,
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
                 "memory": 1,
-                "min_count": 1,
-                "network": 20
+                "min_count": 2,
+                "network": 2
               },
-              "resource_bottleneck": "disk_iops"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "evcache",
-            "count": 21,
+            "count": 39,
             "deployment": "zonal",
-            "instance": "c6id.4xlarge"
+            "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 53949.0,
+            "annual_cost": 50102.130000000005,
             "cluster_params": {
-              "effective_disk_per_node_gib": 885,
+              "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
               "required_nodes_by_type": {
-                "cluster_size": 21,
-                "cpu": 20,
-                "disk_capacity": 1,
-                "disk_iops": 21,
+                "cluster_size": 39,
+                "cpu": 39,
+                "disk_capacity": 2,
+                "disk_iops": 2,
                 "memory": 1,
-                "min_count": 1,
-                "network": 20
+                "min_count": 2,
+                "network": 2
               },
-              "resource_bottleneck": "disk_iops"
+              "resource_bottleneck": "cpu"
             },
             "cluster_type": "evcache",
-            "count": 21,
+            "count": 39,
             "deployment": "zonal",
-            "instance": "c6id.4xlarge"
+            "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 10276.0,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.gib": 15.0,
               "cassandra.heap.table.percent": 0.11,
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
+              "effective_disk_per_node_gib": 885,
               "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
+                "cluster_size": 4,
+                "cpu": 4,
                 "disk_capacity": 1,
                 "disk_iops": 0,
                 "memory": 1,
@@ -3569,27 +1928,24 @@
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
-            "count": 2,
+            "count": 4,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.4xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 10276.0,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.gib": 15.0,
               "cassandra.heap.table.percent": 0.11,
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
+              "effective_disk_per_node_gib": 885,
               "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
+                "cluster_size": 4,
+                "cpu": 4,
                 "disk_capacity": 1,
                 "disk_iops": 0,
                 "memory": 1,
@@ -3599,27 +1955,24 @@
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
-            "count": 2,
+            "count": 4,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.4xlarge"
           },
           {
-            "annual_cost": 14753.34,
+            "annual_cost": 10276.0,
             "cluster_params": {
               "cassandra.compaction.min_threshold": 4,
               "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
+              "cassandra.heap.gib": 15.0,
               "cassandra.heap.table.percent": 0.11,
               "cassandra.heap.write.percent": 0.25,
               "cassandra.keyspace.rf": 3,
               "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
+              "effective_disk_per_node_gib": 885,
               "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
+                "cluster_size": 4,
+                "cpu": 4,
                 "disk_capacity": 1,
                 "disk_iops": 0,
                 "memory": 1,
@@ -3629,9 +1982,9 @@
               "resource_bottleneck": "cpu"
             },
             "cluster_type": "cassandra",
-            "count": 2,
+            "count": 4,
             "deployment": "zonal",
-            "instance": "c5d.12xlarge"
+            "instance": "c6id.4xlarge"
           },
           {
             "annual_cost": 111150.0,
@@ -3644,359 +1997,7 @@
             "instance": "c6a.24xlarge"
           }
         ],
-        "total_annual_cost": 627814.61
-      },
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 21121.733657867433,
-          "cassandra.net.inter.region": 86875.88689476252,
-          "cassandra.net.intra.region": 260627.66068428755,
-          "cassandra.zonal-clusters": 44260.020000000004,
-          "evcache.zonal-clusters": 150306.39,
-          "nflx-java-app.regional-clusters": 108432.87
-        },
-        "clusters": [
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 14753.34,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c5d.12xlarge"
-          },
-          {
-            "annual_cost": 14753.34,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c5d.12xlarge"
-          },
-          {
-            "annual_cost": 14753.34,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 1676,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c5d.12xlarge"
-          },
-          {
-            "annual_cost": 108432.87,
-            "attached_drives": [
-              "gp2 : 20GB"
-            ],
-            "cluster_type": "dgwkv",
-            "count": 39,
-            "deployment": "regional",
-            "instance": "c7a.4xlarge"
-          }
-        ],
-        "total_annual_cost": 671624.56
-      },
-      {
-        "annual_costs": {
-          "cassandra.backup.s3-standard": 23155.87767324829,
-          "cassandra.net.inter.region": 95340.11403471231,
-          "cassandra.net.intra.region": 286020.34210413694,
-          "cassandra.zonal-clusters": 46243.979999999996,
-          "evcache.zonal-clusters": 150306.39,
-          "nflx-java-app.regional-clusters": 108432.87
-        },
-        "clusters": [
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 50102.130000000005,
-            "cluster_params": {
-              "effective_disk_per_node_gib": 441,
-              "evcache.copies": 3,
-              "required_nodes_by_type": {
-                "cluster_size": 39,
-                "cpu": 39,
-                "disk_capacity": 2,
-                "disk_iops": 1,
-                "memory": 1,
-                "min_count": 2,
-                "network": 1
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "evcache",
-            "count": 39,
-            "deployment": "zonal",
-            "instance": "c6id.2xlarge"
-          },
-          {
-            "annual_cost": 15414.66,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 2654,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c6id.12xlarge"
-          },
-          {
-            "annual_cost": 15414.66,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 2654,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c6id.12xlarge"
-          },
-          {
-            "annual_cost": 15414.66,
-            "cluster_params": {
-              "cassandra.compaction.min_threshold": 4,
-              "cassandra.compute_buffer_ratio": 1.38,
-              "cassandra.heap.gib": 30.0,
-              "cassandra.heap.table.percent": 0.11,
-              "cassandra.heap.write.percent": 0.25,
-              "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 3.83,
-              "effective_disk_per_node_gib": 2654,
-              "rank_penalties": {
-                "large_instance": 0.1
-              },
-              "required_nodes_by_type": {
-                "cluster_size": 2,
-                "cpu": 2,
-                "disk_capacity": 1,
-                "disk_iops": 0,
-                "memory": 1,
-                "min_count": 2,
-                "network": 2
-              },
-              "resource_bottleneck": "cpu"
-            },
-            "cluster_type": "cassandra",
-            "count": 2,
-            "deployment": "zonal",
-            "instance": "c6id.12xlarge"
-          },
-          {
-            "annual_cost": 108432.87,
-            "attached_drives": [
-              "gp2 : 20GB"
-            ],
-            "cluster_type": "dgwkv",
-            "count": 39,
-            "deployment": "regional",
-            "instance": "c7a.4xlarge"
-          }
-        ],
-        "total_annual_cost": 709499.57
+        "total_annual_cost": 571466.0
       }
     ],
     "mean": [
@@ -4359,243 +2360,76 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 14497.313357345582,
-            "cassandra.net.inter.region": 59073.25191423297,
-            "cassandra.net.intra.region": 177219.7557426989,
-            "cassandra.zonal-clusters": 29508.0,
-            "evcache.zonal-clusters": 150306.39,
-            "nflx-java-app.regional-clusters": 99299.01
-          },
-          "clusters": [
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 1,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            },
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 1,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            },
-            {
-              "annual_cost": 50102.130000000005,
-              "cluster_params": {
-                "effective_disk_per_node_gib": 441,
-                "evcache.copies": 3,
-                "required_nodes_by_type": {
-                  "cluster_size": 39,
-                  "cpu": 39,
-                  "disk_capacity": 2,
-                  "disk_iops": 1,
-                  "memory": 1,
-                  "min_count": 2,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "evcache",
-              "count": 39,
-              "deployment": "zonal",
-              "instance": "c6id.2xlarge"
-            },
-            {
-              "annual_cost": 9836.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 373,
-                "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
-                  "disk_capacity": 3,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 4,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 4,
-              "deployment": "zonal",
-              "instance": "c5d.4xlarge"
-            },
-            {
-              "annual_cost": 9836.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 373,
-                "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
-                  "disk_capacity": 3,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 4,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 4,
-              "deployment": "zonal",
-              "instance": "c5d.4xlarge"
-            },
-            {
-              "annual_cost": 9836.0,
-              "cluster_params": {
-                "cassandra.compaction.min_threshold": 4,
-                "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 15.0,
-                "cassandra.heap.table.percent": 0.11,
-                "cassandra.heap.write.percent": 0.25,
-                "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 373,
-                "required_nodes_by_type": {
-                  "cluster_size": 4,
-                  "cpu": 4,
-                  "disk_capacity": 3,
-                  "disk_iops": 0,
-                  "memory": 1,
-                  "min_count": 4,
-                  "network": 1
-                },
-                "resource_bottleneck": "cpu"
-              },
-              "cluster_type": "cassandra",
-              "count": 4,
-              "deployment": "zonal",
-              "instance": "c5d.4xlarge"
-            },
-            {
-              "annual_cost": 99299.01,
-              "attached_drives": [
-                "gp2 : 20GB"
-              ],
-              "cluster_type": "dgwkv",
-              "count": 3,
-              "deployment": "regional",
-              "instance": "c7a.48xlarge"
-            }
-          ],
-          "total_annual_cost": 529903.72
-        },
-        {
-          "annual_costs": {
-            "cassandra.backup.s3-standard": 14497.313357345582,
-            "cassandra.net.inter.region": 59073.25191423297,
-            "cassandra.net.intra.region": 177219.7557426989,
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
             "cassandra.zonal-clusters": 30828.0,
-            "evcache.zonal-clusters": 169647.53999999998,
+            "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 104049.0
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
                   "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 1,
+                  "min_count": 2,
                   "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
                   "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 1,
+                  "min_count": 2,
                   "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 186,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 46,
-                  "cpu": 46,
-                  "disk_capacity": 3,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
                   "disk_iops": 1,
-                  "memory": 2,
-                  "min_count": 3,
+                  "memory": 1,
+                  "min_count": 2,
                   "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 46,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c5d.2xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
               "annual_cost": 10276.0,
@@ -4611,7 +2445,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 2,
+                  "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4638,7 +2472,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 2,
+                  "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4665,7 +2499,7 @@
                 "required_nodes_by_type": {
                   "cluster_size": 4,
                   "cpu": 4,
-                  "disk_capacity": 2,
+                  "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
                   "min_count": 2,
@@ -4689,16 +2523,183 @@
               "instance": "c6a.2xlarge"
             }
           ],
-          "total_annual_cost": 555314.86
+          "total_annual_cost": 537454.21
+        },
+        {
+          "annual_costs": {
+            "cassandra.backup.s3-standard": 14567.10685798645,
+            "cassandra.net.inter.region": 59425.92804506421,
+            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.zonal-clusters": 37518.0,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 105150.0
+          },
+          "clusters": [
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 56549.17999999999,
+              "cluster_params": {
+                "effective_disk_per_node_gib": 186,
+                "evcache.copies": 3,
+                "required_nodes_by_type": {
+                  "cluster_size": 46,
+                  "cpu": 46,
+                  "disk_capacity": 3,
+                  "disk_iops": 1,
+                  "memory": 2,
+                  "min_count": 3,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "evcache",
+              "count": 46,
+              "deployment": "zonal",
+              "instance": "c5d.2xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 12506.0,
+              "cluster_params": {
+                "cassandra.compaction.min_threshold": 4,
+                "cassandra.compute_buffer_ratio": 1.38,
+                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.table.percent": 0.11,
+                "cassandra.heap.write.percent": 0.25,
+                "cassandra.keyspace.rf": 3,
+                "cassandra.storage_buffer_ratio": 3.83,
+                "effective_disk_per_node_gib": 1770,
+                "required_nodes_by_type": {
+                  "cluster_size": 2,
+                  "cpu": 2,
+                  "disk_capacity": 1,
+                  "disk_iops": 0,
+                  "memory": 1,
+                  "min_count": 2,
+                  "network": 1
+                },
+                "resource_bottleneck": "cpu"
+              },
+              "cluster_type": "cassandra",
+              "count": 2,
+              "deployment": "zonal",
+              "instance": "m6id.8xlarge"
+            },
+            {
+              "annual_cost": 105150.0,
+              "attached_drives": [
+                "gp2 : 20GB"
+              ],
+              "cluster_type": "dgwkv",
+              "count": 75,
+              "deployment": "regional",
+              "instance": "c7a.2xlarge"
+            }
+          ],
+          "total_annual_cost": 564586.36
         }
       ],
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 18088.365884902953,
-            "cassandra.net.inter.region": 74238.32553997636,
-            "cassandra.net.intra.region": 222714.97661992908,
-            "cassandra.zonal-clusters": 44260.020000000004,
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 30828.0,
             "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 108432.87
           },
@@ -4767,22 +2768,19 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 10276.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 885,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
+                  "cluster_size": 4,
+                  "cpu": 4,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -4792,27 +2790,24 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 2,
+              "count": 4,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 10276.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 885,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
+                  "cluster_size": 4,
+                  "cpu": 4,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -4822,27 +2817,24 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 2,
+              "count": 4,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
-              "annual_cost": 14753.34,
+              "annual_cost": 10276.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
-                "cassandra.heap.gib": 30.0,
+                "cassandra.heap.gib": 15.0,
                 "cassandra.heap.table.percent": 0.11,
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 1676,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 885,
                 "required_nodes_by_type": {
-                  "cluster_size": 2,
-                  "cpu": 2,
+                  "cluster_size": 4,
+                  "cpu": 4,
                   "disk_capacity": 1,
                   "disk_iops": 0,
                   "memory": 1,
@@ -4852,9 +2844,9 @@
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
-              "count": 2,
+              "count": 4,
               "deployment": "zonal",
-              "instance": "c5d.12xlarge"
+              "instance": "c6id.4xlarge"
             },
             {
               "annual_cost": 108432.87,
@@ -4867,14 +2859,14 @@
               "instance": "c7a.4xlarge"
             }
           ],
-          "total_annual_cost": 618040.95
+          "total_annual_cost": 593889.53
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 18088.365884902953,
-            "cassandra.net.inter.region": 74238.32553997636,
-            "cassandra.net.intra.region": 222714.97661992908,
-            "cassandra.zonal-clusters": 46243.979999999996,
+            "cassandra.backup.s3-standard": 17479.02113031006,
+            "cassandra.net.inter.region": 71710.81326901913,
+            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.zonal-clusters": 37518.0,
             "evcache.zonal-clusters": 169647.53999999998,
             "nflx-java-app.regional-clusters": 110355.0
           },
@@ -4888,7 +2880,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 3,
+                  "disk_iops": 2,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -4909,7 +2901,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 3,
+                  "disk_iops": 2,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -4930,7 +2922,7 @@
                   "cluster_size": 46,
                   "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 3,
+                  "disk_iops": 2,
                   "memory": 2,
                   "min_count": 3,
                   "network": 2
@@ -4943,7 +2935,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 12506.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -4952,10 +2944,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 1770,
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -4970,10 +2959,10 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "m6id.8xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 12506.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -4982,10 +2971,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 1770,
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -5000,10 +2986,10 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "m6id.8xlarge"
             },
             {
-              "annual_cost": 15414.66,
+              "annual_cost": 12506.0,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5012,10 +2998,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
-                "rank_penalties": {
-                  "large_instance": 0.1
-                },
+                "effective_disk_per_node_gib": 1770,
                 "required_nodes_by_type": {
                   "cluster_size": 2,
                   "cpu": 2,
@@ -5030,7 +3013,7 @@
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "c6id.12xlarge"
+              "instance": "m6id.8xlarge"
             },
             {
               "annual_cost": 110355.0,
@@ -5043,85 +3026,85 @@
               "instance": "c6a.2xlarge"
             }
           ],
-          "total_annual_cost": 641288.19
+          "total_annual_cost": 621842.81
         }
       ],
       "95": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 32689.79024523926,
-            "cassandra.net.inter.region": 134957.39939808846,
-            "cassandra.net.intra.region": 404872.19819426537,
-            "cassandra.zonal-clusters": 67924.02,
-            "evcache.zonal-clusters": 323694.0,
-            "nflx-java-app.regional-clusters": 166704.0
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 44260.020000000004,
+            "evcache.zonal-clusters": 150306.39,
+            "nflx-java-app.regional-clusters": 116270.07
           },
           "clusters": [
             {
-              "annual_cost": 107898.0,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 42,
-                  "cpu": 20,
-                  "disk_capacity": 1,
-                  "disk_iops": 42,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
                   "memory": 1,
-                  "min_count": 1,
-                  "network": 40
+                  "min_count": 2,
+                  "network": 4
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 42,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 107898.0,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 42,
-                  "cpu": 20,
-                  "disk_capacity": 1,
-                  "disk_iops": 42,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
                   "memory": 1,
-                  "min_count": 1,
-                  "network": 40
+                  "min_count": 2,
+                  "network": 4
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 42,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 107898.0,
+              "annual_cost": 50102.130000000005,
               "cluster_params": {
-                "effective_disk_per_node_gib": 885,
+                "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 42,
-                  "cpu": 20,
-                  "disk_capacity": 1,
-                  "disk_iops": 42,
+                  "cluster_size": 39,
+                  "cpu": 39,
+                  "disk_capacity": 2,
+                  "disk_iops": 4,
                   "memory": 1,
-                  "min_count": 1,
-                  "network": 40
+                  "min_count": 2,
+                  "network": 4
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 42,
+              "count": 39,
               "deployment": "zonal",
-              "instance": "c6id.4xlarge"
+              "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 22641.34,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5130,7 +3113,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
+                "effective_disk_per_node_gib": 1676,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5139,19 +3122,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6idn.12xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
-              "annual_cost": 22641.34,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5160,7 +3143,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
+                "effective_disk_per_node_gib": 1676,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5169,19 +3152,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6idn.12xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
-              "annual_cost": 22641.34,
+              "annual_cost": 14753.34,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5190,7 +3173,7 @@
                 "cassandra.heap.write.percent": 0.25,
                 "cassandra.keyspace.rf": 3,
                 "cassandra.storage_buffer_ratio": 3.83,
-                "effective_disk_per_node_gib": 2654,
+                "effective_disk_per_node_gib": 1676,
                 "rank_penalties": {
                   "large_instance": 0.1
                 },
@@ -5199,105 +3182,105 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "m6idn.12xlarge"
+              "instance": "c5d.12xlarge"
             },
             {
-              "annual_cost": 166704.0,
+              "annual_cost": 116270.07,
               "attached_drives": [
                 "gp2 : 20GB"
               ],
               "cluster_type": "dgwkv",
-              "count": 69,
+              "count": 21,
               "deployment": "regional",
-              "instance": "c5n.4xlarge"
+              "instance": "c7a.8xlarge"
             }
           ],
-          "total_annual_cost": 1130841.41
+          "total_annual_cost": 721578.8
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 32689.79024523926,
-            "cassandra.net.inter.region": 134957.39939808846,
-            "cassandra.net.intra.region": 404872.19819426537,
-            "cassandra.zonal-clusters": 87346.02,
-            "evcache.zonal-clusters": 391611.66000000003,
-            "nflx-java-app.regional-clusters": 194298.39
+            "cassandra.backup.s3-standard": 23503.92992591858,
+            "cassandra.net.inter.region": 96809.59791317582,
+            "cassandra.net.intra.region": 290428.79373952746,
+            "cassandra.zonal-clusters": 46243.979999999996,
+            "evcache.zonal-clusters": 169647.53999999998,
+            "nflx-java-app.regional-clusters": 116661.0
           },
           "clusters": [
             {
-              "annual_cost": 130537.22,
+              "annual_cost": 56549.17999999999,
               "cluster_params": {
-                "effective_disk_per_node_gib": 221,
+                "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 167,
-                  "cpu": 78,
+                  "cluster_size": 46,
+                  "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 167,
-                  "memory": 1,
+                  "disk_iops": 6,
+                  "memory": 2,
                   "min_count": 3,
-                  "network": 160
+                  "network": 5
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 167,
+              "count": 46,
               "deployment": "zonal",
-              "instance": "m6id.xlarge"
+              "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 130537.22,
+              "annual_cost": 56549.17999999999,
               "cluster_params": {
-                "effective_disk_per_node_gib": 221,
+                "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 167,
-                  "cpu": 78,
+                  "cluster_size": 46,
+                  "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 167,
-                  "memory": 1,
+                  "disk_iops": 6,
+                  "memory": 2,
                   "min_count": 3,
-                  "network": 160
+                  "network": 5
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 167,
+              "count": 46,
               "deployment": "zonal",
-              "instance": "m6id.xlarge"
+              "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 130537.22,
+              "annual_cost": 56549.17999999999,
               "cluster_params": {
-                "effective_disk_per_node_gib": 221,
+                "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
                 "required_nodes_by_type": {
-                  "cluster_size": 167,
-                  "cpu": 78,
+                  "cluster_size": 46,
+                  "cpu": 46,
                   "disk_capacity": 3,
-                  "disk_iops": 167,
-                  "memory": 1,
+                  "disk_iops": 6,
+                  "memory": 2,
                   "min_count": 3,
-                  "network": 160
+                  "network": 5
                 },
-                "resource_bottleneck": "disk_iops"
+                "resource_bottleneck": "cpu"
               },
               "cluster_type": "evcache",
-              "count": 167,
+              "count": 46,
               "deployment": "zonal",
-              "instance": "m6id.xlarge"
+              "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 29115.34,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5315,19 +3298,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r6idn.12xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
-              "annual_cost": 29115.34,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5345,19 +3328,19 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r6idn.12xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
-              "annual_cost": 29115.34,
+              "annual_cost": 15414.66,
               "cluster_params": {
                 "cassandra.compaction.min_threshold": 4,
                 "cassandra.compute_buffer_ratio": 1.38,
@@ -5375,35 +3358,37 @@
                   "cpu": 2,
                   "disk_capacity": 1,
                   "disk_iops": 0,
-                  "memory": 2,
+                  "memory": 1,
                   "min_count": 2,
-                  "network": 2
+                  "network": 1
                 },
                 "resource_bottleneck": "cpu"
               },
               "cluster_type": "cassandra",
               "count": 2,
               "deployment": "zonal",
-              "instance": "r6idn.12xlarge"
+              "instance": "c6id.12xlarge"
             },
             {
-              "annual_cost": 194298.39,
+              "annual_cost": 116661.0,
               "attached_drives": [
                 "gp2 : 20GB"
               ],
               "cluster_type": "dgwkv",
-              "count": 117,
+              "count": 111,
               "deployment": "regional",
-              "instance": "m6in.2xlarge"
+              "instance": "c6a.2xlarge"
             }
           ],
-          "total_annual_cost": 1245775.46
+          "total_annual_cost": 743294.84
         }
       ]
     },
     "region": "us-east-1",
     "scenario": "kv_with_cache",
     "service_tier": 1,
-    "simulations": 16
+    "simulations": 16,
+    "snapshot_format": "seeded-scipy-cost-preserve-v1",
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   }
 ]

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -3,10 +3,10 @@
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 405481.92149738566,
-          "cassandra.net.inter.region": 1190853.6608613518,
-          "cassandra.net.intra.region": 3572560.9825840555,
-          "cassandra.zonal-clusters": 1457600.6400000001
+          "cassandra.backup.s3-standard": 405481.92,
+          "cassandra.net.inter.region": 1190853.66,
+          "cassandra.net.intra.region": 3572560.98,
+          "cassandra.zonal-clusters": 1457600.64
         },
         "clusters": [
           {
@@ -115,10 +115,10 @@
     "mean": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 353277.0672346802,
-          "cassandra.net.inter.region": 1009641.2273436785,
-          "cassandra.net.intra.region": 3028923.6820310354,
-          "cassandra.zonal-clusters": 1478336.6400000001
+          "cassandra.backup.s3-standard": 353277.07,
+          "cassandra.net.inter.region": 1009641.23,
+          "cassandra.net.intra.region": 3028923.68,
+          "cassandra.zonal-clusters": 1478336.64
         },
         "clusters": [
           {
@@ -225,10 +225,10 @@
       },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 353277.0672346802,
-          "cassandra.net.inter.region": 1009641.2273436785,
-          "cassandra.net.intra.region": 3028923.6820310354,
-          "cassandra.zonal-clusters": 1564863.3599999999
+          "cassandra.backup.s3-standard": 353277.07,
+          "cassandra.net.inter.region": 1009641.23,
+          "cassandra.net.intra.region": 3028923.68,
+          "cassandra.zonal-clusters": 1564863.36
         },
         "clusters": [
           {
@@ -340,10 +340,10 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 233074.95698382912,
-            "cassandra.net.inter.region": 564776.7496072351,
-            "cassandra.net.intra.region": 1694330.248821705,
-            "cassandra.zonal-clusters": 1409216.6400000001
+            "cassandra.backup.s3-standard": 233074.96,
+            "cassandra.net.inter.region": 564776.75,
+            "cassandra.net.intra.region": 1694330.25,
+            "cassandra.zonal-clusters": 1409216.64
           },
           "clusters": [
             {
@@ -450,10 +450,10 @@
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 233074.95698382912,
-            "cassandra.net.inter.region": 564776.7496072351,
-            "cassandra.net.intra.region": 1694330.248821705,
-            "cassandra.zonal-clusters": 1495743.3599999999
+            "cassandra.backup.s3-standard": 233074.96,
+            "cassandra.net.inter.region": 564776.75,
+            "cassandra.net.intra.region": 1694330.25,
+            "cassandra.zonal-clusters": 1495743.36
           },
           "clusters": [
             {
@@ -562,10 +562,10 @@
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 342869.5600652009,
-            "cassandra.net.inter.region": 968024.8720495387,
-            "cassandra.net.intra.region": 2904074.616148616,
-            "cassandra.zonal-clusters": 1471424.6400000001
+            "cassandra.backup.s3-standard": 342869.56,
+            "cassandra.net.inter.region": 968024.87,
+            "cassandra.net.intra.region": 2904074.62,
+            "cassandra.zonal-clusters": 1471424.64
           },
           "clusters": [
             {
@@ -672,10 +672,10 @@
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 342869.5600652009,
-            "cassandra.net.inter.region": 968024.8720495387,
-            "cassandra.net.intra.region": 2904074.616148616,
-            "cassandra.zonal-clusters": 1557951.3599999999
+            "cassandra.backup.s3-standard": 342869.56,
+            "cassandra.net.inter.region": 968024.87,
+            "cassandra.net.intra.region": 2904074.62,
+            "cassandra.zonal-clusters": 1557951.36
           },
           "clusters": [
             {
@@ -788,17 +788,17 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
       {
         "annual_costs": {
-          "kafka.zonal-clusters": 13494.059999999998
+          "kafka.zonal-clusters": 13494.06
         },
         "clusters": [
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -819,7 +819,7 @@
             "instance": "i3en.large"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -840,7 +840,7 @@
             "instance": "i3en.large"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -867,11 +867,11 @@
     "mean": [
       {
         "annual_costs": {
-          "kafka.zonal-clusters": 13494.059999999998
+          "kafka.zonal-clusters": 13494.06
         },
         "clusters": [
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -892,7 +892,7 @@
             "instance": "i3en.large"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -913,7 +913,7 @@
             "instance": "i3en.large"
           },
           {
-            "annual_cost": 4498.0199999999995,
+            "annual_cost": 4498.02,
             "cluster_params": {
               "effective_disk_per_node_gib": 1164,
               "kafka.copies": 2,
@@ -1476,22 +1476,22 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   },
   {
     "least_regret": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 19184.434642913817,
-          "cassandra.net.inter.region": 78646.77717536688,
-          "cassandra.net.intra.region": 235940.33152610064,
-          "cassandra.zonal-clusters": 44260.020000000004,
+          "cassandra.backup.s3-standard": 19184.43,
+          "cassandra.net.inter.region": 78646.78,
+          "cassandra.net.intra.region": 235940.33,
+          "cassandra.zonal-clusters": 44260.02,
           "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 108432.87
         },
         "clusters": [
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1512,7 +1512,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1533,7 +1533,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1658,16 +1658,16 @@
       },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 18441.540387680056,
-          "cassandra.net.inter.region": 75766.5887735784,
-          "cassandra.net.intra.region": 227299.76632073522,
-          "cassandra.zonal-clusters": 44260.020000000004,
+          "cassandra.backup.s3-standard": 18441.54,
+          "cassandra.net.inter.region": 75766.59,
+          "cassandra.net.intra.region": 227299.77,
+          "cassandra.zonal-clusters": 44260.02,
           "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 105994.83
         },
         "clusters": [
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1688,7 +1688,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1709,7 +1709,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1834,16 +1834,16 @@
       },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 16085.217869522095,
-          "cassandra.net.inter.region": 65774.09840002656,
-          "cassandra.net.intra.region": 197322.29520007968,
+          "cassandra.backup.s3-standard": 16085.22,
+          "cassandra.net.inter.region": 65774.1,
+          "cassandra.net.intra.region": 197322.3,
           "cassandra.zonal-clusters": 30828.0,
           "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 111150.0
         },
         "clusters": [
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1864,7 +1864,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -1885,7 +1885,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -2003,16 +2003,16 @@
     "mean": [
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 18088.365884902953,
-          "cassandra.net.inter.region": 74238.32553997636,
-          "cassandra.net.intra.region": 222714.97661992908,
-          "cassandra.zonal-clusters": 44260.020000000004,
+          "cassandra.backup.s3-standard": 18088.37,
+          "cassandra.net.inter.region": 74238.33,
+          "cassandra.net.intra.region": 222714.98,
+          "cassandra.zonal-clusters": 44260.02,
           "evcache.zonal-clusters": 150306.39,
           "nflx-java-app.regional-clusters": 108432.87
         },
         "clusters": [
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -2033,7 +2033,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -2054,7 +2054,7 @@
             "instance": "c6id.2xlarge"
           },
           {
-            "annual_cost": 50102.130000000005,
+            "annual_cost": 50102.13,
             "cluster_params": {
               "effective_disk_per_node_gib": 441,
               "evcache.copies": 3,
@@ -2179,16 +2179,16 @@
       },
       {
         "annual_costs": {
-          "cassandra.backup.s3-standard": 18088.365884902953,
-          "cassandra.net.inter.region": 74238.32553997636,
-          "cassandra.net.intra.region": 222714.97661992908,
-          "cassandra.zonal-clusters": 46243.979999999996,
-          "evcache.zonal-clusters": 169647.53999999998,
+          "cassandra.backup.s3-standard": 18088.37,
+          "cassandra.net.inter.region": 74238.33,
+          "cassandra.net.intra.region": 222714.98,
+          "cassandra.zonal-clusters": 46243.98,
+          "evcache.zonal-clusters": 169647.54,
           "nflx-java-app.regional-clusters": 110355.0
         },
         "clusters": [
           {
-            "annual_cost": 56549.17999999999,
+            "annual_cost": 56549.18,
             "cluster_params": {
               "effective_disk_per_node_gib": 186,
               "evcache.copies": 3,
@@ -2209,7 +2209,7 @@
             "instance": "c5d.2xlarge"
           },
           {
-            "annual_cost": 56549.17999999999,
+            "annual_cost": 56549.18,
             "cluster_params": {
               "effective_disk_per_node_gib": 186,
               "evcache.copies": 3,
@@ -2230,7 +2230,7 @@
             "instance": "c5d.2xlarge"
           },
           {
-            "annual_cost": 56549.17999999999,
+            "annual_cost": 56549.18,
             "cluster_params": {
               "effective_disk_per_node_gib": 186,
               "evcache.copies": 3,
@@ -2360,16 +2360,16 @@
       "5": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 14567.10685798645,
-            "cassandra.net.inter.region": 59425.92804506421,
-            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.backup.s3-standard": 14567.11,
+            "cassandra.net.inter.region": 59425.93,
+            "cassandra.net.intra.region": 178277.78,
             "cassandra.zonal-clusters": 30828.0,
             "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 104049.0
           },
           "clusters": [
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2390,7 +2390,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2411,7 +2411,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2527,16 +2527,16 @@
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 14567.10685798645,
-            "cassandra.net.inter.region": 59425.92804506421,
-            "cassandra.net.intra.region": 178277.78413519263,
+            "cassandra.backup.s3-standard": 14567.11,
+            "cassandra.net.inter.region": 59425.93,
+            "cassandra.net.intra.region": 178277.78,
             "cassandra.zonal-clusters": 37518.0,
-            "evcache.zonal-clusters": 169647.53999999998,
+            "evcache.zonal-clusters": 169647.54,
             "nflx-java-app.regional-clusters": 105150.0
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -2557,7 +2557,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -2578,7 +2578,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -2696,16 +2696,16 @@
       "50": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 17479.02113031006,
-            "cassandra.net.inter.region": 71710.81326901913,
-            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.backup.s3-standard": 17479.02,
+            "cassandra.net.inter.region": 71710.81,
+            "cassandra.net.intra.region": 215132.44,
             "cassandra.zonal-clusters": 30828.0,
             "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 108432.87
           },
           "clusters": [
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2726,7 +2726,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2747,7 +2747,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -2863,16 +2863,16 @@
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 17479.02113031006,
-            "cassandra.net.inter.region": 71710.81326901913,
-            "cassandra.net.intra.region": 215132.43980705738,
+            "cassandra.backup.s3-standard": 17479.02,
+            "cassandra.net.inter.region": 71710.81,
+            "cassandra.net.intra.region": 215132.44,
             "cassandra.zonal-clusters": 37518.0,
-            "evcache.zonal-clusters": 169647.53999999998,
+            "evcache.zonal-clusters": 169647.54,
             "nflx-java-app.regional-clusters": 110355.0
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -2893,7 +2893,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -2914,7 +2914,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -3032,16 +3032,16 @@
       "95": [
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 23503.92992591858,
-            "cassandra.net.inter.region": 96809.59791317582,
-            "cassandra.net.intra.region": 290428.79373952746,
-            "cassandra.zonal-clusters": 44260.020000000004,
+            "cassandra.backup.s3-standard": 23503.93,
+            "cassandra.net.inter.region": 96809.6,
+            "cassandra.net.intra.region": 290428.79,
+            "cassandra.zonal-clusters": 44260.02,
             "evcache.zonal-clusters": 150306.39,
             "nflx-java-app.regional-clusters": 116270.07
           },
           "clusters": [
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -3062,7 +3062,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -3083,7 +3083,7 @@
               "instance": "c6id.2xlarge"
             },
             {
-              "annual_cost": 50102.130000000005,
+              "annual_cost": 50102.13,
               "cluster_params": {
                 "effective_disk_per_node_gib": 441,
                 "evcache.copies": 3,
@@ -3208,16 +3208,16 @@
         },
         {
           "annual_costs": {
-            "cassandra.backup.s3-standard": 23503.92992591858,
-            "cassandra.net.inter.region": 96809.59791317582,
-            "cassandra.net.intra.region": 290428.79373952746,
-            "cassandra.zonal-clusters": 46243.979999999996,
-            "evcache.zonal-clusters": 169647.53999999998,
+            "cassandra.backup.s3-standard": 23503.93,
+            "cassandra.net.inter.region": 96809.6,
+            "cassandra.net.intra.region": 290428.79,
+            "cassandra.zonal-clusters": 46243.98,
+            "evcache.zonal-clusters": 169647.54,
             "nflx-java-app.regional-clusters": 116661.0
           },
           "clusters": [
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -3238,7 +3238,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -3259,7 +3259,7 @@
               "instance": "c5d.2xlarge"
             },
             {
-              "annual_cost": 56549.17999999999,
+              "annual_cost": 56549.18,
               "cluster_params": {
                 "effective_disk_per_node_gib": 186,
                 "evcache.copies": 3,
@@ -3389,6 +3389,6 @@
     "service_tier": 1,
     "simulations": 16,
     "snapshot_format": "seeded-scipy-cost-preserve-v1",
-    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
+    "snapshot_note": "Uses the planner's seeded SciPy uncertainty sampling. When regenerating an existing snapshot, cost values are serialized to cents and values within 1% or $1 are preserved because scipy.optimize distribution fitting can produce tiny output drift across CPU/libm builds. Set SCM_BASELINE_PRESERVE_COSTS=0 for a fresh rewrite."
   }
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=("tests*", "notebooks*")),
     install_requires=[
         "pydantic>2.0",
-        "scipy",
+        # The uncertain planner regression snapshots exercise scipy.optimize
+        # distribution fitting. Keep CI on the tested optimizer behavior until
+        # the snapshot tolerance is intentionally refreshed for a newer SciPy.
+        "scipy<1.17",
         "numpy",
         "isodate",
     ],

--- a/tests/netflix/test_uncertain_regression.py
+++ b/tests/netflix/test_uncertain_regression.py
@@ -1,0 +1,160 @@
+"""Regression tests for stochastic planner snapshots."""
+
+import json
+from importlib import resources
+from typing import Any
+
+import pytest
+
+from service_capacity_modeling import tools as scm_tools
+from service_capacity_modeling.tools.capture_baseline_costs import (
+    UNCERTAIN_SCENARIOS,
+    capture_uncertain,
+)
+
+_BASELINE_HELP = (
+    "To fix: tox -e capture-baseline\nTo auto-update on commit: pre-commit install"
+)
+
+
+def load_baseline() -> dict[str, dict[str, Any]]:
+    """Load uncertain planner baselines from package resources."""
+    try:
+        baseline_file = resources.files(scm_tools).joinpath(
+            "data", "baseline_uncertain.json"
+        )
+        content = baseline_file.read_text(encoding="utf-8")
+        baselines = json.loads(content)
+        return {b["scenario"]: b for b in baselines if "scenario" in b}
+    except FileNotFoundError:
+        return {}
+
+
+@pytest.fixture(scope="session")
+def uncertain_baselines() -> dict[str, dict[str, Any]]:
+    return load_baseline()
+
+
+def _assert_cluster_matches(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str
+) -> None:
+    assert actual["cluster_type"] == expected["cluster_type"], scenario_name
+    assert actual["deployment"] == expected["deployment"], scenario_name
+    assert actual["instance"] == expected["instance"], scenario_name
+    assert actual["count"] == expected["count"], scenario_name
+    assert actual.get("attached_drives", []) == expected.get("attached_drives", []), (
+        scenario_name
+    )
+    assert actual.get("cluster_params", {}) == expected.get("cluster_params", {}), (
+        f"cluster_params drift for {scenario_name}.\n{_BASELINE_HELP}"
+    )
+    assert actual["annual_cost"] == pytest.approx(expected["annual_cost"], rel=0.01), (
+        f"cluster annual_cost drift for {scenario_name}: "
+        f"baseline=${expected['annual_cost']:,.2f}, "
+        f"actual=${actual['annual_cost']:,.2f}.\n"
+        f"{_BASELINE_HELP}"
+    )
+
+
+def _assert_candidate_matches(
+    actual: dict[str, Any], expected: dict[str, Any], scenario_name: str, label: str
+) -> None:
+    assert actual["total_annual_cost"] == pytest.approx(
+        expected["total_annual_cost"], rel=0.01
+    ), (
+        f"{label} total cost drift for {scenario_name}: "
+        f"baseline=${expected['total_annual_cost']:,.2f}, "
+        f"actual=${actual['total_annual_cost']:,.2f}.\n{_BASELINE_HELP}"
+    )
+    assert set(actual["annual_costs"].keys()) == set(expected["annual_costs"].keys()), (
+        f"{label} annual_cost keys changed for {scenario_name}: "
+        f"baseline={set(expected['annual_costs'].keys())}, "
+        f"actual={set(actual['annual_costs'].keys())}.\n{_BASELINE_HELP}"
+    )
+    for key, expected_cost in expected["annual_costs"].items():
+        assert actual["annual_costs"][key] == pytest.approx(expected_cost, rel=0.01), (
+            f"{label} annual_cost bucket '{key}' drift for {scenario_name}: "
+            f"baseline=${expected_cost:,.2f}, "
+            f"actual=${actual['annual_costs'][key]:,.2f}.\n"
+            f"{_BASELINE_HELP}"
+        )
+
+    assert len(actual["clusters"]) == len(expected["clusters"]), (
+        f"{label} cluster count drift for {scenario_name}: "
+        f"baseline={len(expected['clusters'])}, actual={len(actual['clusters'])}.\n"
+        f"{_BASELINE_HELP}"
+    )
+    for actual_cluster, expected_cluster in zip(
+        actual["clusters"], expected["clusters"]
+    ):
+        _assert_cluster_matches(actual_cluster, expected_cluster, scenario_name)
+
+
+def _assert_plan_sequence_matches(
+    actual: list[dict[str, Any]],
+    expected: list[dict[str, Any]],
+    scenario_name: str,
+    label: str,
+) -> None:
+    assert len(actual) == len(expected), (
+        f"{label} plan count drift for {scenario_name}: "
+        f"baseline={len(expected)}, actual={len(actual)}.\n{_BASELINE_HELP}"
+    )
+    for idx, (actual_plan, expected_plan) in enumerate(zip(actual, expected)):
+        _assert_candidate_matches(
+            actual_plan, expected_plan, scenario_name, f"{label}[{idx}]"
+        )
+
+
+class TestUncertainBaselineDrift:
+    @pytest.mark.parametrize("scenario_name", list(UNCERTAIN_SCENARIOS.keys()))
+    def test_uncertain_baseline_drift(
+        self,
+        scenario_name: str,
+        uncertain_baselines: dict[str, dict[str, Any]],
+    ) -> None:
+        if scenario_name not in uncertain_baselines:
+            pytest.fail(
+                "Scenario "
+                f"'{scenario_name}' not in uncertain baseline.\n{_BASELINE_HELP}"
+            )
+
+        scenario = UNCERTAIN_SCENARIOS[scenario_name]
+        baseline = uncertain_baselines[scenario_name]
+        actual = capture_uncertain(
+            model_name=scenario["model"],
+            region=scenario["region"],
+            desires=scenario["desires"],
+            extra_args=scenario["extra_args"],
+            scenario_name=scenario_name,
+            simulations=baseline["simulations"],
+            num_results=baseline["num_results"],
+        )
+
+        assert "error" not in actual, (
+            f"Unexpected error for {scenario_name}: {actual['error']}\n{_BASELINE_HELP}"
+        )
+        assert baseline["simulations"] == actual["simulations"]
+        assert baseline["num_results"] == actual["num_results"]
+
+        _assert_plan_sequence_matches(
+            actual["least_regret"],
+            baseline["least_regret"],
+            scenario_name,
+            "least_regret",
+        )
+        _assert_plan_sequence_matches(
+            actual["mean"],
+            baseline["mean"],
+            scenario_name,
+            "mean",
+        )
+
+        assert set(actual["percentiles"].keys()) == set(baseline["percentiles"].keys())
+        for percentile, expected in baseline["percentiles"].items():
+            _assert_plan_sequence_matches(
+                actual["percentiles"][percentile],
+                expected,
+                scenario_name,
+                f"percentiles[{percentile}]",
+            )

--- a/tests/netflix/test_uncertain_regression.py
+++ b/tests/netflix/test_uncertain_regression.py
@@ -16,9 +16,10 @@ from service_capacity_modeling.tools.capture_baseline_costs import (
 _BASELINE_HELP = (
     "Uncertain snapshots exercise seeded SciPy sampling. The capture tool "
     "preserves existing cost values when regenerated values are within 1% or "
-    "$1 because scipy.optimize distribution fitting can produce tiny "
-    "platform-specific float drift across CPU/libm builds. Structural changes "
-    "or meaningful cost movement should be reviewed, then refreshed with: "
+    "$1 because scipy.optimize distribution fitting can produce drift across "
+    "SciPy releases and CPU/libm builds. CI pins the tested SciPy range; widen "
+    "it only with an intentional baseline refresh. Structural changes or "
+    "meaningful cost movement should be reviewed, then refreshed with: "
     "tox -e capture-baseline\n"
     "To auto-update on commit: pre-commit install"
 )

--- a/tests/netflix/test_uncertain_regression.py
+++ b/tests/netflix/test_uncertain_regression.py
@@ -8,12 +8,19 @@ import pytest
 
 from service_capacity_modeling import tools as scm_tools
 from service_capacity_modeling.tools.capture_baseline_costs import (
+    BASELINE_UNCERTAIN_SNAPSHOT_FORMAT,
     UNCERTAIN_SCENARIOS,
     capture_uncertain,
 )
 
 _BASELINE_HELP = (
-    "To fix: tox -e capture-baseline\nTo auto-update on commit: pre-commit install"
+    "Uncertain snapshots exercise seeded SciPy sampling. The capture tool "
+    "preserves existing cost values when regenerated values are within 1% or "
+    "$1 because scipy.optimize distribution fitting can produce tiny "
+    "platform-specific float drift across CPU/libm builds. Structural changes "
+    "or meaningful cost movement should be reviewed, then refreshed with: "
+    "tox -e capture-baseline\n"
+    "To auto-update on commit: pre-commit install"
 )
 
 
@@ -136,6 +143,11 @@ class TestUncertainBaselineDrift:
         )
         assert baseline["simulations"] == actual["simulations"]
         assert baseline["num_results"] == actual["num_results"]
+        assert (
+            baseline["snapshot_format"]
+            == actual["snapshot_format"]
+            == (BASELINE_UNCERTAIN_SNAPSHOT_FORMAT)
+        )
 
         _assert_plan_sequence_matches(
             actual["least_regret"],

--- a/tox.ini
+++ b/tox.ini
@@ -87,8 +87,8 @@ commands =
     echo "Pre-commit hook installed successfully!"
 
 [testenv:capture-baseline]
-# Try compatible Python versions in order (package requires >=3.10,<3.13)
-basepython = python3.12,python3.11,python3.10
+# Canonical baseline capture runs on 3.11. CI and local pre-commit must agree.
+basepython = python3.11
 usedevelop = True
 commands =
     python -m service_capacity_modeling.tools.capture_baseline_costs

--- a/tox.ini
+++ b/tox.ini
@@ -90,5 +90,7 @@ commands =
 # Try compatible Python versions in order (package requires >=3.10,<3.13)
 basepython = python3.12,python3.11,python3.10
 usedevelop = True
+passenv =
+    SCM_BASELINE_PRESERVE_COSTS
 commands =
     python -m service_capacity_modeling.tools.capture_baseline_costs

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     pre-commit
     pylint
     pydantic>2.0
-    scipy
+    scipy<1.17
     numpy
     isodate
     setuptools


### PR DESCRIPTION
## What am I trying to do?
Capture regression baselines for uncertain planner output while avoiding the oversized explained snapshot fixture.

## Why did I do it this way?
This branch is the fixture layer on top of the explainability changes. It keeps only `baseline_uncertain.json` and the plain uncertain regression test. The explained snapshot path was removed because it creates too much churn for small changes.

## Are there any tests?
Yes.
- `tox -e capture-baseline`
- `tox -e py312 -- tests/netflix/test_uncertain_regression.py`

## How would I use the new code?
Run `tox -e capture-baseline` after intentional uncertain planner changes. The checked-in fixture remains `baseline_uncertain.json` only.