### PR TITLE
Cap Cassandra provisioned disk utilization

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -78,10 +78,43 @@ logger = logging.getLogger(__name__)
 
 BACKGROUND_BUFFER = "background"
 EBS_HOTTER = "EBS_HOTTER"
+CASSANDRA_DISK_UTILIZATION_LIMIT = "CASSANDRA_DISK_UTILIZATION_LIMIT"
 CRITICAL_TIERS: Set[int] = {0, 1}
 # cluster size aka nodes per ASG
 CRITICAL_TIER_MIN_CLUSTER_SIZE = 2
 EBS_HOTTER_BUFFER_RATIO = 0.5
+CASSANDRA_MAX_DISK_UTILIZATION = 0.55
+
+
+def _with_disk_utilization_buffer(
+    desires: CapacityDesires,
+    max_disk_utilization: float,
+) -> CapacityDesires:
+    """Add only the disk buffer needed to keep Cassandra below the utilization cap.
+
+    The default target leaves margin below the previous cap. Callers may make
+    this stricter but not looser.
+    """
+    capped_desires = desires.model_copy(deep=True)
+    target_disk_buffer_ratio = 1 / max_disk_utilization
+    existing_disk_buffer = buffer_for_components(
+        buffers=desires.buffers,
+        components=[BufferComponent.disk],
+    )
+    disk_utilization_ratio = (
+        target_disk_buffer_ratio
+        if not existing_disk_buffer.sources
+        else max(1.0, target_disk_buffer_ratio / existing_disk_buffer.ratio)
+    )
+    disk_utilization_buffer = Buffer(
+        ratio=disk_utilization_ratio,
+        components=[BufferComponent.disk],
+    )
+    capped_desires.buffers.desired = {
+        **capped_desires.buffers.desired,
+        CASSANDRA_DISK_UTILIZATION_LIMIT: disk_utilization_buffer,
+    }
+    return capped_desires
 
 
 def _with_ebs_hotter_buffer(desires: CapacityDesires) -> CapacityDesires:
@@ -621,6 +654,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     different_family_regret: float = 0.10,
     max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
     backup_retention_days: Optional[float] = None,
+    max_disk_utilization: float = CASSANDRA_MAX_DISK_UTILIZATION,
 ) -> Union[CapacityPlan, Excuse, None]:
     drive_name = drive.name
 
@@ -715,6 +749,10 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
 
     is_ebs = instance.drive is None
     capacity_desires = _with_ebs_hotter_buffer(desires) if is_ebs else desires
+    capacity_desires = _with_disk_utilization_buffer(
+        capacity_desires,
+        max_disk_utilization,
+    )
     requirement_estimate = _estimate_cassandra_requirement(
         instance=instance,
         desires=capacity_desires,
@@ -1191,6 +1229,14 @@ class NflxCassandraArguments(BaseModel):
         "recommend a smaller attached volume when requirements shrink. Defaults "
         "false to preserve the current EBS per-node disk floor.",
     )
+    max_disk_utilization: float = Field(
+        default=CASSANDRA_MAX_DISK_UTILIZATION,
+        gt=0,
+        le=CASSANDRA_MAX_DISK_UTILIZATION,
+        description="Maximum planned disk utilization for provisioned Cassandra "
+        f"clusters. Defaults to {CASSANDRA_MAX_DISK_UTILIZATION:.0%}. "
+        "This can only be made stricter per workload.",
+    )
 
     @model_validator(mode="after")
     def _check_storage_buffer_bounds(self) -> "NflxCassandraArguments":
@@ -1414,6 +1460,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             different_family_regret=args.different_family_regret,
             max_page_cache_gib=args.max_page_cache_gib,
             backup_retention_days=args.backup_retention_days,
+            max_disk_utilization=args.max_disk_utilization,
         )
 
         return result

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -410,21 +410,21 @@
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.09,
-          "effective_disk_per_node_gib": 3300,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 5500,
           "rank_penalties": {
             "family_migration": 0.1
           },
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 50,
-            "disk_capacity": 38,
+            "disk_capacity": 63,
             "disk_iops": 0,
             "memory": 2,
             "min_count": 64,
             "network": 3
           },
