### PR TITLE
Prefer smaller read-only KV instances

### DIFF
--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -29,6 +29,7 @@ from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import CapacityRegretParameters
 from service_capacity_modeling.interface import CapacityRequirement
 from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
@@ -38,6 +39,7 @@ from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import normalized_aws_size
 from service_capacity_modeling.interface import Platform
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionClusterCapacity
@@ -46,6 +48,7 @@ from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ServiceCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
+from service_capacity_modeling.models import RANK_PENALTIES
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_effective_disk_per_node_gib
@@ -59,6 +62,19 @@ from service_capacity_modeling.models.org.netflix.partition_aware_algorithm impo
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _compute_penalties(
+    instance: Instance,
+    large_instance_regret: float,
+) -> Dict[str, float]:
+    penalties: Dict[str, float] = {}
+
+    instance_size = float(normalized_aws_size(instance.name))
+    if large_instance_regret > 0 and instance_size > 4:
+        penalties["large_instance"] = large_instance_regret * (instance_size - 4) / 4
+
+    return penalties
 
 
 class NflxReadOnlyKVArguments(BaseModel):
@@ -95,6 +111,12 @@ class NflxReadOnlyKVArguments(BaseModel):
         description="Reserved memory for OS, bloom filters, index blocks, "
         "and other processes (GiB).",
         ge=0,
+    )
+    large_instance_regret: float = Field(
+        default=0.2,
+        description="Graduated cost penalty for instance sizes above 4xlarge. "
+        "Adds penalty * max(0, (normalized_size - 4) / 4) * cost to the "
+        "effective sort cost. Set to 0 to disable.",
     )
 
 
@@ -233,6 +255,13 @@ def _compute_read_only_kv_regional_cluster(
     }
     upsert_params(cluster, params)
 
+    penalties = _compute_penalties(
+        instance=instance,
+        large_instance_regret=args.large_instance_regret,
+    )
+    if penalties:
+        upsert_params(cluster, {RANK_PENALTIES: penalties})
+
     return cluster
 
 
@@ -304,10 +333,14 @@ def _estimate_read_only_kv_cluster(
         regional=[cluster],
         services=[],
     )
+    penalty_ratio = sum(
+        cluster.cluster_params.get(RANK_PENALTIES, {}).values(),
+    )
 
     return CapacityPlan(
         requirements=Requirements(regional=[requirement]),
         candidate_clusters=clusters,
+        rank=clusters.total_annual_cost * (1 + penalty_ratio),
     )
 
 
@@ -323,6 +356,27 @@ class NflxReadOnlyKVCapacityModel(CapacityModel, CostAwareModel):
 
     service_name = "read-only-kv"
     cluster_type = "read-only-kv"
