### PR TITLE
Support per-model instance filters

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -93,6 +93,33 @@ class _CertainResult(ExcludeUnsetModel):
     excuses: Sequence[Excuse] = []
 
 
+InstanceFamiliesByModel = Dict[str, Optional[Sequence[str]]]
+_NO_MATCHING_INSTANCE_FAMILIES = ("__no_matching_instance_families__",)
+
+
+def _instance_families_for_model(
+    model_name: str,
+    instance_families: Optional[Sequence[str]],
+    instance_families_by_model: Optional[InstanceFamiliesByModel],
+) -> Optional[Sequence[str]]:
+    if (
+        instance_families_by_model is None
+        or model_name not in instance_families_by_model
+    ):
+        return instance_families
+    model_instance_families = instance_families_by_model[model_name]
+    if model_instance_families is None:
+        return instance_families
+    if instance_families is None:
+        return model_instance_families
+
+    allowed_families = set(instance_families)
+    matching_families = [
+        family for family in model_instance_families if family in allowed_families
+    ]
+    return matching_families or _NO_MATCHING_INSTANCE_FAMILIES
+
+
 def simulate_interval(
     interval: Interval, name: str
 ) -> Callable[[int], Sequence[Interval]]:
@@ -549,6 +576,7 @@ class CapacityPlanner:
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
+        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
     ) -> Tuple[Sequence[CapacityPlan], Dict[int, Sequence[CapacityPlan]]]:
         if model_name not in self._models:
             raise ValueError(
@@ -585,6 +613,7 @@ class CapacityPlanner:
             drives,
             extra_model_arguments,
             instance_families,
+            instance_families_by_model,
             lifecycles,
             num_regions,
             num_results,
@@ -595,6 +624,7 @@ class CapacityPlanner:
             drives,
             extra_model_arguments,
             instance_families,
+            instance_families_by_model,
             lifecycles,
             num_regions,
             num_results,
@@ -610,6 +640,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
+        instance_families_by_model: Optional[InstanceFamiliesByModel],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -631,7 +662,11 @@ class CapacityPlanner:
                     num_regions=num_regions,
                     extra_model_arguments=extra_model_arguments,
                     lifecycles=lifecycles,
-                    instance_families=instance_families,
+                    instance_families=_instance_families_for_model(
+                        percentile_sub_model,
+                        instance_families,
+                        instance_families_by_model,
+                    ),
                     drives=drives,
                 )
                 if percentile_sub_result.plans:
@@ -651,6 +686,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
+        instance_families_by_model: Optional[InstanceFamiliesByModel],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -667,7 +703,11 @@ class CapacityPlanner:
                 num_regions=num_regions,
                 extra_model_arguments=extra_model_arguments,
                 lifecycles=lifecycles,
-                instance_families=instance_families,
+                instance_families=_instance_families_for_model(
+                    mean_sub_model,
+                    instance_families,
+                    instance_families_by_model,
+                ),
                 drives=drives,
             )
             if mean_sub_result.plans:
@@ -691,6 +731,7 @@ class CapacityPlanner:
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
+        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
     ) -> Sequence[CapacityPlan]:
         return self.plan_certain_explained(
             model_name=model_name,
@@ -698,6 +739,7 @@ class CapacityPlanner:
             desires=desires,
             lifecycles=lifecycles,
             instance_families=instance_families,
+            instance_families_by_model=instance_families_by_model,
             drives=drives,
             num_results=num_results,
             num_regions=num_regions,
@@ -719,6 +761,7 @@ class CapacityPlanner:
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
+        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
     ) -> ExplainedPlans:
         """Like plan_certain() but returns excuses and family graph too."""
         if model_name not in self._models:
@@ -753,7 +796,11 @@ class CapacityPlanner:
                 num_regions=num_regions,
                 extra_model_arguments=extra_model_arguments,
                 lifecycles=lifecycles,
-                instance_families=instance_families,
+                instance_families=_instance_families_for_model(
+                    sub_model,
+                    instance_families,
+                    instance_families_by_model,
+                ),
                 drives=drives,
                 planner_arguments=pargs,
             )
@@ -1102,6 +1149,7 @@ class CapacityPlanner:
         explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
