### PR TITLE
Fix attached drive sizing convergence

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -51,6 +51,7 @@ from service_capacity_modeling.interface import UncertainCapacityPlan
 from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
+from service_capacity_modeling.models.common import AttachedDriveSizingError
 from service_capacity_modeling.models.common import get_disk_size_gib
 from service_capacity_modeling.models.common import merge_plan
 from service_capacity_modeling.models.org import netflix
@@ -784,6 +785,31 @@ class CapacityPlanner:
             family_graph=graph,
         )
 
+    @staticmethod
+    def _capacity_plan_or_attached_drive_excuse(
+        *,
+        model: CapacityModel,
+        instance: Instance,
+        drive: Drive,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+    ) -> CapacityPlan | Excuse | None:
+        try:
+            return model.capacity_plan(
+                instance=instance,
+                drive=drive,
+                context=context,
+                desires=desires,
+                extra_model_arguments=extra_model_arguments,
+            )
+        except AttachedDriveSizingError as exc:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=str(exc),
+            )
+
     def _plan_certain(  # pylint: disable=too-many-positional-arguments
         self,
         model_name: str,
@@ -808,7 +834,8 @@ class CapacityPlanner:
         for instance, drive, context in self.generate_scenarios(
             model, region, desires, num_regions, lifecycles, instance_families, drives
         ):
-            match model.capacity_plan(
+            match self._capacity_plan_or_attached_drive_excuse(
+                model=model,
                 instance=instance,
                 drive=drive,
                 context=context,

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -51,6 +52,11 @@ logger = logging.getLogger(__name__)
 SECONDS_IN_YEAR = 31556926
 
 EFFECTIVE_DISK_PER_NODE_GIB = "effective_disk_per_node_gib"
+_ATTACHED_DRIVE_MAX_ITERATIONS = 10
+
+
+class AttachedDriveSizingError(Exception):
+    """Attached drive sizing could not find a stable node count."""
 
 
 def upsert_params(cluster: ClusterCapacity, params: Dict[str, Any]) -> None:
@@ -667,6 +673,73 @@ def _local_disk_node_counts(
     return count_disk_capacity, count_disk_iops
 
 
+class _AttachedDriveSizing(NamedTuple):
+    count_disk_capacity: int
+    count_disk_iops: int
+    drive_size_gib: int
+    read_io: float
+    write_io: float
+
+
+def _attached_drive_sizing_for_count(
+    *,
+    drive: Drive,
+    needed_disk_gib: float,
+    node_count: int,
+    required_disk_ios: Callable[[float, int], Tuple[float, float]],
+    max_size_gib: int,
+) -> _AttachedDriveSizing:
+    space_gib = max(1, math.ceil(needed_disk_gib / node_count))
+    read_io, write_io = required_disk_ios(space_gib, node_count)
+    read_io, write_io = (
+        utils.next_n(read_io, n=200),
+        utils.next_n(write_io, n=200),
+    )
+    io_gib = cloud_gib_for_io(drive, read_io + write_io, space_gib)
+    drive_size_gib = utils.next_n(max(1, io_gib, space_gib), n=100)
+
+    count_disk_capacity = 0
+    if max_size_gib > 0:
+        count_disk_capacity = max(
+            math.ceil(needed_disk_gib / max_size_gib),
+            math.ceil(node_count * drive_size_gib / max_size_gib),
+        )
+        drive_size_gib = min(drive_size_gib, int(max_size_gib))
+
+    count_disk_iops = 0
+    if (read_io + write_io) > drive.max_io_per_s:
+        count_disk_iops = math.ceil(
+            node_count * ((read_io + write_io) / drive.max_io_per_s)
+        )
+
+    return _AttachedDriveSizing(
+        count_disk_capacity=count_disk_capacity,
+        count_disk_iops=count_disk_iops,
+        drive_size_gib=drive_size_gib,
+        read_io=read_io,
+        write_io=write_io,
+    )
+
+
+def _attached_drive_node_count(
+    *,
+    preliminary_resource_count: int,
+    sizing: _AttachedDriveSizing,
+    cluster_size: Callable[[int], int],
+    min_count: int,
+) -> int:
+    return max(
+        cluster_size(
+            max(
+                preliminary_resource_count,
+                sizing.count_disk_capacity,
+                sizing.count_disk_iops,
+            )
+        ),
+        min_count,
+    )
+
+
 def _attached_drive_plan(
     *,
     drive: Drive,
@@ -680,52 +753,84 @@ def _attached_drive_plan(
     max_node_disk_gib: Callable[[Drive], int],
 ) -> Tuple[int, int, List[Drive]]:
     preliminary_resource_count = max(count_cpu, count_memory, count_network)
-    preliminary_count = max(cluster_size(preliminary_resource_count), min_count)
+    initial_count = max(cluster_size(preliminary_resource_count), min_count)
+    effective_count = initial_count
+    max_size_gib = max_node_disk_gib(drive)
+    sizing: _AttachedDriveSizing
+    growth_constraint: Optional[str] = None
 
-    space_gib = max(1, math.ceil(needed_disk_gib / preliminary_count))
-    read_io, write_io = required_disk_ios(space_gib, preliminary_count)
-    read_io, write_io = (
-        utils.next_n(read_io, n=200),
-        utils.next_n(write_io, n=200),
-    )
-    io_gib = cloud_gib_for_io(drive, read_io + write_io, space_gib)
-    ebs_gib = utils.next_n(max(1, io_gib, space_gib), n=100)
-
-    count_disk_capacity = 0
-    max_size = max_node_disk_gib(drive)
-    if max_size > 0:
-        count_disk_capacity = math.ceil(needed_disk_gib / max_size)
-    if ebs_gib > max_size > 0:
-        count_disk_capacity = max(
-            count_disk_capacity,
-            math.ceil(preliminary_count * ebs_gib / max_size),
+    for _ in range(_ATTACHED_DRIVE_MAX_ITERATIONS):
+        sizing = _attached_drive_sizing_for_count(
+            drive=drive,
+            needed_disk_gib=needed_disk_gib,
+            node_count=effective_count,
+            required_disk_ios=required_disk_ios,
+            max_size_gib=max_size_gib,
         )
-        ebs_gib = int(max_size)
-
-    effective_count = max(
-        cluster_size(max(preliminary_count, count_disk_capacity)), min_count
-    )
-    read_io, write_io = required_disk_ios(space_gib, effective_count)
-    read_io, write_io = (
-        utils.next_n(read_io, n=200),
-        utils.next_n(write_io, n=200),
-    )
-
-    count_disk_iops = 0
-    if (read_io + write_io) > drive.max_io_per_s:
-        ratio = (read_io + write_io) / drive.max_io_per_s
-        count_disk_iops = math.ceil(effective_count * ratio)
-        iops_count = max(cluster_size(count_disk_iops), min_count)
-        read_io, write_io = required_disk_ios(space_gib, iops_count)
-        read_io, write_io = (
-            utils.next_n(read_io, n=200),
-            utils.next_n(write_io, n=200),
+        next_count = _attached_drive_node_count(
+            preliminary_resource_count=preliminary_resource_count,
+            sizing=sizing,
+            cluster_size=cluster_size,
+            min_count=min_count,
         )
+        if next_count <= effective_count:
+            break
+        growth_constraint = (
+            "disk_iops"
+            if sizing.count_disk_iops >= sizing.count_disk_capacity
+            else "disk_capacity"
+        )
+        effective_count = next_count
+    else:
+        raise AttachedDriveSizingError(
+            "Attached drive sizing did not converge after "
+            f"{_ATTACHED_DRIVE_MAX_ITERATIONS} iterations"
+        )
+
+    final_count = effective_count
+    final_sizing = sizing
+    checked_counts: Set[int] = set()
+    for raw_count in range(initial_count, effective_count + 1):
+        candidate_count = max(cluster_size(raw_count), min_count)
+        if candidate_count in checked_counts or candidate_count > effective_count:
+            continue
+        checked_counts.add(candidate_count)
+        candidate_sizing = _attached_drive_sizing_for_count(
+            drive=drive,
+            needed_disk_gib=needed_disk_gib,
+            node_count=candidate_count,
+            required_disk_ios=required_disk_ios,
+            max_size_gib=max_size_gib,
+        )
+        candidate_next_count = _attached_drive_node_count(
+            preliminary_resource_count=preliminary_resource_count,
+            sizing=candidate_sizing,
+            cluster_size=cluster_size,
+            min_count=min_count,
+        )
+        if candidate_next_count <= candidate_count:
+            final_count = candidate_count
+            final_sizing = candidate_sizing
+            break
+
+    count_disk_capacity = final_sizing.count_disk_capacity
+    count_disk_iops = final_sizing.count_disk_iops
+    reported_count = _attached_drive_node_count(
+        preliminary_resource_count=preliminary_resource_count,
+        sizing=final_sizing,
+        cluster_size=cluster_size,
+        min_count=min_count,
+    )
+    if final_count > initial_count and reported_count < final_count:
+        if growth_constraint == "disk_capacity":
+            count_disk_capacity = final_count
+        else:
+            count_disk_iops = final_count
 
     attached_drive = drive.model_copy()
-    attached_drive.size_gib = ebs_gib
-    attached_drive.read_io_per_s = int(round(read_io, 2))
-    attached_drive.write_io_per_s = int(round(write_io, 2))
+    attached_drive.size_gib = final_sizing.drive_size_gib
+    attached_drive.read_io_per_s = int(round(final_sizing.read_io, 2))
+    attached_drive.write_io_per_s = int(round(final_sizing.write_io, 2))
     return count_disk_capacity, count_disk_iops, [attached_drive]
 
 

--- a/tests/test_generate_scenarios.py
+++ b/tests/test_generate_scenarios.py
@@ -9,6 +9,8 @@ from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentRegionClusterCapacity
 from service_capacity_modeling.interface import Lifecycle
 from service_capacity_modeling.interface import Platform
+from service_capacity_modeling.models import CapacityModel
+from service_capacity_modeling.models.common import AttachedDriveSizingError
 
 
 def test_generate_scenarios():
@@ -37,6 +39,29 @@ def test_generate_scenarios():
 
     # Check we got some instances
     assert len(scenarios) > 0
+
+
+def test_attached_drive_sizing_error_becomes_excuse():
+    class NonConvergingModel(CapacityModel):
+        @staticmethod
+        def capacity_plan(*_args, **_kwargs):
+            raise AttachedDriveSizingError("attached drive did not converge")
+
+    planner = CapacityPlanner()
+    planner.register_model("test.non-converging", NonConvergingModel())
+
+    explained = planner.plan_certain_explained(
+        model_name="test.non-converging",
+        region="us-east-1",
+        desires=CapacityDesires(),
+        num_results=1,
+        instance_families=["m5"],
+        drives=["gp3"],
+    )
+
+    assert explained.plans == []
+    assert explained.excuses
+    assert all("attached drive did not converge" in e.reason for e in explained.excuses)
 
 
 def test_generate_scenarios_limit_family():

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -6,6 +6,7 @@ from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import NodeCountContext
 from service_capacity_modeling.interface import NodeCountConstraint
+from service_capacity_modeling.models.common import AttachedDriveSizingError
 from service_capacity_modeling.models.common import compute_stateful_zone
 
 EBS = Drive(name="gp3", size_gib=0)
@@ -112,6 +113,134 @@ def test_attached_drive_iops_overflow_recalculates_per_node_iops():
     assert cluster.count == 2
     assert attached_drive.read_io_per_s == 600
     assert attached_drive.read_io_per_s < attached_drive.max_io_per_s
+
+
+def test_attached_drive_capacity_overflow_recalculates_per_node_ios():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=Drive(
+            name="tiny-ebs",
+            size_gib=0,
+            max_scale_size_gib=100,
+            max_scale_io_per_s=1_000,
+        ),
+        needed_cores=4,
+        needed_disk_gib=200,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        required_disk_ios=lambda size, _count: (size * 3.0, 0.0),
+        max_node_disk_gib=lambda d: int(d.max_size_gib),
+    )
+
+    attached_drive = cluster.attached_drives[0]
+    assert cluster.node_count_context is not None
+    counts = {
+        k.value: v for k, v in cluster.node_count_context.required_nodes_by_type.items()
+    }
+    assert counts["disk_capacity"] == 2
+    assert cluster.count == 2
+    assert attached_drive.size_gib == 100
+    assert attached_drive.read_io_per_s == 400
+
+
+def test_attached_drive_capacity_reports_final_recomputed_count():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=Drive(
+            name="tiny-ebs",
+            size_gib=0,
+            max_scale_size_gib=150,
+            max_scale_io_per_s=1_000,
+        ),
+        needed_cores=4,
+        needed_disk_gib=212,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        required_disk_ios=lambda size, _count: (size, 0.0),
+        max_node_disk_gib=lambda d: int(d.max_size_gib),
+    )
+
+    attached_drive = cluster.attached_drives[0]
+    assert cluster.node_count_context is not None
+    counts = {
+        k.value: v for k, v in cluster.node_count_context.required_nodes_by_type.items()
+    }
+    assert counts["disk_capacity"] == 3
+    assert cluster.count == 3
+    assert attached_drive.size_gib == 100
+    assert attached_drive.read_io_per_s == 200
+
+
+def test_gp2_attached_drive_recomputes_per_node_size_after_count_increase():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=Drive(
+            name="gp2",
+            size_gib=0,
+            max_scale_size_gib=1_000,
+        ),
+        needed_cores=4,
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        required_disk_ios=lambda _size, count: (7500 / count, 0.0),
+        max_node_disk_gib=lambda d: int(d.max_size_gib),
+    )
+
+    attached_drive = cluster.attached_drives[0]
+    assert cluster.node_count_context is not None
+    counts = {
+        k.value: v for k, v in cluster.node_count_context.required_nodes_by_type.items()
+    }
+    assert counts["disk_capacity"] == 3
+    assert cluster.count == 3
+    assert attached_drive.size_gib == 900
+    assert attached_drive.read_io_per_s == 2600
+
+
+def test_attached_drive_iops_uses_smallest_valid_recomputed_count():
+    cluster = compute_stateful_zone(
+        instance=M5_4XL,
+        drive=Drive(
+            name="tiny-ebs",
+            size_gib=0,
+            max_scale_size_gib=1_000,
+            max_scale_io_per_s=267,
+        ),
+        needed_cores=4,
+        needed_disk_gib=100,
+        needed_memory_gib=10,
+        needed_network_mbps=100,
+        required_disk_ios=lambda _size, count: (601 / count, 0.0),
+    )
+
+    attached_drive = cluster.attached_drives[0]
+    assert cluster.node_count_context is not None
+    counts = {
+        k.value: v for k, v in cluster.node_count_context.required_nodes_by_type.items()
+    }
+    assert counts["disk_iops"] == 4
+    assert cluster.count == 4
+    assert attached_drive.read_io_per_s == 200
+    assert attached_drive.read_io_per_s < attached_drive.max_io_per_s
+
+
+def test_attached_drive_iops_fails_when_sizing_never_converges():
+    with pytest.raises(AttachedDriveSizingError, match="did not converge"):
+        compute_stateful_zone(
+            instance=M5_4XL,
+            drive=Drive(
+                name="tiny-ebs",
+                size_gib=0,
+                max_scale_size_gib=1_000,
+                max_scale_io_per_s=1_000,
+            ),
+            needed_cores=4,
+            needed_disk_gib=100,
+            needed_memory_gib=10,
+            needed_network_mbps=100,
+            required_disk_ios=lambda _size, _count: (2000.0, 0.0),
+        )
 
 
 def test_write_buffer_merged_into_memory():


### PR DESCRIPTION
## What am I trying to do?

Fix attached-drive sizing so node count, per-node disk size, and per-node IOPS are recalculated until they agree. This is a fresh rewrite of PR #271 on latest `upstream/main`.

## Why did I do it this way?

The original loop direction was right, but the review found two edge cases: historical max counts could preserve transient IOPS overprovisioning, and a non-convergent loop could return stale drive IOPS. This version makes each sizing pass explicit, finds a stable upper count, tightens back to the smallest topology-valid count that still satisfies recomputed sizing, and converts attached-drive non-convergence into a planner `Excuse` instead of aborting the whole plan.

The old generated baseline diff no longer applies to current `main`; after running `tox -e capture-baseline`, no generated baseline files remain changed.

## Are there any tests?

- `tox -e py312 -- tests/test_resource_counts.py tests/test_generate_scenarios.py tests/netflix/test_cost_regression.py -k 'resource_counts or generate_scenarios or attached_drive_sizing_error or cassandra_kv_dense_ebs' -q`
- `tox -e capture-baseline`
- `tox -e pre-commit`

## How would I use the new code?

No API change. Existing callers of `compute_stateful_zone` get attached-drive plans whose returned drive size/IOPS and node-count context are based on the same converged node count.
