### PR TITLE
Fix mutual exclusivity of IPC gain and HT in deduce_cpu_ipc_scale

### DIFF
--- a/service_capacity_modeling/tools/auto_shape.py
+++ b/service_capacity_modeling/tools/auto_shape.py
@@ -143,13 +143,17 @@ def deduce_cpu_ipc_scale(
 ) -> float:
     """
     Deduce CPU IPC scale factor from vCPU and core counts.
-    If all vCPUs are full cores (no SMT), use 1.5, otherwise 1.0.
+    Combine IPC gain and HT as independent factors:
+        - arch_ipc: per-physical core IPC compared to baseline=Skylake (IPC = 1.0)
+        - ht_factor: hyperthreading impact, 1.5 when no SMT (vcpu = cpu_cores), 1.0 when SMT (vcpu = 2x cpu_cores)
+    Both factors are always applied
     """
+    arch_ipc = 1.0
     if cpu_perf is not None and cpu_perf.ipc_scale_factor is not None:
-        return cpu_perf.ipc_scale_factor
-    if vcpu_count == cpu_cores:
-        return 1.5
-    return 1.0
+        arch_ipc = cpu_perf.ipc_scale_factor
+    ht_factor = 1.5 if vcpu_count == cpu_cores else 1.0
+
+    return arch_ipc * ht_factor
 
 
 def convert_mib_to_gib(size_mib: float) -> float:

--- a/tests/tools/test_auto_shape.py
+++ b/tests/tools/test_auto_shape.py
@@ -7,6 +7,8 @@ from service_capacity_modeling.tools.auto_shape import deduce_cpu_perf
 from service_capacity_modeling.tools.auto_shape import deduce_io_perf
 from service_capacity_modeling.tools.auto_shape import guess_iops_per_gib
 from service_capacity_modeling.tools.auto_shape import pull_family
+from service_capacity_modeling.tools.auto_shape import CPUPerformance
+from service_capacity_modeling.tools.auto_shape import deduce_cpu_ipc_scale
 from tests.tools import mock_data
 
 
@@ -85,3 +87,30 @@ def test_guess_iops_per_gib():
             assert family == "did not exist"
 
     assert guess_iops_per_gib("random shape") is None
+
+
+# Tests IPC and HT scale factors
+def test_deduce_cpu_ipc_scale_no_ht_multiplies_both_factors():
+    # no-HT (vcpu == cores): arch IPC × 1.5
+    perf = CPUPerformance(ipc_scale_factor=1.2995)  # GENOA_IPC
+    result = deduce_cpu_ipc_scale(vcpu_count=2, cpu_cores=2, cpu_perf=perf)
+    assert result == approx(1.2995 * 1.5, rel=0.01)  # ≈ 1.949
+
+
+def test_deduce_cpu_ipc_scale_ht_on_no_ht_factor():
+    # HT on (vcpu != cores): arch IPC only, ht_factor = 1.0
+    perf = CPUPerformance(ipc_scale_factor=1.15)  # MILAN_IPC
+    result = deduce_cpu_ipc_scale(vcpu_count=2, cpu_cores=1, cpu_perf=perf)
+    assert result == approx(1.15)
+
+
+def test_deduce_cpu_ipc_scale_no_perf_ht_on():
+    # no arch IPC provided, HT on: defaults to 1.0
+    result = deduce_cpu_ipc_scale(vcpu_count=2, cpu_cores=1, cpu_perf=None)
+    assert result == approx(1.0)
+
+
+def test_deduce_cpu_ipc_scale_no_perf_no_ht():
+    # no arch IPC provided, HT off: 1.0 × 1.5
+    result = deduce_cpu_ipc_scale(vcpu_count=2, cpu_cores=2, cpu_perf=None)
+    assert result == approx(1.5)


### PR DESCRIPTION
## Title
Fix auto_shape to multiply arch-ipc and no-HT factor in deduce_cpu_ipc_scale

## Problem
`deduce_cpu_ipc_scale()` in `auto_shape.py` treated architectural IPC and the
  no-HT factor as mutually exclusive due to an early return:

  When generate_missing.py passes --cpu-ipc-scale (e.g. GENOA_IPC=1.2995
  for m7a), the first branch always wins and the no-HT factor is never applied.

  _normalize_cpu() in common.py always divides by vCPU count, so
  cpu_ipc_scale must carry both factors — architectural IPC improvement AND
  the no-HT factor (1 vCPU = 1 full physical core)

## Solution
 Separate the assignment from the return so both factors always apply and return the product
  `return arch_ipc * ht_factor`
 
For HT-on instance families, there should be no change as a factor of 1.0 for HT shall be applied against the Skylake baseline.

## Testing
- Added 4 unit tests for deduce_cpu_ipc_scale covering all combinations of arch IPC present/absent × HT on/off 