### PR TITLE
Rename model-scoped instance filters

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -56,7 +56,7 @@ from service_capacity_modeling.models.common import merge_plan
 from service_capacity_modeling.models.org import netflix
 from service_capacity_modeling.models.utils import compute_excuse_tags
 from service_capacity_modeling.models.utils import current_instance_name
-from service_capacity_modeling.models.utils import resolve_instance_family_allowlist
+from service_capacity_modeling.models.utils import resolve_instance_filter_allowlist
 from service_capacity_modeling.models.utils import reduce_by_family
 from service_capacity_modeling.stats import dist_for_interval
 from service_capacity_modeling.stats import interval_percentile
@@ -546,11 +546,11 @@ class CapacityPlanner:
         desires: CapacityDesires,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
         drives: Optional[Sequence[str]] = None,
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> Tuple[Sequence[CapacityPlan], Dict[int, Sequence[CapacityPlan]]]:
         if model_name not in self._models:
             raise ValueError(
@@ -587,7 +587,7 @@ class CapacityPlanner:
             drives,
             extra_model_arguments,
             instance_families,
-            instance_families_by_model,
+            instance_filters_by_model,
             lifecycles,
             num_regions,
             num_results,
@@ -598,7 +598,7 @@ class CapacityPlanner:
             drives,
             extra_model_arguments,
             instance_families,
-            instance_families_by_model,
+            instance_filters_by_model,
             lifecycles,
             num_regions,
             num_results,
@@ -614,7 +614,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -628,10 +628,10 @@ class CapacityPlanner:
             for percentile_sub_model, percentile_sub_desire in model_percentile_desires[
                 index
             ].items():
-                percentile_sub_instance_families = resolve_instance_family_allowlist(
+                percentile_sub_instance_families = resolve_instance_filter_allowlist(
                     percentile_sub_model,
                     instance_families,
-                    instance_families_by_model,
+                    instance_filters_by_model,
                 )
 
                 percentile_sub_result = self._plan_certain(
@@ -662,7 +662,7 @@ class CapacityPlanner:
         drives: Optional[Sequence[str]],
         extra_model_arguments: Dict[str, Any],
         instance_families: Optional[Sequence[str]],
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
         lifecycles: Sequence[Lifecycle],
         num_regions: int,
         num_results: Optional[int],
@@ -671,10 +671,10 @@ class CapacityPlanner:
     ) -> Sequence[CapacityPlan]:
         mean_plans = []
         for mean_sub_model, mean_sub_desire in model_mean_desires.items():
-            mean_sub_instance_families = resolve_instance_family_allowlist(
+            mean_sub_instance_families = resolve_instance_filter_allowlist(
                 mean_sub_model,
                 instance_families,
-                instance_families_by_model,
+                instance_filters_by_model,
             )
 
             mean_sub_result = self._plan_certain(
@@ -703,13 +703,13 @@ class CapacityPlanner:
         desires: CapacityDesires,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
         drives: Optional[Sequence[str]] = None,
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> Sequence[CapacityPlan]:
         return self.plan_certain_explained(
             model_name=model_name,
@@ -717,7 +717,7 @@ class CapacityPlanner:
             desires=desires,
             lifecycles=lifecycles,
             instance_families=instance_families,
-            instance_families_by_model=instance_families_by_model,
+            instance_filters_by_model=instance_filters_by_model,
             drives=drives,
             num_results=num_results,
             num_regions=num_regions,
@@ -733,13 +733,13 @@ class CapacityPlanner:
         desires: CapacityDesires,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
         drives: Optional[Sequence[str]] = None,
         num_results: Optional[int] = None,
         num_regions: int = 3,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> ExplainedPlans:
         """Like plan_certain() but returns excuses and family graph too."""
         if model_name not in self._models:
@@ -766,10 +766,10 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
-            sub_instance_families = resolve_instance_family_allowlist(
+            sub_instance_families = resolve_instance_filter_allowlist(
                 sub_model,
                 instance_families,
-                instance_families_by_model,
+                instance_filters_by_model,
             )
 
             sub_result = self._plan_certain(
@@ -1123,13 +1123,13 @@ class CapacityPlanner:
         num_regions: int = 3,
         lifecycles: Optional[Sequence[Lifecycle]] = None,
         instance_families: Optional[Sequence[str]] = None,
+        instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
         drives: Optional[Sequence[str]] = None,
         regret_params: Optional[CapacityRegretParameters] = None,
         extra_model_arguments: Optional[Dict[str, Any]] = None,
         explain: bool = False,
         max_results_per_family: int = 1,
         planner_arguments: Optional[PlannerArguments] = None,
-        instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]] = None,
     ) -> UncertainCapacityPlan:
         extra_model_arguments = extra_model_arguments or {}
         pargs = planner_arguments or PlannerArguments(
@@ -1163,10 +1163,10 @@ class CapacityPlanner:
             desires=desires,
             extra_model_arguments=extra_model_arguments,
         ):
-            sub_instance_families = resolve_instance_family_allowlist(
+            sub_instance_families = resolve_instance_filter_allowlist(
                 sub_model,
                 instance_families,
-                instance_families_by_model,
+                instance_filters_by_model,
             )
 
             desires_by_model[sub_model] = sub_desires
@@ -1246,7 +1246,7 @@ class CapacityPlanner:
             extra_model_arguments=extra_model_arguments,
             num_regions=num_regions,
             instance_families=instance_families,
-            instance_families_by_model=instance_families_by_model,
+            instance_filters_by_model=instance_filters_by_model,
         )
 
         result = UncertainCapacityPlan(

--- a/service_capacity_modeling/models/utils.py
+++ b/service_capacity_modeling/models/utils.py
@@ -101,15 +101,15 @@ def reduce_by_family(
     return result
 
 
-def resolve_instance_family_allowlist(
+def resolve_instance_filter_allowlist(
     model_name: str,
     instance_families: Optional[Sequence[str]],
-    instance_families_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
+    instance_filters_by_model: Optional[Dict[str, Optional[Sequence[str]]]],
 ) -> Optional[Sequence[str]]:
-    """Resolve the instance-family allowlist for one model in a composed plan.
+    """Resolve instance filters for one model in a composed plan.
 
     ``instance_families`` is the request-wide filter. It applies to every model.
-    ``instance_families_by_model`` is an additive per-model filter. When both
+    ``instance_filters_by_model`` is an additive per-model filter. When both
     inputs contain values for ``model_name``, the effective filter is their
     ordered union.
 
@@ -118,16 +118,14 @@ def resolve_instance_family_allowlist(
         de-duplicated allowlist with request-wide candidates first, followed by
         new per-model candidates.
     """
-    model_instance_families = (
-        instance_families_by_model.get(model_name)
-        if instance_families_by_model is not None
+    model_instance_filters = (
+        instance_filters_by_model.get(model_name)
+        if instance_filters_by_model is not None
         else None
     )
     return (
         list(
-            dict.fromkeys(
-                [*(instance_families or ()), *(model_instance_families or ())]
-            )
+            dict.fromkeys([*(instance_families or ()), *(model_instance_filters or ())])
         )
         or None
     )

--- a/tests/test_model_scoped_instance_filters.py
+++ b/tests/test_model_scoped_instance_filters.py
@@ -13,7 +13,7 @@ from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import QueryPattern
-from service_capacity_modeling.models.utils import resolve_instance_family_allowlist
+from service_capacity_modeling.models.utils import resolve_instance_filter_allowlist
 
 
 def _kv_desires() -> CapacityDesires:
@@ -64,7 +64,7 @@ def test_plan_certain_explained_uses_model_scoped_instance_filters(monkeypatch):
         region="us-east-1",
         desires=_kv_desires(),
         extra_model_arguments={"kv_force_evcache": True},
-        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+        instance_filters_by_model={"org.netflix.cassandra": ["i4i"]},
     )
 
     assert _filters_by_model(calls) == {
@@ -82,7 +82,7 @@ def test_plan_certain_forwards_model_scoped_instance_filters(monkeypatch):
         region="us-east-1",
         desires=_kv_desires(),
         extra_model_arguments={"kv_force_evcache": True},
-        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+        instance_filters_by_model={"org.netflix.cassandra": ["i4i"]},
     )
 
     assert _filters_by_model(calls) == {
@@ -101,7 +101,7 @@ def test_model_scoped_instance_filters_union_with_global_filters(monkeypatch):
         desires=_kv_desires(),
         extra_model_arguments={"kv_force_evcache": True},
         instance_families=["m6id", "i4i"],
-        instance_families_by_model={"org.netflix.cassandra": ["i4i", "i7i"]},
+        instance_filters_by_model={"org.netflix.cassandra": ["i4i", "i7i"]},
     )
 
     assert _filters_by_model(calls) == {
@@ -111,26 +111,26 @@ def test_model_scoped_instance_filters_union_with_global_filters(monkeypatch):
     }
 
 
-def test_resolve_instance_family_allowlist_combines_request_and_model_filters():
+def test_resolve_instance_filter_allowlist_combines_request_and_model_filters():
     assert (
-        resolve_instance_family_allowlist(
+        resolve_instance_filter_allowlist(
             "org.netflix.cassandra",
             None,
             None,
         )
         is None
     )
-    assert resolve_instance_family_allowlist(
+    assert resolve_instance_filter_allowlist(
         "org.netflix.cassandra",
         ["m6id"],
         {"org.netflix.cassandra": None},
     ) == ["m6id"]
-    assert resolve_instance_family_allowlist(
+    assert resolve_instance_filter_allowlist(
         "org.netflix.cassandra",
         ["m6id", "i4i"],
         {"org.netflix.cassandra": ["i4i", "i7i"]},
     ) == ["m6id", "i4i", "i7i"]
-    assert resolve_instance_family_allowlist(
+    assert resolve_instance_filter_allowlist(
         "org.netflix.cassandra",
         ["m6id"],
         {"org.netflix.cassandra": ["i4i"]},
@@ -146,7 +146,7 @@ def test_model_scoped_instance_filters_add_to_disjoint_global_filters(monkeypatc
         desires=_kv_desires(),
         extra_model_arguments={"kv_force_evcache": True},
         instance_families=["m6id"],
-        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+        instance_filters_by_model={"org.netflix.cassandra": ["i4i"]},
     )
 
     assert _filters_by_model(calls) == {
@@ -165,7 +165,7 @@ def test_plan_percentiles_uses_model_scoped_instance_filters(monkeypatch):
         region="us-east-1",
         desires=_kv_desires(),
         extra_model_arguments={"kv_force_evcache": True},
-        instance_families_by_model={"org.netflix.cassandra": ["i4i"]},
+        instance_filters_by_model={"org.netflix.cassandra": ["i4i"]},
     )
 
     assert {
@@ -188,7 +188,7 @@ def test_uncertain_plan_uses_model_scoped_instance_filters(monkeypatch):
     monkeypatch.setattr(capacity_planner, "_regret", lambda **kwargs: [])
     monkeypatch.setattr(planner, "_plan_percentiles", fake_plan_percentiles)
 
-    instance_families_by_model = {"org.netflix.cassandra": ["i4i"]}
+    instance_filters_by_model = {"org.netflix.cassandra": ["i4i"]}
 
     planner.plan(
         model_name="org.netflix.key-value",
@@ -196,7 +196,7 @@ def test_uncertain_plan_uses_model_scoped_instance_filters(monkeypatch):
         desires=_kv_desires(),
         simulations=1,
         extra_model_arguments={"kv_force_evcache": True},
-        instance_families_by_model=instance_families_by_model,
+        instance_filters_by_model=instance_filters_by_model,
     )
 
     assert _filters_by_model(calls) == {
@@ -204,6 +204,4 @@ def test_uncertain_plan_uses_model_scoped_instance_filters(monkeypatch):
         "org.netflix.evcache": None,
         "org.netflix.cassandra": ["i4i"],
     }
-    assert (
-        percentile_calls[0]["instance_families_by_model"] is instance_families_by_model
-    )
+    assert percentile_calls[0]["instance_filters_by_model"] is instance_filters_by_model


### PR DESCRIPTION
## What am I trying to do?

Rename the per-model instance filter API from `instance_families_by_model` to `instance_filters_by_model` so it clearly mirrors the existing request-wide `instance_families` filter while leaving the global field unchanged.

## Why did I do it this way?

This is a narrow follow-up on top of the already-merged per-model filter support. It renames the planner keyword argument and internal resolver helper without changing the effective ordered-union behavior.

## Are there any tests?

- `tox -e py311 -- tests/test_model_scoped_instance_filters.py`
- Commit hooks: pre-commit suite, mypy, pylint