### PR TITLE
Allow Cassandra min instance RAM override

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -655,23 +655,25 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
     backup_retention_days: Optional[float] = None,
     max_disk_utilization: float = CASSANDRA_MAX_DISK_UTILIZATION,
+    min_instance_ram_gib_exclusive: float = 16.0,
 ) -> Union[CapacityPlan, Excuse, None]:
     drive_name = drive.name
 
     # Netflix Cassandra doesn't like to deploy on really small instances
-    if instance.cpu < 2 or instance.ram_gib <= 16:
+    if instance.cpu < 2 or instance.ram_gib <= min_instance_ram_gib_exclusive:
         return Excuse(
             instance=instance.name,
             drive=drive_name,
             reason=(
                 f"Instance too small: {instance.cpu} vCPUs "
-                f"(min 2), {instance.ram_gib:.0f} GiB RAM (requires > 16 GiB)"
+                f"(min 2), {instance.ram_gib:.2f} GiB RAM "
+                f"(requires > {min_instance_ram_gib_exclusive:g} GiB)"
             ),
             context={
                 "cpu": instance.cpu,
                 "ram_gib": instance.ram_gib,
                 "min_cpu": 2,
-                "min_ram_gib_exclusive": 16,
+                "min_ram_gib_exclusive": min_instance_ram_gib_exclusive,
             },
             bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
         )
@@ -1185,6 +1187,11 @@ class NflxCassandraArguments(BaseModel):
         "Default 14.0 (derived from LCS production clusters). Lower for TWCS or "
         "aggressive TTL workloads where SSTables expire before retention matters.",
     )
+    min_instance_ram_gib_exclusive: float = Field(
+        default=16.0,
+        description="Exclusive minimum instance RAM (GiB) for Cassandra candidates. "
+        "Candidates with ram_gib <= this value are rejected.",
+    )
     adaptive_storage_buffer: bool = Field(
         default=True,
         description="Use a data-size-adaptive storage buffer instead of the fixed 4x. "
@@ -1461,6 +1468,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             max_page_cache_gib=args.max_page_cache_gib,
             backup_retention_days=args.backup_retention_days,
             max_disk_utilization=args.max_disk_utilization,
+            min_instance_ram_gib_exclusive=args.min_instance_ram_gib_exclusive,
         )
 
         return result

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -15,11 +15,13 @@ from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentZoneClusterCapacity
 from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import fixed_float
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models.org.netflix.cassandra import (
     _default_cluster_size_mode,
     _get_cluster_size_lambda,
@@ -886,6 +888,49 @@ class TestCassandraExtraModelArguments:
 
         args = NflxCassandraArguments.from_extra_model_arguments({})
         assert args.max_page_cache_gib == 28.0
+
+    def test_min_instance_ram_gib_exclusive_default(self):
+        from service_capacity_modeling.models.org.netflix.cassandra import (
+            NflxCassandraArguments,
+        )
+
+        args = NflxCassandraArguments.from_extra_model_arguments({})
+        assert args.min_instance_ram_gib_exclusive == 16.0
+
+    def test_default_min_instance_ram_rejects_m6id_xlarge(self):
+        hardware = shapes.region("us-east-1")
+        result = NflxCassandraCapacityModel.capacity_plan(
+            instance=hardware.instances["m6id.xlarge"],
+            drive=hardware.drives["gp3"],
+            context=RegionContext(
+                zones_in_region=hardware.zones_in_region,
+                services=hardware.services,
+            ),
+            desires=small_but_high_qps,
+            extra_model_arguments={},
+        )
+
+        assert isinstance(result, Excuse)
+        assert result.context["ram_gib"] == 15.26
+        assert result.context["min_ram_gib_exclusive"] == 16.0
+        assert "requires > 16 GiB" in result.reason
+
+    def test_min_instance_ram_override_allows_m6id_xlarge(self):
+        hardware = shapes.region("us-east-1")
+        result = NflxCassandraCapacityModel.capacity_plan(
+            instance=hardware.instances["m6id.xlarge"],
+            drive=hardware.drives["gp3"],
+            context=RegionContext(
+                zones_in_region=hardware.zones_in_region,
+                services=hardware.services,
+            ),
+            desires=small_but_high_qps,
+            extra_model_arguments={"min_instance_ram_gib_exclusive": 15.0},
+        )
+
+        assert not isinstance(result, Excuse)
+        assert result is not None
+        assert result.candidate_clusters.zonal[0].instance.name == "m6id.xlarge"
 
     def test_cluster_size_mode_extra_argument(self):
         from service_capacity_modeling.models.org.netflix.cassandra import (


### PR DESCRIPTION
## What am I trying to do?

Add a typed Cassandra extra model argument that lets callers lower the exclusive minimum instance RAM threshold when they intentionally need to evaluate an existing small-memory Cassandra shape.

The default remains unchanged: Cassandra candidates with RAM `<= 16 GiB` are rejected.

## Why did I do it this way?

### Preserve the existing default

`NflxCassandraArguments.min_instance_ram_gib_exclusive` defaults to `16.0`, so existing planner calls keep the same behavior as the previous hard-coded check.

### Make the boundary explicit

The field name includes `exclusive` because the planner accepts only candidates with RAM strictly greater than the threshold. That avoids the ambiguity of a plain `min_instance_ram_gib` field, where readers might assume `>= min` passes.

### Keep the exception caller-controlled

The override is an extra model argument, not an implicit special case. Callers that need current-shape planning for smaller deployed instances can pass a lower exclusive threshold, and planner excuses report the configured threshold in both the reason and context.

## Are there any tests?

Yes. Focused Cassandra tests verify that the default still rejects real `m6id.xlarge` RAM, and that `min_instance_ram_gib_exclusive=15.0` permits that current-shape candidate.

## Verification

```bash
tox -e py312 -- tests/netflix/test_cassandra.py::TestCassandraExtraModelArguments -q
```

Result: `36 passed`; tox also ran coverage and mypy successfully.