### PR TITLE
[ODS-3502] Consider Existing Writer's CPU Utilization in Aurora Capacity Recommendation

### DIFF
--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -11,6 +11,9 @@ from pydantic import Field
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import Buffer
+from service_capacity_modeling.interface import BufferComponent
+from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
@@ -30,11 +33,15 @@ from service_capacity_modeling.interface import RegionClusterCapacity
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.models import CapacityModel
+from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 
 logger = logging.getLogger(__name__)
+
+# Buffer component for P95 to provisioned headroom on existing writer CPU utilization.
+AURORA_WRITER_CPU_BUFFER = "aurora-writer-cpu"
 
 
 def _existing_writer_cpu_floor_cores(
@@ -45,6 +52,10 @@ def _existing_writer_cpu_floor_cores(
     cc = desires.current_clusters
     if not cc or not cc.regional:
         return 0
+    writer_cpu_buffer = buffer_for_components(
+        buffers=desires.buffers,
+        components=[AURORA_WRITER_CPU_BUFFER],
+    )
     best = 0
     for row in cc.regional:
         ref = row.cluster_instance
@@ -52,9 +63,9 @@ def _existing_writer_cpu_floor_cores(
         if ref is None or ref.cpu <= 0 or cpu_pct < 1.0:
             continue
         # ref.cpu * (cpu_pct/100): Number of cores on the reference writer.
-        # An extra headroom of 1.15 is added above point utilization since
-        # cpu_pct is P95.
-        load_cores_on_ref = float(ref.cpu) * (cpu_pct / 100.0) * 1.15
+        # An extra headroom of writer_cpu_buffer.ratio (defaults to 1.15) is added above
+        # point utilization since cpu_pct is P95.
+        load_cores_on_ref = float(ref.cpu) * (cpu_pct / 100.0) * writer_cpu_buffer.ratio
         need_on_candidate = normalize_cores(load_cores_on_ref, instance, ref)
         best = max(best, need_on_candidate)
     return best
@@ -85,7 +96,9 @@ def _estimate_aurora_requirement(
     # When `current_clusters` includes an existing writer, account for it as well
     # as query-pattern staffing. The latter alone may yield fewer cores than the
     # writer already needs.
-    needed_cores = max(needed_cores, _existing_writer_cpu_floor_cores(instance, desires))
+    needed_cores = max(
+        needed_cores, _existing_writer_cpu_floor_cores(instance, desires)
+    )
 
     # 20% head room for replication, backups etc.
     needed_network_mbps = simple_network_mbps(desires) * 1.2
@@ -343,6 +356,19 @@ class NflxAuroraCapacityModel(CapacityModel):
         return Platform.aurora_mysql, Platform.aurora_postgres
 
     @staticmethod
+    def default_buffers(writer_cpu_ratio: float = 1.15) -> Buffers:
+        """Headroom over observed writer CPU (P95) when sizing from current_clusters."""
+        return Buffers(
+            desired={
+                AURORA_WRITER_CPU_BUFFER: Buffer(
+                    ratio=writer_cpu_ratio,
+                    components=[BufferComponent.cpu, AURORA_WRITER_CPU_BUFFER],
+                    explanation="Headroom over observed Aurora writer CPU utilization.",
+                ),
+            },
+        )
+
+    @staticmethod
     def default_desires(
         user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
     ) -> CapacityDesires:
@@ -397,6 +423,7 @@ class NflxAuroraCapacityModel(CapacityModel):
                     low=0.05, mid=0.10, high=0.20, confidence=0.8
                 )
             ),
+            buffers=NflxAuroraCapacityModel.default_buffers(),
         )
 
 

--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -37,6 +37,29 @@ from service_capacity_modeling.models.common import sqrt_staffed_cores
 logger = logging.getLogger(__name__)
 
 
+def _existing_writer_cpu_floor_cores(
+    instance: Instance, desires: CapacityDesires
+) -> int:
+    """Minimum cores required on candidate instance from the existing
+    cluster in `desires` (`current_clusters.regional`)."""
+    cc = desires.current_clusters
+    if not cc or not cc.regional:
+        return 0
+    best = 0
+    for row in cc.regional:
+        ref = row.cluster_instance
+        cpu_pct = row.cpu_utilization.mid
+        if ref is None or ref.cpu <= 0 or cpu_pct < 1.0:
+            continue
+        # ref.cpu * (cpu_pct/100): Number of cores on the reference writer.
+        # An extra headroom of 1.15 is added above point utilization since
+        # cpu_pct is P95.
+        load_cores_on_ref = float(ref.cpu) * (cpu_pct / 100.0) * 1.15
+        need_on_candidate = normalize_cores(load_cores_on_ref, instance, ref)
+        best = max(best, need_on_candidate)
+    return best
+
+
 def _estimate_aurora_requirement(
     instance: Instance, desires: CapacityDesires, db_type: str
 ) -> CapacityRequirement:
@@ -59,7 +82,12 @@ def _estimate_aurora_requirement(
         reference_shape=desires.reference_shape,
     )
 
-    # 20% head room For replication, backups etc.
+    # When `current_clusters` includes an existing writer, account for it as well
+    # as query-pattern staffing. The latter alone may yield fewer cores than the
+    # writer already needs.
+    needed_cores = max(needed_cores, _existing_writer_cpu_floor_cores(instance, desires))
+
+    # 20% head room for replication, backups etc.
     needed_network_mbps = simple_network_mbps(desires) * 1.2
     needed_disk = round(desires.data_shape.estimated_state_size_gib.mid, 2)
 

--- a/service_capacity_modeling/models/org/netflix/postgres.py
+++ b/service_capacity_modeling/models/org/netflix/postgres.py
@@ -103,6 +103,7 @@ class NflxPostgresCapacityModel(CapacityModel):
                     low=0.05, mid=0.10, high=0.20, confidence=0.8
                 )
             ),