+
+    @staticmethod
+    def regret(
+        regret_params: CapacityRegretParameters,
+        optimal_plan: CapacityPlan,
+        proposed_plan: CapacityPlan,
+    ) -> Dict[str, float]:
+        regrets = CapacityModel.regret(regret_params, optimal_plan, proposed_plan)
+
+        if proposed_plan.candidate_clusters.regional:
+            params = proposed_plan.candidate_clusters.regional[0].cluster_params
+            penalties = params.get(RANK_PENALTIES, {})
+            if "large_instance" in penalties:
+                compute_cost = float(
+                    sum(
+                        c.annual_cost for c in proposed_plan.candidate_clusters.regional
+                    )
+                )
+                regrets["large_instance"] = penalties["large_instance"] * compute_cost
+
+        return regrets
 
     @staticmethod
     def service_costs(

--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -124,7 +124,7 @@ class NflxReadOnlyKVArguments(BaseModel):
 # doesn't work well for large datasets (which is all of OODM use cases). The working
 # set calculation assumes a relationship between drive latency and SLO that doesn't
 # hold for large datasets where the working set is a small fraction of total data.
-# For now, we rely on the 64 GiB minimum RAM filter on instances and don't use
+# For now, we rely on the 30 GiB minimum RAM filter on instances and don't use
 # memory as a sizing constraint. Future work: implement a better memory estimation
 # that considers actual access patterns and cache hit rates for large datasets.
 
@@ -162,7 +162,7 @@ def _estimate_read_only_kv_requirement(
     )
 
     # Memory: not used as sizing constraint (see TODO at top of file)
-    # Instances are filtered to require 64+ GiB RAM
+    # Instances are filtered to require 30+ GiB RAM
 
     # Network calculation (read-only, so only outbound read traffic)
     needed_network_mbps = simple_network_mbps(desires)
@@ -286,9 +286,9 @@ def _estimate_read_only_kv_cluster(
     """
 
     # Validate instance constraints
-    # Minimum 64 GiB RAM: ensures sufficient memory for RocksDB block cache
-    # and working set without needing memory as a sizing constraint
-    if instance.cpu < 2 or instance.ram_gib < 64:
+    # Minimum 30 GiB RAM: allows 32 GiB-class shapes in the hardware catalog
+    # while keeping enough memory for RocksDB block cache and working set.
+    if instance.cpu < 2 or instance.ram_gib < 30:
         return None
 
     # Only support instances with local disks

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -1261,15 +1261,15 @@
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 449867.0
+      "read-only-kv.regional-clusters": 149967.0
     },
     "clusters": [
       {
-        "annual_cost": 449867.0,
+        "annual_cost": 149967.0,
         "cluster_params": {
-          "effective_disk_per_node_gib": 2355.2,
+          "effective_disk_per_node_gib": 2328,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 5,
+          "read-only-kv.nodes_for_cpu": 15,
           "read-only-kv.nodes_for_one_copy": 25,
           "read-only-kv.partitions_per_node": 21,
           "read-only-kv.replica_count": 4,
@@ -1278,69 +1278,69 @@
         "cluster_type": "read-only-kv",
         "count": 100,
         "deployment": "regional",
-        "instance": "i3en.3xlarge"
+        "instance": "i3en.xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_large",
     "service_tier": 1,
-    "total_annual_cost": 449867.0
+    "total_annual_cost": 149967.0
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 14525.01
+      "read-only-kv.regional-clusters": 14523.96
     },
     "clusters": [
       {
-        "annual_cost": 14525.01,
+        "annual_cost": 14523.96,
         "cluster_params": {
-          "effective_disk_per_node_gib": 2355.2,
+          "effective_disk_per_node_gib": 873,
           "read-only-kv.min_replica_count": 3,
-          "read-only-kv.nodes_for_cpu": 3,
-          "read-only-kv.nodes_for_one_copy": 1,
-          "read-only-kv.partitions_per_node": 11,
-          "read-only-kv.replica_count": 3,
+          "read-only-kv.nodes_for_cpu": 12,
+          "read-only-kv.nodes_for_one_copy": 2,
+          "read-only-kv.partitions_per_node": 4,
+          "read-only-kv.replica_count": 6,
           "read-only-kv.total_num_partitions": 8
         },
         "cluster_type": "read-only-kv",
-        "count": 3,
+        "count": 12,
         "deployment": "regional",
-        "instance": "i4i.4xlarge"
+        "instance": "i4i.xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_medium",
     "service_tier": 1,
-    "total_annual_cost": 14525.01
+    "total_annual_cost": 14523.96
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 15177.32
+      "read-only-kv.regional-clusters": 7816.65
     },
     "clusters": [
       {
-        "annual_cost": 15177.32,
+        "annual_cost": 7816.65,
         "cluster_params": {
-          "effective_disk_per_node_gib": 559,
+          "effective_disk_per_node_gib": 441,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 4,
+          "read-only-kv.nodes_for_cpu": 5,
           "read-only-kv.nodes_for_one_copy": 1,
-          "read-only-kv.partitions_per_node": 129,
-          "read-only-kv.replica_count": 4,
+          "read-only-kv.partitions_per_node": 102,
+          "read-only-kv.replica_count": 5,
           "read-only-kv.total_num_partitions": 16
         },
         "cluster_type": "read-only-kv",
-        "count": 4,
+        "count": 5,
         "deployment": "regional",
-        "instance": "r5d.4xlarge"
+        "instance": "m6id.2xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_small",
     "service_tier": 1,
-    "total_annual_cost": 15177.32
+    "total_annual_cost": 7816.65
   }
 ]

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -10,13 +10,30 @@ Note: Algorithm-specific tests live in test_partition_aware_algorithm.py.
 These tests focus on model integration and E2E behavior.
 """
 
+from decimal import Decimal
+
+import pytest
+
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import CapacityRegretParameters
 from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionClusterCapacity
+from service_capacity_modeling.interface import Requirements
+from service_capacity_modeling.models import RANK_PENALTIES
+from service_capacity_modeling.models.org.netflix.read_only_kv import (
+    _compute_penalties,
+)
+from service_capacity_modeling.models.org.netflix.read_only_kv import (
+    NflxReadOnlyKVCapacityModel,
+)
 from tests.util import get_total_storage_gib
 from tests.util import has_local_storage
 
@@ -160,6 +177,46 @@ class TestReadOnlyKVBasicCapacityPlanning:
         assert total_network >= 640, (
             f"Expected >= 640 Mbps network for throughput workload, got {total_network}"
         )
+
+
+class TestReadOnlyKVLargeInstanceRegret:
+    """Test Cassandra-style large-instance regret for ReadOnlyKV."""
+
+    def test_large_instance_penalty_starts_after_4xlarge(self):
+        assert not _compute_penalties(shapes.instance("m6id.4xlarge"), 0.2)
+        assert _compute_penalties(shapes.instance("m6id.8xlarge"), 0.2) == {
+            "large_instance": 0.2
+        }
+        penalties = _compute_penalties(shapes.instance("m6id.16xlarge"), 0.2)
+        assert penalties["large_instance"] == pytest.approx(0.6)
+
+    def test_large_instance_penalty_can_be_disabled(self):
+        assert not _compute_penalties(shapes.instance("m6id.16xlarge"), 0)
+
+    def test_large_instance_regret_uses_regional_compute_cost(self):
+        instance = shapes.instance("m6id.8xlarge")
+        cluster = RegionClusterCapacity(
+            cluster_type="read-only-kv",
+            count=2,
+            instance=instance,
+            cluster_params={RANK_PENALTIES: {"large_instance": 0.2}},
+        )
+        proposed_plan = CapacityPlan(
+            requirements=Requirements(),
+            candidate_clusters=Clusters(
+                annual_costs={"read-only-kv": Decimal(str(cluster.annual_cost))},
+                regional=[cluster],
+            ),
+        )
+        optimal_plan = proposed_plan.model_copy(deep=True)
+
+        regrets = NflxReadOnlyKVCapacityModel.regret(
+            regret_params=CapacityRegretParameters(),
+            optimal_plan=optimal_plan,
+            proposed_plan=proposed_plan,
+        )
+
+        assert regrets["large_instance"] == 0.2 * cluster.annual_cost
 
 
 class TestReadOnlyKVStorageTypes:

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -14,9 +14,13 @@ from decimal import Decimal
 
 import pytest
 
+from service_capacity_modeling.capacity_planner import PlannerArguments
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import Buffer
+from service_capacity_modeling.interface import BufferComponent
+from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRegretParameters
@@ -157,8 +161,8 @@ class TestReadOnlyKVBasicCapacityPlanning:
 
         # Memory should be sufficient for RocksDB block cache
         total_memory = result.count * result.instance.ram_gib
-        # Instance minimum is 64GB, so minimum cluster memory is 64GB * 2 nodes = 128GB
-        assert total_memory >= 128, f"Expected >= 128 GiB memory, got {total_memory}"
+        # Instance minimum is 32GB, so minimum cluster memory is 32GB * 2 nodes = 64GB
+        assert total_memory >= 64, f"Expected >= 64 GiB memory, got {total_memory}"
 
     def test_throughput_workload(self):
         """Test ReadOnlyKV with throughput-oriented workload (scans)."""
@@ -181,6 +185,68 @@ class TestReadOnlyKVBasicCapacityPlanning:
 
 class TestReadOnlyKVLargeInstanceRegret:
     """Test Cassandra-style large-instance regret for ReadOnlyKV."""
+
+    @pytest.mark.parametrize(
+        "read_qps,large_instance_regret,expected_instance,expected_nodes",
+        [
+            (12_500, 0, "m6id.8xlarge", 2),
+            (12_500, 0.2, "m6id.4xlarge", 4),
+            (25_000, 0, "m6id.12xlarge", 2),
+            (25_000, 0.2, "m6id.4xlarge", 6),
+            (50_000, 0, "m6id.4xlarge", 11),
+            (50_000, 0.2, "m6id.4xlarge", 11),
+        ],
+    )
+    def test_m6id_baseline_shows_large_instance_regret_effect(
+        self,
+        read_qps,
+        large_instance_regret,
+        expected_instance,
+        expected_nodes,
+    ):
+        baseline_desires = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(read_qps),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_write_latency_ms=certain_float(0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_float(581_680_552_071 / 1024**3),
+            ),
+            buffers=Buffers(
+                desired={
+                    "compute": Buffer(
+                        ratio=2.5,
+                        components=[BufferComponent.compute],
+                    ),
+                },
+            ),
+        )
+
+        cap_plan = planner.plan_certain(
+            model_name="org.netflix.read-only-kv",
+            region="us-east-1",
+            desires=baseline_desires,
+            extra_model_arguments={
+                "total_num_partitions": 32,
+                "large_instance_regret": large_instance_regret,
+            },
+            instance_families=["m6id"],
+            planner_arguments=PlannerArguments(max_results_per_family=20),
+        )[0]
+
+        result = cap_plan.candidate_clusters.regional[0]
+        params = result.cluster_params
+
+        assert result.instance.name == expected_instance
+        assert result.count == expected_nodes
+        assert params["read-only-kv.total_num_partitions"] == 32
+        assert params["read-only-kv.replica_count"] == expected_nodes
+        assert params["read-only-kv.partitions_per_node"] > 0
 
     def test_large_instance_penalty_starts_after_4xlarge(self):
         assert not _compute_penalties(shapes.instance("m6id.4xlarge"), 0.2)
@@ -523,7 +589,7 @@ class TestReadOnlyKVMultiplePlans:
             )
 
     def test_plans_scale_with_data_size(self):