-          "resource_bottleneck": "cpu"
+          "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -443,21 +443,21 @@
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.09,
-          "effective_disk_per_node_gib": 3300,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 5500,
           "rank_penalties": {
             "family_migration": 0.1
           },
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 50,
-            "disk_capacity": 38,
+            "disk_capacity": 63,
             "disk_iops": 0,
             "memory": 2,
             "min_count": 64,
             "network": 3
           },
-          "resource_bottleneck": "cpu"
+          "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -476,21 +476,21 @@
           "cassandra.heap.table.percent": 0.2,
           "cassandra.heap.write.percent": 0.5,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.09,
-          "effective_disk_per_node_gib": 3300,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 5500,
           "rank_penalties": {
             "family_migration": 0.1
           },
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 50,
-            "disk_capacity": 38,
+            "disk_capacity": 63,
             "disk_iops": 0,
             "memory": 2,
             "min_count": 64,
             "network": 3
           },
-          "resource_bottleneck": "cpu"
+          "resource_bottleneck": "disk_capacity"
         },
         "cluster_type": "cassandra",
         "count": 64,
@@ -509,13 +509,13 @@
       "cassandra.backup.s3-standard": 37961.56,
       "cassandra.net.inter.region": 29695.33,
       "cassandra.net.intra.region": 89085.99,
