### PR TITLE
Support Cassandra EBS volume shrinking

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -600,6 +600,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     max_write_buffer_percent: float = 0.25,
     max_table_buffer_percent: float = 0.11,
     cluster_size_mode: CassandraClusterSizeMode = CassandraClusterSizeMode.doubling,
+    allow_ebs_volume_shrink: bool = False,
     large_instance_regret: float = 0.2,
     different_family_regret: float = 0.10,
     max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
@@ -726,6 +727,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     ebs_disk_floor = 0
     if (
         is_ebs
+        and not allow_ebs_volume_shrink
         and current_disk_utilization is not None
         and current_disk_utilization.mid > 0
     ):
@@ -1157,6 +1159,12 @@ class NflxCassandraArguments(BaseModel):
         "clusters. It does not use required_cluster_size as the doubling base. "
         "'unrestricted' disables cluster-size rounding for all tiers.",
     )
+    allow_ebs_volume_shrink: bool = Field(
+        default=False,
+        description="Allow existing Cassandra clusters on attached EBS volumes to "
+        "recommend a smaller attached volume when requirements shrink. Defaults "
+        "false to preserve the current EBS per-node disk floor.",
+    )
 
     @model_validator(mode="after")
     def _check_storage_buffer_bounds(self) -> "NflxCassandraArguments":
@@ -1375,6 +1383,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             max_table_buffer_percent=max_table_buffer_percent,
             cluster_size_mode=args.cluster_size_mode
             or _default_cluster_size_mode(desires.service_tier),
+            allow_ebs_volume_shrink=args.allow_ebs_volume_shrink,
             large_instance_regret=args.large_instance_regret,
             different_family_regret=args.different_family_regret,
             max_page_cache_gib=args.max_page_cache_gib,

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -260,6 +260,60 @@ class TestCassandraStorage:
         # constrains memory denominator → more nodes → higher total IOs
         assert 4_000 < write_ios < 16_000
 
+    def test_existing_ebs_volume_shrink_requires_extra_argument(self):
+        current_drive_size_gib = 6000
+        current_cluster = CurrentZoneClusterCapacity(
+            cluster_instance=shapes.instance("m6a.4xlarge"),
+            cluster_instance_name="m6a.4xlarge",
+            cluster_drive=simple_drive(size_gib=current_drive_size_gib),
+            cluster_instance_count=certain_int(8),
+            cluster_type="cassandra",
+            cpu_utilization=certain_float(1),
+            memory_utilization_gib=certain_float(8),
+            disk_utilization_gib=certain_float(4000),
+            network_utilization_mbps=certain_float(1),
+        )
+        desires = CapacityDesires(
+            service_tier=1,
+            current_clusters=CurrentClusters(zonal=[current_cluster]),
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(100),
+                estimated_write_per_second=certain_int(100),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(100)),
+            buffers=Buffers(
+                derived={
+                    "storage": Buffer(
+                        ratio=0.5,
+                        intent=BufferIntent.scale_down,
+                        components=[BufferComponent.storage],
+                    )
+                }
+            ),
+        )
+
+        def plan(allow_ebs_volume_shrink: bool):
+            return planner.plan_certain(
+                model_name="org.netflix.cassandra",
+                region="us-east-1",
+                desires=desires,
+                extra_model_arguments={
+                    "require_attached_disks": True,
+                    "require_local_disks": False,
+                    "cluster_size_mode": "unrestricted",
+                    "allow_ebs_volume_shrink": allow_ebs_volume_shrink,
+                },
+                instance_families=["m6a"],
+                num_results=1,
+            )[0].candidate_clusters.zonal[0]
+
+        default_result = plan(False)
+        shrink_result = plan(True)
+
+        assert default_result.attached_drives[0].size_gib >= current_drive_size_gib
+        assert shrink_result.attached_drives[0].size_gib < current_drive_size_gib
+
 
 class TestCassandraThroughput:
     """Test high throughput scenarios."""
@@ -848,6 +902,24 @@ class TestCassandraExtraModelArguments:
                 {"cluster_size_mode": "unrestricted"}
             ).cluster_size_mode
             == CassandraClusterSizeMode.unrestricted
+        )
+
+    def test_allow_ebs_volume_shrink_extra_argument(self):
+        from service_capacity_modeling.models.org.netflix.cassandra import (
+            NflxCassandraArguments,
+        )
+
+        assert (
+            NflxCassandraArguments.from_extra_model_arguments(
+                {}
+            ).allow_ebs_volume_shrink
+            is False
+        )
+        assert (
+            NflxCassandraArguments.from_extra_model_arguments(
+                {"allow_ebs_volume_shrink": True}
+            ).allow_ebs_volume_shrink
+            is True
         )
 
     def test_cluster_size_mode_schema_exposes_enum_docstrings(self):


### PR DESCRIPTION
## What am I trying to do?

Allow Cassandra recommendations for existing attached-EBS clusters to shrink the suggested per-node EBS volume size when the caller explicitly opts in.

## Why did I do it this way?

Existing EBS clusters currently floor attached volume sizing from observed per-node disk usage, which preserves current topology but blocks smaller volume recommendations for over-provisioned clusters. The new behavior is feature-flagged so default recommendations are unchanged.

## How did I do it?

- Added `allow_ebs_volume_shrink` to Cassandra `extra_model_arguments`, defaulting to `False`.
- Kept the existing EBS disk floor unless the new flag is true.
- Passed the parsed argument into zonal Cassandra sizing.
- Added tests showing the default keeps the current EBS floor and the opt-in path can recommend a smaller attached volume.

## Are there any tests?

Yes.

```
tox -e py312 -- tests/netflix/test_cassandra.py::TestCassandraStorage::test_existing_ebs_volume_shrink_requires_extra_argument tests/netflix/test_cassandra.py::TestCassandraExtraModelArguments
tox -e py312 -- tests/netflix/test_cassandra_memory.py tests/netflix/test_cassandra_resource_counts.py tests/netflix/test_cassandra.py tests/test_buffers.py
tox -e capture-baseline
git diff --check
```