### PR TITLE
feat(key-value): add kv_force_evcache flag and NflxKeyValueArguments schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ debian/*.debhelper
 # Notebooks
 notebooks/.ipynb_checkpoints/
 
+# Worktrees
+.worktrees/
+
 # Profiling
 prof
 

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -103,7 +103,8 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
         )
         force_evcache: bool = extra_model_arguments.get("kv_force_evcache", False)
         use_evcache = force_evcache or (
-            target_consistency in (
+            target_consistency
+            in (
                 AccessConsistency.eventual,
                 AccessConsistency.best_effort,
             )

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -34,7 +34,7 @@ from service_capacity_modeling.models.common import cluster_infra_cost
 class NflxKeyValueArguments(NflxJavaAppArguments):
     kv_evcache_read_write_ratio_threshold: float = Field(
         default=0.9,
-        description="Minimum read/write ratio to attach EVCache (alongside RPS threshold)",
+        description="Min read/write ratio to attach EVCache (alongside RPS threshold)",
     )
     estimated_kv_cache_hit_rate: float = Field(
         default=0.8,
@@ -42,7 +42,7 @@ class NflxKeyValueArguments(NflxJavaAppArguments):
     )
     kv_force_evcache: bool = Field(
         default=False,
-        description="Force EVCache attachment regardless of RPS or consistency thresholds",
+        description="Attach EVCache regardless of RPS or consistency thresholds",
     )
 
 

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -34,15 +34,15 @@ from service_capacity_modeling.models.common import cluster_infra_cost
 class NflxKeyValueArguments(NflxJavaAppArguments):
     kv_evcache_read_write_ratio_threshold: float = Field(
         default=0.9,
-        description="Minimum read/write ratio required to attach EVCache (alongside the RPS threshold)",
+        description="Minimum read/write ratio to attach EVCache (alongside RPS threshold)",
     )
     estimated_kv_cache_hit_rate: float = Field(
         default=0.8,
-        description="Fraction of KV reads served by EVCache, used to scale down Cassandra RPS",
+        description="Fraction of KV reads served by EVCache; scales down Cassandra RPS",
     )
     kv_force_evcache: bool = Field(
         default=False,
-        description="Force EVCache to be attached regardless of RPS or consistency thresholds",
+        description="Force EVCache attachment regardless of RPS or consistency thresholds",
     )
 
 

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -6,7 +6,10 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
+from pydantic import Field
+
 from .stateless_java import nflx_java_app_capacity_model
+from .stateless_java import NflxJavaAppArguments
 from .stateless_java import NflxJavaAppCapacityModel
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -26,6 +29,21 @@ from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models.common import cluster_infra_cost
+
+
+class NflxKeyValueArguments(NflxJavaAppArguments):
+    kv_evcache_read_write_ratio_threshold: float = Field(
+        default=0.9,
+        description="Minimum read/write ratio required to attach EVCache (alongside the RPS threshold)",
+    )
+    estimated_kv_cache_hit_rate: float = Field(
+        default=0.8,
+        description="Fraction of KV reads served by EVCache, used to scale down Cassandra RPS",
+    )
+    kv_force_evcache: bool = Field(
+        default=False,
+        description="Force EVCache to be attached regardless of RPS or consistency thresholds",
+    )
 
 
 class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
@@ -63,7 +81,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
 
     @staticmethod
     def extra_model_arguments_schema() -> Dict[str, Any]:
-        return nflx_java_app_capacity_model.extra_model_arguments_schema()
+        return NflxKeyValueArguments.model_json_schema()
 
     @staticmethod
     def compose_with(
@@ -83,12 +101,16 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
         evcache_rw_ratio_threshold: float = extra_model_arguments.get(
             "kv_evcache_read_write_ratio_threshold", 0.9
         )
-        use_evcache = target_consistency in (
-            AccessConsistency.eventual,
-            AccessConsistency.best_effort,
-        ) and (
-            rps > 250_000
-            or (rps > 100_000 and read_write_ratio > evcache_rw_ratio_threshold)
+        force_evcache: bool = extra_model_arguments.get("kv_force_evcache", False)
+        use_evcache = force_evcache or (
+            target_consistency in (
+                AccessConsistency.eventual,
+                AccessConsistency.best_effort,
+            )
+            and (
+                rps > 250_000
+                or (rps > 100_000 and read_write_ratio > evcache_rw_ratio_threshold)
+            )
         )
 
         if use_evcache:


### PR DESCRIPTION
## Summary
- Introduces `NflxKeyValueArguments(NflxJavaAppArguments)` to formally document all KV-specific `extra_model_arguments` (previously undocumented dict lookups)
- Adds `kv_force_evcache: bool` flag to bypass the RPS/consistency thresholds and always attach EVCache
- Moves `kv_evcache_read_write_ratio_threshold` and `estimated_kv_cache_hit_rate` into the schema alongside the new flag

## Motivation
Small test clusters don't hit the 100k RPS threshold, but sometimes need an EVCache cluster provisioned regardless (e.g. sprue integration test templates).

## Test plan
- [ ] `NflxKeyValueCapacityModel.extra_model_arguments_schema()` returns all 6 fields including inherited Java app ones
- [ ] `kv_force_evcache=True` with low RPS still results in EVCache being included in `compose_with`
- [ ] Default behaviour (flag absent/false) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)