-      "cassandra.zonal-clusters": 680511.36
+      "cassandra.zonal-clusters": 740784.0
     },
     "clusters": [
       {
-        "annual_cost": 226837.12,
+        "annual_cost": 246928.0,
         "attached_drives": [
-          "gp3 : 2400GB"
+          "gp3 : 2727GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -524,12 +524,12 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.22,
-          "effective_disk_per_node_gib": 1900,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2800,
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 56,
-            "disk_capacity": 12,
+            "disk_capacity": 15,
             "disk_iops": 0,
             "memory": 1,
             "min_count": 32,
@@ -543,9 +543,9 @@
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 226837.12,
+        "annual_cost": 246928.0,
         "attached_drives": [
-          "gp3 : 2400GB"
+          "gp3 : 2727GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -554,12 +554,12 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.22,
-          "effective_disk_per_node_gib": 1900,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2800,
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 56,
-            "disk_capacity": 12,
+            "disk_capacity": 15,
             "disk_iops": 0,
             "memory": 1,
             "min_count": 32,
@@ -573,9 +573,9 @@
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 226837.12,
+        "annual_cost": 246928.0,
         "attached_drives": [
-          "gp3 : 2400GB"
+          "gp3 : 2727GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -584,12 +584,12 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.22,
-          "effective_disk_per_node_gib": 1900,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2800,
           "required_nodes_by_type": {
             "cluster_size": 64,
             "cpu": 56,
-            "disk_capacity": 12,
+            "disk_capacity": 15,
             "disk_iops": 0,
             "memory": 1,
             "min_count": 32,
@@ -607,20 +607,20 @@
     "region": "us-east-1",
     "scenario": "cassandra_kv_dense_ebs",
     "service_tier": 1,
-    "total_annual_cost": 837254.24
+    "total_annual_cost": 897526.88
   },
   {
     "annual_costs": {
       "cassandra.backup.s3-standard": 15626.78,
       "cassandra.net.inter.region": 7423.83,
       "cassandra.net.intra.region": 22271.5,
-      "cassandra.zonal-clusters": 284959.68
+      "cassandra.zonal-clusters": 320072.64
     },
     "clusters": [
       {
-        "annual_cost": 94986.56,
+        "annual_cost": 106690.88,
         "attached_drives": [
-          "gp3 : 1800GB"
+          "gp3 : 2181GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -629,8 +629,8 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.37,
-          "effective_disk_per_node_gib": 1700,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2200,
           "required_nodes_by_type": {
             "cluster_size": 32,
             "cpu": 18,
@@ -648,9 +648,9 @@
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 94986.56,
+        "annual_cost": 106690.88,
         "attached_drives": [
-          "gp3 : 1800GB"
+          "gp3 : 2181GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -659,8 +659,8 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.37,
-          "effective_disk_per_node_gib": 1700,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2200,
           "required_nodes_by_type": {
             "cluster_size": 32,
             "cpu": 18,
@@ -678,9 +678,9 @@
         "instance": "r6a.xlarge"
       },
       {
-        "annual_cost": 94986.56,
+        "annual_cost": 106690.88,
         "attached_drives": [
-          "gp3 : 1800GB"
+          "gp3 : 2181GB"
         ],
         "cluster_params": {
           "cassandra.compaction.min_threshold": 4,
@@ -689,8 +689,8 @@
           "cassandra.heap.table.percent": 0.11,
           "cassandra.heap.write.percent": 0.25,
           "cassandra.keyspace.rf": 3,
-          "cassandra.storage_buffer_ratio": 1.37,
-          "effective_disk_per_node_gib": 1700,
+          "cassandra.storage_buffer_ratio": 1.82,
+          "effective_disk_per_node_gib": 2200,
           "required_nodes_by_type": {
             "cluster_size": 32,
             "cpu": 18,
@@ -712,7 +712,7 @@
     "region": "us-east-1",
     "scenario": "cassandra_kv_compact_ebs",
     "service_tier": 1,
-    "total_annual_cost": 330281.79
+    "total_annual_cost": 365394.75
   },
   {
     "annual_costs": {

--- a/service_capacity_modeling/tools/data/baseline_uncertain.json
+++ b/service_capacity_modeling/tools/data/baseline_uncertain.json
@@ -21,21 +21,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -54,21 +54,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -87,21 +87,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 5,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -133,21 +133,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -166,21 +166,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -199,21 +199,21 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 50,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
                 "network": 3
               },
-              "resource_bottleneck": "cpu"
+              "resource_bottleneck": "disk_capacity"
             },
             "cluster_type": "cassandra",
             "count": 64,
@@ -243,15 +243,15 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 32,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
@@ -276,15 +276,15 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 32,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
@@ -309,15 +309,15 @@
               "cassandra.heap.table.percent": 0.2,
               "cassandra.heap.write.percent": 0.5,
               "cassandra.keyspace.rf": 3,
-              "cassandra.storage_buffer_ratio": 1.09,
-              "effective_disk_per_node_gib": 3300,
+              "cassandra.storage_buffer_ratio": 1.82,
+              "effective_disk_per_node_gib": 5500,
               "rank_penalties": {
                 "family_migration": 0.1
               },
               "required_nodes_by_type": {
                 "cluster_size": 64,
                 "cpu": 32,
-                "disk_capacity": 38,
+                "disk_capacity": 63,
                 "disk_iops": 0,
                 "memory": 2,
                 "min_count": 64,
@@ -358,21 +358,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -391,21 +391,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -424,21 +424,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -468,15 +468,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
@@ -501,15 +501,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
@@ -534,15 +534,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 2,
                   "min_count": 64,
@@ -580,21 +580,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -613,21 +613,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -646,21 +646,21 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 50,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,
                   "network": 3
                 },
-                "resource_bottleneck": "cpu"
+                "resource_bottleneck": "disk_capacity"
               },
               "cluster_type": "cassandra",
               "count": 64,
@@ -690,15 +690,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,
@@ -723,15 +723,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,
@@ -756,15 +756,15 @@
                 "cassandra.heap.table.percent": 0.2,
                 "cassandra.heap.write.percent": 0.5,
                 "cassandra.keyspace.rf": 3,
-                "cassandra.storage_buffer_ratio": 1.09,
-                "effective_disk_per_node_gib": 3300,
+                "cassandra.storage_buffer_ratio": 1.82,
+                "effective_disk_per_node_gib": 5500,
                 "rank_penalties": {
                   "family_migration": 0.1
                 },
                 "required_nodes_by_type": {
                   "cluster_size": 64,
                   "cpu": 32,
-                  "disk_capacity": 38,
+                  "disk_capacity": 63,
                   "disk_iops": 0,
                   "memory": 6,
                   "min_count": 64,

--- a/tests/netflix/test_cassandra_ebs_buffer.py
+++ b/tests/netflix/test_cassandra_ebs_buffer.py
@@ -1,3 +1,5 @@
+import pytest
+
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
@@ -7,7 +9,14 @@ from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
+from service_capacity_modeling.models.org.netflix.cassandra import (
+    _with_disk_utilization_buffer,
+)
+from service_capacity_modeling.models.org.netflix.cassandra import (
+    NflxCassandraArguments,
+)
 
 
 def _ebs_desires(buffers: Buffers | None = None) -> CapacityDesires:
@@ -66,6 +75,52 @@ def test_ebs_multiplies_explicit_storage_buffer():
         )
     )
 
-    assert result.attached_drives[0].size_gib == 1600
-    assert result.cluster_params[EFFECTIVE_DISK_PER_NODE_GIB] == 1600
-    assert result.cluster_params["cassandra.storage_buffer_ratio"] == 1.5
+    assert result.attached_drives[0].size_gib == 1900
+    assert result.cluster_params[EFFECTIVE_DISK_PER_NODE_GIB] == 1900
+    assert result.cluster_params["cassandra.storage_buffer_ratio"] == pytest.approx(
+        1 / 0.55,
+        abs=0.01,
+    )
+
+
+def test_ebs_hotter_buffer_respects_disk_utilization_cap_with_adaptive_storage():
+    result = _plan_ebs(
+        _ebs_desires(),
+        adaptive_storage_buffer=True,
+    )
+    stricter = _plan_ebs(
+        _ebs_desires(),
+        adaptive_storage_buffer=True,
+        max_disk_utilization=0.50,
+    )
+
+    assert result.cluster_params["cassandra.storage_buffer_ratio"] == pytest.approx(
+        1 / 0.55,
+        abs=0.01,
+    )
+    assert result.cluster_params[EFFECTIVE_DISK_PER_NODE_GIB] == 1900
+    assert stricter.cluster_params["cassandra.storage_buffer_ratio"] == pytest.approx(
+        1 / 0.50,
+        abs=0.01,
+    )
+
+
+def test_disk_utilization_cap_does_not_weaken_default_buffer_fallback():
+    desires = _with_disk_utilization_buffer(_ebs_desires(), max_disk_utilization=0.55)
+
+    disk_buffer = buffer_for_components(
+        buffers=desires.buffers,
+        components=[BufferComponent.disk],
+    )
+
+    assert disk_buffer.ratio == pytest.approx(1 / 0.55, abs=0.01)
+
+
+def test_max_disk_utilization_must_not_exceed_default_target():
+    with pytest.raises(ValueError, match="max_disk_utilization"):
+        NflxCassandraArguments.from_extra_model_arguments(
+            {"max_disk_utilization": 0.56}
+        )
+
+    with pytest.raises(ValueError, match="max_disk_utilization"):
+        NflxCassandraArguments.from_extra_model_arguments({"max_disk_utilization": 0})


### PR DESCRIPTION
## What am I trying to do?

Cap Cassandra provisioned disk utilization at 55% after all storage and disk buffers are applied. This keeps additional headroom in generated plans while preserving the existing buffer composition model.

## Why did I do it this way?

### Apply the cap as a final disk-buffer floor

Cassandra already has several storage/disk influences: model storage buffers, explicit caller buffers, and the EBS-hotter multiplier. The helper reads the current composite disk buffer and injects only the missing multiplicative factor needed to reach `1 / max_disk_utilization`.

That means:

- existing buffers above the cap are preserved
- buffers below the cap are raised to the cap
- EBS-hotter still runs first, but cannot push the final provisioned utilization above the configured cap

### Keep the limit stricter-only

The extra model argument is `max_disk_utilization`. It defaults to `0.55`, and validation only allows stricter values. The field exists so a workload can request more headroom, not less.

### Keep the estimator contract narrow

The estimator receives `max_disk_utilization` as a scalar rather than the full argument object. That keeps this policy consistent with the surrounding scalar arguments like `max_page_cache_gib` and `backup_retention_days`.

## Are there any tests?

Yes. The tests cover the caller-visible EBS sizing behavior, stricter utilization overrides, the default-buffer fallback edge in the cap helper, and validation that rejects looser or invalid utilization values.

Validation run:

```bash
tox -e py312 -- tests/netflix/test_cassandra_ebs_buffer.py
tox -e capture-baseline
tox -e pre-commit
```

The commit hook also reran the repo pre-commit path, including baseline capture.

## How would I use the new code?

Default planning now enforces 55% maximum provisioned Cassandra disk utilization. A caller can request stricter headroom through extra model arguments:

```json
{
  "max_disk_utilization": 0.50
}
```

The generated baselines show the expected impact: affected EBS Cassandra scenarios provision larger volumes and their annual cost increases accordingly.