+        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
@@ -1147,7 +1195,11 @@ class CapacityPlanner:
                     num_regions=num_regions,
                     extra_model_arguments=extra_model_arguments,
                     lifecycles=lifecycles,
-                    instance_families=instance_families,
+                    instance_families=_instance_families_for_model(
+                        sub_model,
+                        instance_families,
+                        instance_families_by_model,
+                    ),
                     drives=drives,
                     planner_arguments=pargs,
                 )
@@ -1212,6 +1264,7 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
             num_regions=num_regions,
             instance_families=instance_families,
+            instance_families_by_model=instance_families_by_model,
         )
 
         result = UncertainCapacityPlan(

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -56,6 +56,7 @@ from service_capacity_modeling.models.common import merge_plan
 from service_capacity_modeling.models.org import netflix
 from service_capacity_modeling.models.utils import compute_excuse_tags
 from service_capacity_modeling.models.utils import current_instance_name
+from service_capacity_modeling.models.utils import resolve_instance_family_allowlist
 from service_capacity_modeling.models.utils import reduce_by_family
 from service_capacity_modeling.stats import dist_for_interval
 from service_capacity_modeling.stats import interval_percentile
@@ -352,62 +353,6 @@ def _allow_instance(
     return True
 
 
-def _normalize_instance_families(
-    instance_families: Optional[Sequence[str]],
-) -> Optional[Sequence[str]]:
-    return instance_families if instance_families else None
-
-
-def _ordered_union_instance_families(
-    *instance_family_filters: Optional[Sequence[str]],
-) -> Optional[Sequence[str]]:
-    instance_families = []
-    seen = set()
-    for instance_family_filter in instance_family_filters:
-        for instance_family in instance_family_filter or ():
-            if instance_family in seen:
-                continue
-            instance_families.append(instance_family)
-            seen.add(instance_family)
-    return instance_families or None
-
-
-def _instance_families_for_model(
-    model_name: str,
-    instance_families: Optional[Sequence[str]],
-    instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
-) -> Optional[Sequence[str]]:
-    """Return the effective instance allowlist for one composed model layer.
-
-    The planner has two instance-family inputs:
-
-    - ``instance_families`` is the existing request-wide filter. It applies to
-      every model layer.
-    - ``instance_families_by_model`` is keyed by capacity model name. A missing
-      key, ``None``, or an empty sequence adds no model-specific candidates.
-      A non-empty entry is unioned with the request-wide filter for that model.
-
-    Returns:
-        ``None`` when no explicit instance filter applies. Otherwise an
-        ordered, de-duplicated allowlist of instance names or families that is
-        safe to pass to ``_plan_certain``. Request-wide entries keep their
-        order, followed by any model-scoped entries not already present.
-    """
-    global_instance_families = _normalize_instance_families(instance_families)
-    if (
-        instance_families_by_model is None
-        or model_name not in instance_families_by_model
-    ):
-        return global_instance_families
-
-    model_instance_families = _normalize_instance_families(
-        instance_families_by_model[model_name]
-    )
-    return _ordered_union_instance_families(
-        global_instance_families, model_instance_families
-    )
-
-
 def _allow_drive(
     drive: Drive,
     allowed_names: Sequence[str],
@@ -683,7 +628,7 @@ class CapacityPlanner:
             for percentile_sub_model, percentile_sub_desire in model_percentile_desires[
                 index
             ].items():
-                percentile_sub_instance_families = _instance_families_for_model(
+                percentile_sub_instance_families = resolve_instance_family_allowlist(
                     percentile_sub_model,
                     instance_families,
                     instance_families_by_model,
@@ -726,7 +671,7 @@ class CapacityPlanner:
     ) -> Sequence[CapacityPlan]:
         mean_plans = []
         for mean_sub_model, mean_sub_desire in model_mean_desires.items():
-            mean_sub_instance_families = _instance_families_for_model(
+            mean_sub_instance_families = resolve_instance_family_allowlist(
                 mean_sub_model,
                 instance_families,
                 instance_families_by_model,
@@ -821,7 +766,7 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
-            sub_instance_families = _instance_families_for_model(
+            sub_instance_families = resolve_instance_family_allowlist(
                 sub_model,
                 instance_families,
                 instance_families_by_model,
@@ -1218,7 +1163,7 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
-            sub_instance_families = _instance_families_for_model(
+            sub_instance_families = resolve_instance_family_allowlist(
                 sub_model,
                 instance_families,
                 instance_families_by_model,

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -93,33 +93,6 @@ class _CertainResult(ExcludeUnsetModel):
     excuses: Sequence[Excuse] = []
 
 
-InstanceFamiliesByModel = Dict[str, Optional[Sequence[str]]]
-_NO_MATCHING_INSTANCE_FAMILIES = ("__no_matching_instance_families__",)
-
-
-def _instance_families_for_model(
-    model_name: str,
-    instance_families: Optional[Sequence[str]],
-    instance_families_by_model: Optional[InstanceFamiliesByModel],
-) -> Optional[Sequence[str]]:
-    if (
-        instance_families_by_model is None
-        or model_name not in instance_families_by_model
-    ):
-        return instance_families
-    model_instance_families = instance_families_by_model[model_name]
-    if model_instance_families is None:
-        return instance_families
-    if instance_families is None:
-        return model_instance_families
-
-    allowed_families = set(instance_families)
-    matching_families = [
-        family for family in model_instance_families if family in allowed_families
-    ]
-    return matching_families or _NO_MATCHING_INSTANCE_FAMILIES
-
-
 def simulate_interval(
     interval: Interval, name: str
 ) -> Callable[[int], Sequence[Interval]]:
@@ -379,6 +352,62 @@ def _allow_instance(
     return True
 
 
+def _normalize_instance_families(
+    instance_families: Optional[Sequence[str]],
+) -> Optional[Sequence[str]]:
+    return instance_families if instance_families else None
+
+
+def _ordered_union_instance_families(
+    *instance_family_filters: Optional[Sequence[str]],
+) -> Optional[Sequence[str]]:
+    instance_families = []
+    seen = set()
+    for instance_family_filter in instance_family_filters:
+        for instance_family in instance_family_filter or ():
+            if instance_family in seen:
+                continue
+            instance_families.append(instance_family)
+            seen.add(instance_family)
+    return instance_families or None
+
+
+def _instance_families_for_model(
+    model_name: str,
+    instance_families: Optional[Sequence[str]],
+    instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
+) -> Optional[Sequence[str]]:
+    """Return the effective instance allowlist for one composed model layer.
+
+    The planner has two instance-family inputs:
+
+    - ``instance_families`` is the existing request-wide filter. It applies to
+      every model layer.
+    - ``instance_families_by_model`` is keyed by capacity model name. A missing
+      key, ``None``, or an empty sequence adds no model-specific candidates.
+      A non-empty entry is unioned with the request-wide filter for that model.
+
+    Returns:
+        ``None`` when no explicit instance filter applies. Otherwise an
+        ordered, de-duplicated allowlist of instance names or families that is
+        safe to pass to ``_plan_certain``. Request-wide entries keep their
+        order, followed by any model-scoped entries not already present.
+    """
+    global_instance_families = _normalize_instance_families(instance_families)
+    if (
+        instance_families_by_model is None
+        or model_name not in instance_families_by_model
+    ):
+        return global_instance_families
+
+    model_instance_families = _normalize_instance_families(
+        instance_families_by_model[model_name]
+    )
+    return _ordered_union_instance_families(
+        global_instance_families, model_instance_families
+    )
+
+
 def _allow_drive(
     drive: Drive,
     allowed_names: Sequence[str],
@@ -576,7 +605,7 @@ class CapacityPlanner:
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
-        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> Tuple[Sequence[CapacityPlan], Dict[int, Sequence[CapacityPlan]]]:
         if model_name not in self._models:
             raise ValueError(
@@ -640,7 +669,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
-        instance_families_by_model: Optional[InstanceFamiliesByModel],
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -650,10 +679,16 @@ class CapacityPlanner:
     ) -> Dict[int, Sequence[CapacityPlan]]:
         percentile_plans = {}
         for index, percentile in enumerate(sorted_percentiles):
-            percentile_plan = []
+            percentile_plan: List[Sequence[CapacityPlan]] = []
             for percentile_sub_model, percentile_sub_desire in model_percentile_desires[
                 index
             ].items():
+                percentile_sub_instance_families = _instance_families_for_model(
+                    percentile_sub_model,
+                    instance_families,
+                    instance_families_by_model,
+                )
+
                 percentile_sub_result = self._plan_certain(
                     model_name=percentile_sub_model,
                     region=region,
@@ -662,11 +697,7 @@ class CapacityPlanner:
                     num_regions=num_regions,
                     extra_model_arguments=extra_model_arguments,
                     lifecycles=lifecycles,
-                    instance_families=_instance_families_for_model(
-                        percentile_sub_model,
-                        instance_families,
-                        instance_families_by_model,
-                    ),
+                    instance_families=percentile_sub_instance_families,
                     drives=drives,
                 )
                 if percentile_sub_result.plans:
@@ -686,7 +717,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
-        instance_families_by_model: Optional[InstanceFamiliesByModel],
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -695,6 +726,12 @@ class CapacityPlanner:
     ) -> Sequence[CapacityPlan]:
         mean_plans = []
         for mean_sub_model, mean_sub_desire in model_mean_desires.items():
+            mean_sub_instance_families = _instance_families_for_model(
+                mean_sub_model,
+                instance_families,
+                instance_families_by_model,
+            )
+
             mean_sub_result = self._plan_certain(
                 model_name=mean_sub_model,
                 region=region,
@@ -703,11 +740,7 @@ class CapacityPlanner:
                 num_regions=num_regions,
                 extra_model_arguments=extra_model_arguments,
                 lifecycles=lifecycles,
-                instance_families=_instance_families_for_model(
-                    mean_sub_model,
-                    instance_families,
-                    instance_families_by_model,
-                ),
+                instance_families=mean_sub_instance_families,
                 drives=drives,
             )
             if mean_sub_result.plans:
@@ -731,7 +764,7 @@ class CapacityPlanner:
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> Sequence[CapacityPlan]:
         return self.plan_certain_explained(
             model_name=model_name,
@@ -761,7 +794,7 @@ class CapacityPlanner:
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> ExplainedPlans:
         """Like plan_certain() but returns excuses and family graph too."""
         if model_name not in self._models:
@@ -788,6 +821,12 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
+            sub_instance_families = _instance_families_for_model(
+                sub_model,
+                instance_families,
+                instance_families_by_model,
+            )
+
             sub_result = self._plan_certain(
                 model_name=sub_model,
                 region=region,
@@ -796,11 +835,7 @@ class CapacityPlanner:
                 num_regions=num_regions,
                 extra_model_arguments=extra_model_arguments,
                 lifecycles=lifecycles,
-                instance_families=_instance_families_for_model(
-                    sub_model,
-                    instance_families,
-                    instance_families_by_model,
-                ),
+                instance_families=sub_instance_families,
                 drives=drives,
                 planner_arguments=pargs,
             )
@@ -1149,7 +1184,7 @@ class CapacityPlanner:
         explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[InstanceFamiliesByModel] = None,
+        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
@@ -1183,6 +1218,12 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
+            sub_instance_families = _instance_families_for_model(
+                sub_model,
+                instance_families,
+                instance_families_by_model,
+            )
+
             desires_by_model[sub_model] = sub_desires
             model_plans: List[Tuple[CapacityDesires, Sequence[CapacityPlan]]] = []
             model_excuses: List[Excuse] = []
@@ -1195,11 +1236,7 @@ class CapacityPlanner:
                     num_regions=num_regions,
                     extra_model_arguments=extra_model_arguments,
                     lifecycles=lifecycles,
-                    instance_families=_instance_families_for_model(
-                        sub_model,
-                        instance_families,
-                        instance_families_by_model,
-                    ),
+                    instance_families=sub_instance_families,
                     drives=drives,
                     planner_arguments=pargs,
                 )

--- a/service_capacity_modeling/models/utils.py
+++ b/service_capacity_modeling/models/utils.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 
 from service_capacity_modeling.interface import CapacityDesires
@@ -98,6 +99,38 @@ def reduce_by_family(
             regional_families[regional_type] = regional_count + 1
 
     return result
+
+
+def resolve_instance_family_allowlist(
+    model_name: str,
+    instance_families: Optional[Sequence[str]],
+    instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
+) -> Optional[Sequence[str]]:
+    """Resolve the instance-family allowlist for one model in a composed plan.
+
+    ``instance_families`` is the request-wide filter. It applies to every model.
+    ``instance_families_by_model`` is an additive per-model filter. When both
+    inputs contain values for ``model_name``, the effective filter is their
+    ordered union.
+
+    Returns:
+        ``None`` when neither input provides candidates. Otherwise, a
+        de-duplicated allowlist with request-wide candidates first, followed by
+        new per-model candidates.
+    """
+    model_instance_families = (
+        instance_families_by_model.get(model_name)
+        if instance_families_by_model is not None
+        else None
+    )
+    return (
+        list(
+            dict.fromkeys(
+                [*(instance_families or ()), *(model_instance_families or ())]
+            )
+        )
+        or None
+    )
 
 
 # https://stackoverflow.com/questions/14267555/find-the-smallest-power-of-2-greater-than-or-equal-to-n-in-python

--- a/tests/test_model_scoped_instance_filters.py
+++ b/tests/test_model_scoped_instance_filters.py
@@ -3,8 +3,8 @@ from typing import Any
 from typing import Sequence
 
 from service_capacity_modeling import capacity_planner
-from service_capacity_modeling.capacity_planner import _NO_MATCHING_INSTANCE_FAMILIES
 from service_capacity_modeling.capacity_planner import _CertainResult
+from service_capacity_modeling.capacity_planner import _instance_families_for_model
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import CapacityDesires
@@ -92,7 +92,7 @@ def test_plan_certain_forwards_model_scoped_instance_filters(monkeypatch):
     }
 
 
-def test_model_scoped_instance_filters_narrow_global_filters(monkeypatch):
+def test_model_scoped_instance_filters_union_with_global_filters(monkeypatch):
     calls = _record_plan_certain_calls(monkeypatch)
 
     planner.plan_certain_explained(
@@ -107,11 +107,37 @@ def test_model_scoped_instance_filters_narrow_global_filters(monkeypatch):
     assert _filters_by_model(calls) == {
         "org.netflix.key-value": ["m6id", "i4i"],
         "org.netflix.evcache": ["m6id", "i4i"],
-        "org.netflix.cassandra": ["i4i"],
+        "org.netflix.cassandra": ["m6id", "i4i", "i7i"],
     }
 
 
-def test_disjoint_model_scoped_and_global_filters_match_no_instances(monkeypatch):
+def test_instance_families_for_model_contract():
+    assert (
+        _instance_families_for_model(
+            "org.netflix.cassandra",
+            None,
+            None,
+        )
+        is None
+    )
+    assert _instance_families_for_model(
+        "org.netflix.cassandra",
+        ["m6id"],
+        {"org.netflix.cassandra": None},
+    ) == ["m6id"]
+    assert _instance_families_for_model(
+        "org.netflix.cassandra",
+        ["m6id", "i4i"],
+        {"org.netflix.cassandra": ["i4i", "i7i"]},
+    ) == ["m6id", "i4i", "i7i"]
+    assert _instance_families_for_model(
+        "org.netflix.cassandra",
+        ["m6id"],
+        {"org.netflix.cassandra": ["i4i"]},
+    ) == ["m6id", "i4i"]
+
+
+def test_model_scoped_instance_filters_add_to_disjoint_global_filters(monkeypatch):
     calls = _record_plan_certain_calls(monkeypatch)
 
     planner.plan_certain_explained(
@@ -126,7 +152,7 @@ def test_disjoint_model_scoped_and_global_filters_match_no_instances(monkeypatch
     assert _filters_by_model(calls) == {
         "org.netflix.key-value": ["m6id"],
         "org.netflix.evcache": ["m6id"],
-        "org.netflix.cassandra": _NO_MATCHING_INSTANCE_FAMILIES,
+        "org.netflix.cassandra": ["m6id", "i4i"],
     }
 
 

--- a/tests/test_model_scoped_instance_filters.py
+++ b/tests/test_model_scoped_instance_filters.py
@@ -4,7 +4,6 @@ from typing import Sequence
 
 from service_capacity_modeling import capacity_planner
 from service_capacity_modeling.capacity_planner import _CertainResult
-from service_capacity_modeling.capacity_planner import _instance_families_for_model
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import CapacityDesires
@@ -14,6 +13,7 @@ from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.models.utils import resolve_instance_family_allowlist
 
 
 def _kv_desires() -> CapacityDesires:
@@ -111,26 +111,26 @@ def test_model_scoped_instance_filters_union_with_global_filters(monkeypatch):
     }
 
 
-def test_instance_families_for_model_contract():
+def test_resolve_instance_family_allowlist_combines_request_and_model_filters():
     assert (
-        _instance_families_for_model(
+        resolve_instance_family_allowlist(
             "org.netflix.cassandra",
             None,
             None,
         )
         is None
     )
-    assert _instance_families_for_model(
+    assert resolve_instance_family_allowlist(
         "org.netflix.cassandra",
         ["m6id"],
         {"org.netflix.cassandra": None},
     ) == ["m6id"]
-    assert _instance_families_for_model(
+    assert resolve_instance_family_allowlist(
         "org.netflix.cassandra",
         ["m6id", "i4i"],
         {"org.netflix.cassandra": ["i4i", "i7i"]},
     ) == ["m6id", "i4i", "i7i"]
-    assert _instance_families_for_model(
+    assert resolve_instance_family_allowlist(
         "org.netflix.cassandra",
         ["m6id"],
         {"org.netflix.cassandra": ["i4i"]},

--- a/tests/test_model_scoped_instance_filters.py
+++ b/tests/test_model_scoped_instance_filters.py
@@ -1,0 +1,183 @@
+# pylint: disable=protected-access
+from typing import Any
+from typing import Sequence
+
+from service_capacity_modeling import capacity_planner
+from service_capacity_modeling.capacity_planner import _NO_MATCHING_INSTANCE_FAMILIES
+from service_capacity_modeling.capacity_planner import _CertainResult
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import QueryPattern
+
+
+def _kv_desires() -> CapacityDesires:
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_consistency=GlobalConsistency(
+                same_region=Consistency(
+                    target_consistency=AccessConsistency.eventual,
+                ),
+                cross_region=Consistency(
+                    target_consistency=AccessConsistency.best_effort,
+                ),
+            ),
+            estimated_read_per_second=certain_int(100_000),
+            estimated_write_per_second=certain_int(10_000),
+            estimated_mean_read_latency_ms=certain_float(1),
+            estimated_mean_write_latency_ms=certain_float(1),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=certain_int(100),
+        ),
+    )
+
+
+def _record_plan_certain_calls(monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    def fake_plan_certain(**kwargs):
+        calls.append(kwargs)
+        return _CertainResult(plans=[])
+
+    monkeypatch.setattr(planner, "_plan_certain", fake_plan_certain)
+    return calls
+
+
+def _filters_by_model(
+    calls: list[dict[str, Any]],
+) -> dict[str, Sequence[str] | None]:
+    return {call["model_name"]: call["instance_families"] for call in calls}
+
+
+def test_plan_certain_explained_uses_model_scoped_instance_filters(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+
+    planner.plan_certain_explained(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=_kv_desires(),
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+    )
+
+    assert _filters_by_model(calls) == {
+        "org.netflix.key-value": None,
+        "org.netflix.evcache": None,
+        "org.netflix.cassandra": ["i4i"],
+    }
+
+
+def test_plan_certain_forwards_model_scoped_instance_filters(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+
+    planner.plan_certain(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=_kv_desires(),
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+    )
+
+    assert _filters_by_model(calls) == {
+        "org.netflix.key-value": None,
+        "org.netflix.evcache": None,
+        "org.netflix.cassandra": ["i4i"],
+    }
+
+
+def test_model_scoped_instance_filters_narrow_global_filters(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+
+    planner.plan_certain_explained(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=_kv_desires(),
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families=["m6id", "i4i"],
+        instance_families_by_model={"org.netflix.cassandra": ["i4i", "i7i"]},
+    )
+
+    assert _filters_by_model(calls) == {
+        "org.netflix.key-value": ["m6id", "i4i"],
+        "org.netflix.evcache": ["m6id", "i4i"],
+        "org.netflix.cassandra": ["i4i"],
+    }
+
+
+def test_disjoint_model_scoped_and_global_filters_match_no_instances(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+
+    planner.plan_certain_explained(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=_kv_desires(),
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families=["m6id"],
+        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+    )
+
+    assert _filters_by_model(calls) == {
+        "org.netflix.key-value": ["m6id"],
+        "org.netflix.evcache": ["m6id"],
+        "org.netflix.cassandra": _NO_MATCHING_INSTANCE_FAMILIES,
+    }
+
+
+def test_plan_percentiles_uses_model_scoped_instance_filters(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+
+    planner._plan_percentiles(
+        model_name="org.netflix.key-value",
+        percentiles=(50,),
+        region="us-east-1",
+        desires=_kv_desires(),
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+    )
+
+    assert {
+        (call["model_name"], tuple(call["instance_families"] or ())) for call in calls
+    } == {
+        ("org.netflix.key-value", ()),
+        ("org.netflix.evcache", ()),
+        ("org.netflix.cassandra", ("i4i",)),
+    }
+
+
+def test_uncertain_plan_uses_model_scoped_instance_filters(monkeypatch):
+    calls = _record_plan_certain_calls(monkeypatch)
+    percentile_calls: list[dict[str, Any]] = []
+
+    def fake_plan_percentiles(**kwargs):
+        percentile_calls.append(kwargs)
+        return [], {}
+
+    monkeypatch.setattr(capacity_planner, "_regret", lambda **kwargs: [])
+    monkeypatch.setattr(planner, "_plan_percentiles", fake_plan_percentiles)
+
+    instance_families_by_model = {"org.netflix.cassandra": ["i4i"]}
+
+    planner.plan(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=_kv_desires(),
+        simulations=1,
+        extra_model_arguments={"kv_force_evcache": True},
+        instance_families_by_model=instance_families_by_model,
+    )
+
+    assert _filters_by_model(calls) == {
+        "org.netflix.key-value": None,
+        "org.netflix.evcache": None,
+        "org.netflix.cassandra": ["i4i"],
+    }
+    assert (
+        percentile_calls[0]["instance_families_by_model"] is instance_families_by_model
+    )


### PR DESCRIPTION
## What am I trying to do?

Allow composed capacity plans to add instance-family filters for specific submodels. This lets callers include Cassandra-specific candidate families independently from the outer composed model while preserving the existing request-wide `instance_families` behavior.

## Why did I do it this way?

The change keeps the existing public `instance_families` argument as the request-wide filter and adds `instance_families_by_model` as an optional, appended parameter for compatibility with positional callers. For a model that has both filters, the effective allowlist is the ordered union: request-wide entries first, followed by model-scoped entries that were not already present.

`resolve_instance_family_allowlist` lives in `service_capacity_modeling.models.utils` beside `reduce_by_family`, so `capacity_planner.py` only threads the resolved allowlist into existing `_plan_certain` calls.

## Are there any tests?

Yes. Focused tests cover `plan_certain`, `plan_certain_explained`, `_plan_percentiles`, and uncertain `plan()` propagation through composed KV + Cassandra plans. The tests also lock the allowlist resolver contract, including unioning disjoint request-wide and Cassandra-scoped filters.

Verification run:
- `.tox/py312/bin/pytest tests/test_model_scoped_instance_filters.py tests/test_generate_scenarios.py::test_generate_scenarios tests/test_reproducible.py::test_compositional -q`
- `.tox/py312/bin/mypy --config-file=.mypy.ini service_capacity_modeling`
- `git diff --check`
- commit hook: `pre-commit run --all-files`

## How would I use the new code?

A common composed-plan case is a KV plan where the outer KV model should consider a general-purpose compute family such as `m7a`, while the Cassandra storage model should also consider storage-heavy or locally attached disk families. The request-wide filter applies to KV; the Cassandra-scoped filter adds Cassandra candidates without forcing those families onto KV.

```python
planner.plan_certain_explained(
    model_name="org.netflix.key-value",
    region="us-east-1",
    desires=desires,
    instance_families=["m7a"],
    instance_families_by_model={
        "org.netflix.cassandra": ["m6id", "r5d", "r6id", "i4i", "i7i", "i7ien"],
    },
)
```

In that example, KV keeps the request-wide `m7a` filter. Cassandra sees the ordered union: `m7a` plus the Cassandra-scoped families.