### PR TITLE
Relax Cassandra cluster sizing for non-critical tiers

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
+from service_capacity_modeling.enum_utils import enum_docstrings
+from service_capacity_modeling.enum_utils import StrEnum
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
@@ -77,6 +79,19 @@ BACKGROUND_BUFFER = "background"
 CRITICAL_TIERS: Set[int] = {0, 1}
 # cluster size aka nodes per ASG
 CRITICAL_TIER_MIN_CLUSTER_SIZE = 2
+
+
+@enum_docstrings
+class CassandraClusterSizeMode(StrEnum):
+    """Controls Cassandra zonal cluster count rounding."""
+
+    doubling = "doubling"
+    """Round constrained Cassandra counts by doubling from an existing non-power
+    current cluster size. New clusters still round to the next power of two.
+    required_cluster_size remains a floor and does not become the doubling base."""
+
+    unrestricted = "unrestricted"
+    """Use the raw required cluster count without Cassandra cluster-size rounding."""
 
 
 # --- CRR network and backup cost helpers ---
@@ -249,7 +264,7 @@ def _get_min_count(
         required_cluster_size or 0,
         min_nodes_for_disk,
     )
-    # Ensure that the min count is an increment of the cluster size constraint (doubling)
+    # Apply any Cassandra cluster-size constraint after the hard floor is known.
     return cluster_size_lambda(min_count)
 
 
@@ -511,15 +526,26 @@ def _get_current_capacity(desires: CapacityDesires) -> Optional[CurrentClusterCa
 
 
 def _get_cluster_size_lambda(
-    current_cluster_size: int,
-    required_cluster_size: Optional[int],
+    cluster_size_mode: CassandraClusterSizeMode = CassandraClusterSizeMode.doubling,
+    current_cluster_size: int = 0,
+    required_cluster_size: Optional[int] = None,
 ) -> Callable[[int], int]:
-    if required_cluster_size:
-        return lambda x: next_doubling(x, base=required_cluster_size)
-    elif current_cluster_size and not is_power_of_2(current_cluster_size):
+    if cluster_size_mode == CassandraClusterSizeMode.unrestricted:
+        return lambda x: x
+
+    if current_cluster_size and not is_power_of_2(current_cluster_size):
         return lambda x: next_doubling(x, base=current_cluster_size)
-    else:  # New provisionings
-        return next_power_of_2
+
+    if required_cluster_size:
+        return lambda x: x
+
+    return next_power_of_2
+
+
+def _default_cluster_size_mode(tier: int) -> CassandraClusterSizeMode:
+    if tier in CRITICAL_TIERS:
+        return CassandraClusterSizeMode.doubling
+    return CassandraClusterSizeMode.unrestricted
 
 
 def _compute_penalties(
@@ -573,6 +599,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     max_regional_size: int = 192,
     max_write_buffer_percent: float = 0.25,
     max_table_buffer_percent: float = 0.11,
+    cluster_size_mode: CassandraClusterSizeMode = CassandraClusterSizeMode.doubling,
     large_instance_regret: float = 0.2,
     different_family_regret: float = 0.10,
     max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
@@ -718,7 +745,9 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
 
     current_cluster_size = _get_current_cluster_size(desires)
     cluster_size_lambda = _get_cluster_size_lambda(
-        current_cluster_size, required_cluster_size
+        cluster_size_mode,
+        current_cluster_size=current_cluster_size,
+        required_cluster_size=required_cluster_size,
     )
     min_count = _get_min_count(
         tier=desires.service_tier,
@@ -757,7 +786,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             _cass_io_per_read(size) * math.ceil(read_io_per_sec / count),
             write_io_per_sec / count,
         ),
-        # C* clusters provision in powers of 2 because doubling
+        # Critical C* clusters grow by doubling from the current cluster size.
         cluster_size=cluster_size_lambda,
         min_count=min_count,
         reserve_memory=lambda x: x - memory_layout(x).page_cache_capacity_gib,
@@ -1119,6 +1148,15 @@ class NflxCassandraArguments(BaseModel):
         default=1.3,
         description="Compute success buffer for very large clusters (adaptive lower bound).",
     )
+    cluster_size_mode: Optional[CassandraClusterSizeMode] = Field(
+        default=None,
+        description="Optional override for zonal Cassandra cluster count rounding. "
+        "When unset, critical tiers use doubling-based counts and non-critical tiers "
+        "are unrestricted. 'doubling' rounds by repeatedly doubling from the "
+        "non-power-of-two current size, or by using the next power of two for new "
+        "clusters. It does not use required_cluster_size as the doubling base. "
+        "'unrestricted' disables cluster-size rounding for all tiers.",
+    )
 
     @model_validator(mode="after")
     def _check_storage_buffer_bounds(self) -> "NflxCassandraArguments":
@@ -1335,6 +1373,8 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             max_attached_data_per_node_gib=args.max_attached_data_per_node_gib,
             max_write_buffer_percent=max_write_buffer_percent,
             max_table_buffer_percent=max_table_buffer_percent,
+            cluster_size_mode=args.cluster_size_mode
+            or _default_cluster_size_mode(desires.service_tier),
             large_instance_regret=args.large_instance_regret,
             different_family_regret=args.different_family_regret,
             max_page_cache_gib=args.max_page_cache_gib,

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -21,6 +21,10 @@ from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.cassandra import (
+    _default_cluster_size_mode,
+    _get_cluster_size_lambda,
+    _get_min_count,
+    CassandraClusterSizeMode,
     NflxCassandraCapacityModel,
 )
 from tests.util import assert_minimum_storage_gib
@@ -559,8 +563,33 @@ class TestCassandraCurrentCapacity:
             },
         )[0]
         result = cap_plan.candidate_clusters.zonal[0]