+            buffers=nflx_aurora_capacity_model.default_buffers(),
         )
 
 

--- a/tests/netflix/test_aurora.py
+++ b/tests/netflix/test_aurora.py
@@ -6,6 +6,8 @@ from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentRegionClusterCapacity
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
@@ -91,6 +93,38 @@ tier_3 = CapacityDesires(
         estimated_state_size_gib=certain_int(200),
     ),
 )
+
+
+def test_observed_cpu_utilization_raises_requirement_over_low_rps():
+    """Number of cores due to low RPS would have been small but higher
+    CPU% on the current writer still forces a large type."""
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=certain_int(10),
+            estimated_write_per_second=certain_int(10),
+            estimated_mean_read_latency_ms=certain_float(5.0),
+            estimated_mean_write_latency_ms=certain_float(8.0),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(20)),
+        current_clusters=CurrentClusters(
+            regional=[
+                CurrentRegionClusterCapacity(
+                    cluster_instance_name="db.r6g.4xlarge",
+                    cluster_instance_count=certain_int(1),
+                    cpu_utilization=certain_float(88.0),
+                )
+            ]
+        ),
+    )
+    cap_plan = planner.plan_certain(
+        model_name="org.netflix.aurora",
+        region="us-east-1",
+        desires=desires,
+    )
+    assert len(cap_plan) >= 1
+    resp = cap_plan[0].candidate_clusters.regional[0].instance
+    assert resp.cpu >= 16
 
 
 def test_tier_0_not_supported():


### PR DESCRIPTION
Current Aurora capacity model used query-pattern signals and this might not be enough when a writer is already running. Relying only on those signals alone can still recommend an instance that is too small for the CPU the cluster is already using.

This PR makes the model use `CapacityDesires.current_clusters` when it is present. The existing writer’s CPU utilization is also included in the regional `current_clusters` input and hence recommendations respect observed writer CPU along with the query-pattern derived load.