-        """Verify larger datasets result in more total storage."""
+        """Verify larger datasets require more partition placement capacity."""
         small_plans = planner.plan_certain(
             model_name="org.netflix.read-only-kv",
             region="us-east-1",
@@ -553,13 +619,14 @@ class TestReadOnlyKVMultiplePlans:
         assert "read-only-kv.partitions_per_node" in large_result.cluster_params
         assert "read-only-kv.replica_count" in large_result.cluster_params
 
-        # Large dataset should have more total storage
         small_storage = get_total_storage_gib(small_result)
         large_storage = get_total_storage_gib(large_result)
+        assert small_storage >= 50
+        assert large_storage >= 1000
 
-        assert large_storage >= small_storage, (
-            f"Large dataset ({large_storage} GiB) should have >= "
-            f"small dataset ({small_storage} GiB) storage"
+        assert (
+            large_result.cluster_params["read-only-kv.nodes_for_one_copy"]
+            > small_result.cluster_params["read-only-kv.nodes_for_one_copy"]
         )
 
 


### PR DESCRIPTION
## What am I trying to do?

Prefer wider read-only KV cluster shapes when the raw cost model sees larger and smaller instances as similarly attractive. This adds Cassandra-style `large_instance` regret to the read-only KV model and sets the read-only KV instance RAM eligibility floor to `30 GiB`, which admits AWS 32 GiB-class local-disk shapes.

## Why did I do it this way?

### Cassandra-style large instance regret

The model now follows the Cassandra pattern instead of inventing a read-only-KV-specific spread penalty:

- compute a named `large_instance` penalty from normalized AWS instance size
- store it under `RANK_PENALTIES` in `cluster_params`
- inflate `CapacityPlan.rank` by the penalty ratio
- expose the same named component through `regret()` using regional compute cost

The threshold intentionally differs from Cassandra: Cassandra starts after `8xlarge`; read-only KV starts after `4xlarge` to bias harder toward horizontal spread for this workload.

### 30 GiB RAM floor

Read-only KV now filters candidate instances with `instance.ram_gib < 30`. The hardware catalog represents AWS 32 GiB-class shapes around `30.52 GiB`, so this allows shapes like `m6id.2xlarge`, `c6id.4xlarge`, and `i4i.xlarge` while still filtering out smaller memory classes.

This remains a coarse eligibility guardrail because read-only KV memory sizing is not modeled as a real capacity constraint yet; it only controls which local-disk shapes are eligible for partition-aware planning.

### Observed m6id-only behavior

Using an anonymized baseline of `581,680,552,071` bytes, `32` partitions, and a `2.5x` compute buffer:

| Read QPS | `large_instance_regret` | Top m6id plan |
|---:|---:|---|
| 12.5k | 0 | `2 x m6id.8xlarge`, RF=2 |
| 12.5k | 0.2 | `4 x m6id.4xlarge`, RF=4 |
| 25k | 0 | `2 x m6id.12xlarge`, RF=2 |
| 25k | 0.2 | `6 x m6id.4xlarge`, RF=6 |
| 50k | 0 | `11 x m6id.4xlarge`, RF=11 |
| 50k | 0.2 | `11 x m6id.4xlarge`, RF=11 |

At lower QPS, regret breaks near-cost ties toward wider shapes. At 50k QPS, once smaller-memory local-disk instances are eligible, `m6id.4xlarge` wins on raw cost already.

## Are there any tests?

Yes. The read-only KV tests now cover the large-instance penalty math, regret output, the 30 GiB RAM floor behavior, and the m6id-only anonymized baseline above. Baseline cost snapshots were regenerated because read-only KV scenarios now choose cheaper 32 GiB-class shapes.

Verification run:

```bash
tox -e py312 -- tests/netflix/test_read_only_kv.py
tox -e capture-baseline
tox -e pre-commit
```

## How would I use the new code?

By default, read-only KV plans now apply `large_instance_regret=0.2`. Callers can disable or tune it with extra model arguments:

```json
{
  "total_num_partitions": 32,
  "large_instance_regret": 0
}
```
