### PR TITLE
fix: preserve cluster_params through exclude_unset serialization

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -55,6 +55,8 @@ EFFECTIVE_DISK_PER_NODE_GIB = "effective_disk_per_node_gib"
 
 def upsert_params(cluster: ClusterCapacity, params: Dict[str, Any]) -> None:
     """Update or set cluster parameters on any cluster type."""
+    if not params:
+        return
     cluster.cluster_params = {**cluster.cluster_params, **params}
 
 

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -55,7 +55,7 @@ EFFECTIVE_DISK_PER_NODE_GIB = "effective_disk_per_node_gib"
 
 def upsert_params(cluster: ClusterCapacity, params: Dict[str, Any]) -> None:
     """Update or set cluster parameters on any cluster type."""
-    cluster.cluster_params.update(params)
+    cluster.cluster_params = {**cluster.cluster_params, **params}
 
 
 def cluster_infra_cost(

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -678,3 +678,12 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert replica_count >= 2
         assert partitions_per_node >= 1
         assert result.count >= 2
+
+        serialized = result.model_dump(exclude_unset=True)
+        assert (
+            serialized["cluster_params"]["read-only-kv.replica_count"] == replica_count
+        )
+        assert (
+            serialized["cluster_params"]["read-only-kv.partitions_per_node"]
+            == partitions_per_node
+        )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -44,6 +44,19 @@ def test_upsert_params_marks_cluster_params_set_for_exclude_unset_serialization(
     }
 
 
+def test_upsert_params_with_empty_params_leaves_default_cluster_params_unset():
+    cluster = RegionClusterCapacity(
+        cluster_type="test",
+        count=2,
+        instance=shapes.region("us-east-1").instances["m5.2xlarge"],
+    )
+
+    upsert_params(cluster, {})
+
+    assert not cluster.cluster_params
+    assert "cluster_params" not in cluster.model_dump(exclude_unset=True)
+
+
 def test_merge_plan():
     left_requirement = CapacityRequirement(
         requirement_type="test",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,6 +24,24 @@ from service_capacity_modeling.models.common import network_services
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import RequirementFromCurrentCapacity
 from service_capacity_modeling.models.common import sqrt_staffed_cores
+from service_capacity_modeling.models.common import upsert_params
+
+
+def test_upsert_params_marks_cluster_params_set_for_exclude_unset_serialization():
+    cluster = RegionClusterCapacity(
+        cluster_type="test",
+        count=2,
+        instance=shapes.region("us-east-1").instances["m5.2xlarge"],
+    )
+
+    upsert_params(cluster, {"existing": "value"})
+    upsert_params(cluster, {"new": 1})
+
+    assert cluster.cluster_params == {"existing": "value", "new": 1}
+    assert cluster.model_dump(exclude_unset=True)["cluster_params"] == {
+        "existing": "value",
+        "new": 1,
+    }
 
 
 def test_merge_plan():


### PR DESCRIPTION
## What
`upsert_params` mutated `cluster.cluster_params` in place (`dict.update`), which does not mark the pydantic field as *set*. Since the cluster/plan models serialize with `exclude_unset=True`, attached cluster params were silently dropped on serialization (e.g. for `org.netflix.read-only-kv`). Reassign the dict so the field is marked set and survives; skip empty upserts.

## Why
Downstream consumers (e.g. the AG Cass recommendation flow) lost attached cluster params from the planner response.

## Tests
- `tests/netflix/test_read_only_kv.py`: asserts `model_dump(exclude_unset=True)` retains `cluster_params`.
- `tests/test_common.py`: upsert behavior incl. empty-upsert no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)