-        # Doubles a 3 node cluster to 6
         assert result.count == 6
+
+    def test_capacity_non_power_of_two_with_doubling_mode(self):
+        cluster_capacity = CurrentZoneClusterCapacity(
+            cluster_instance_name="r5d.4xlarge",
+            cluster_instance_count=fixed_float(3),
+            cpu_utilization=certain_float(80),
+            memory_utilization_gib=certain_float(32.0),
+            disk_utilization_gib=certain_float(2048),
+            network_utilization_mbps=certain_float(128.0),
+        )
+        desires = CapacityDesires(
+            service_tier=1,
+            current_clusters=CurrentClusters(zonal=[cluster_capacity]),
+        )
+        cap_plan = planner.plan_certain(
+            model_name="org.netflix.cassandra",
+            region="us-east-1",
+            desires=desires,
+            extra_model_arguments={
+                "require_local_disks": True,
+                "cluster_size_mode": "doubling",
+            },
+        )[0]
+        result = cap_plan.candidate_clusters.zonal[0]
+        counts = result.cluster_params["required_nodes_by_type"]
+        assert counts["min_count"] == 6
 
     def test_capacity_non_power_of_two_with_required_size(self):
         cluster_capacity = CurrentZoneClusterCapacity(
@@ -584,6 +613,7 @@ class TestCassandraCurrentCapacity:
             extra_model_arguments={
                 "require_local_disks": True,
                 "required_cluster_size": 24,
+                "cluster_size_mode": "unrestricted",
             },
         )[0]
 
@@ -636,6 +666,160 @@ class TestCassandraExtraModelArguments:
                 tier, extra_model_arguments
             )
 
+    @pytest.mark.parametrize("tier", [2, 3, 4])
+    def test_non_critical_tiers_do_not_round_cluster_size(self, tier):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=_default_cluster_size_mode(tier),
+        )
+
+        assert (
+            _get_min_count(
+                tier=tier,
+                required_cluster_size=None,
+                needed_disk_gib=3,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 3
+        )
+
+    def test_cluster_size_lambda_defaults_to_doubling_mode(self):
+        cluster_size = _get_cluster_size_lambda()
+
+        assert cluster_size(3) == 4
+
+    @pytest.mark.parametrize(
+        "tier, expected_mode",
+        [
+            (0, CassandraClusterSizeMode.doubling),
+            (1, CassandraClusterSizeMode.doubling),
+            (2, CassandraClusterSizeMode.unrestricted),
+            (3, CassandraClusterSizeMode.unrestricted),
+            (4, CassandraClusterSizeMode.unrestricted),
+        ],
+    )
+    def test_default_cluster_size_mode_is_tier_based(self, tier, expected_mode):
+        assert _default_cluster_size_mode(tier) == expected_mode
+
+    @pytest.mark.parametrize("tier", [2, 3, 4])
+    def test_non_critical_tiers_do_not_round_above_required_cluster_size(self, tier):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=_default_cluster_size_mode(tier),
+        )
+
+        assert (
+            _get_min_count(
+                tier=tier,
+                required_cluster_size=5,
+                needed_disk_gib=6,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 6
+        )
+
+    @pytest.mark.parametrize("tier", [0, 1])
+    def test_critical_tiers_keep_doubling_cluster_size(self, tier):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=_default_cluster_size_mode(tier),
+        )
+
+        assert (
+            _get_min_count(
+                tier=tier,
+                required_cluster_size=None,
+                needed_disk_gib=3,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 4
+        )
+
+    @pytest.mark.parametrize("tier", [2, 3, 4])
+    def test_cluster_size_mode_can_force_doubling_for_non_critical_tiers(self, tier):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=CassandraClusterSizeMode.doubling,
+        )
+
+        assert (
+            _get_min_count(
+                tier=tier,
+                required_cluster_size=None,
+                needed_disk_gib=3,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 4
+        )
+
+    def test_cluster_size_mode_does_not_double_from_required_size(self):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=CassandraClusterSizeMode.doubling,
+            required_cluster_size=5,
+        )
+
+        assert (
+            _get_min_count(
+                tier=2,
+                required_cluster_size=5,
+                needed_disk_gib=6,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 6
+        )
+
+    def test_required_cluster_size_remains_the_min_count_floor(self):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=CassandraClusterSizeMode.doubling,
+            required_cluster_size=5,
+        )
+
+        assert (
+            _get_min_count(
+                tier=2,
+                required_cluster_size=5,
+                needed_disk_gib=4,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 5
+        )
+
+    def test_cluster_size_mode_doubles_from_current_non_power_of_two_size(self):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=CassandraClusterSizeMode.doubling,
+            current_cluster_size=6,
+        )
+
+        assert (
+            _get_min_count(
+                tier=2,
+                required_cluster_size=None,
+                needed_disk_gib=7,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 12
+        )
+
+    @pytest.mark.parametrize("tier", [0, 1])
+    def test_cluster_size_mode_can_force_unrestricted_for_critical_tiers(self, tier):
+        cluster_size = _get_cluster_size_lambda(
+            cluster_size_mode=CassandraClusterSizeMode.unrestricted,
+        )
+
+        assert (
+            _get_min_count(
+                tier=tier,
+                required_cluster_size=None,
+                needed_disk_gib=3,
+                disk_per_node_gib=1,
+                cluster_size_lambda=cluster_size,
+            )
+            == 3
+        )
+
     def test_page_cache_cap_default(self):
         from service_capacity_modeling.models.org.netflix.cassandra import (
             NflxCassandraArguments,
@@ -643,3 +827,46 @@ class TestCassandraExtraModelArguments:
 
         args = NflxCassandraArguments.from_extra_model_arguments({})
         assert args.max_page_cache_gib == 28.0
+
+    def test_cluster_size_mode_extra_argument(self):
+        from service_capacity_modeling.models.org.netflix.cassandra import (
+            NflxCassandraArguments,
+        )
+
+        assert (
+            NflxCassandraArguments.from_extra_model_arguments({}).cluster_size_mode
+            is None
+        )
+        assert (
+            NflxCassandraArguments.from_extra_model_arguments(
+                {"cluster_size_mode": "doubling"}
+            ).cluster_size_mode
+            == CassandraClusterSizeMode.doubling
+        )
+        assert (
+            NflxCassandraArguments.from_extra_model_arguments(
+                {"cluster_size_mode": "unrestricted"}
+            ).cluster_size_mode
+            == CassandraClusterSizeMode.unrestricted
+        )
+
+    def test_cluster_size_mode_schema_exposes_enum_docstrings(self):
+        from service_capacity_modeling.models.org.netflix.cassandra import (
+            NflxCassandraArguments,
+        )
+
+        schema = NflxCassandraArguments.model_json_schema()
+        cluster_size_mode = schema["$defs"]["CassandraClusterSizeMode"]
+
+        assert cluster_size_mode["oneOf"] == [
+            {
+                "const": CassandraClusterSizeMode.doubling.value,
+                "title": CassandraClusterSizeMode.doubling.name,
+                "description": CassandraClusterSizeMode.doubling.__doc__,
+            },
+            {
+                "const": CassandraClusterSizeMode.unrestricted.value,
+                "title": CassandraClusterSizeMode.unrestricted.name,
+                "description": CassandraClusterSizeMode.unrestricted.__doc__,
+            },
+        ]


### PR DESCRIPTION
## What am I trying to do?

Relax Cassandra zonal cluster-count rounding for non-critical tiers while preserving critical-tier behavior and explicit user overrides.

## Why did I do it this way?

Non-critical tiers should not be forced through the critical-tier doubling convention by default. This keeps `doubling` as the default mode for critical tiers, defaults tiers 2-4 to unrestricted counts, and still honors `cluster_size_mode` when callers pass it explicitly.

This recreates the former PR274 as a clean single-commit replacement branch after PR274 was accidentally merged into PR275.

## How did I do it?

- Added a documented `CassandraClusterSizeMode` StrEnum extra model argument.
- Chose the default cluster-size mode from service tier only when the caller did not pass a mode.
- Kept required cluster size as a floor rather than a doubling seed.
- Added tests for critical tiers, non-critical tiers, explicit overrides, and non-power-of-two current clusters.

## Are there any tests?

Yes.

```
tox -e py312 -- tests/netflix/test_cassandra_memory.py tests/netflix/test_cassandra_resource_counts.py tests/netflix/test_cassandra.py tests/test_buffers.py
tox -e capture-baseline
git diff --check
```