### PR TITLE
Allow looser Cassandra disk utilization override

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1239,10 +1239,11 @@ class NflxCassandraArguments(BaseModel):
     max_disk_utilization: float = Field(
         default=CASSANDRA_MAX_DISK_UTILIZATION,
         gt=0,
-        le=CASSANDRA_MAX_DISK_UTILIZATION,
+        le=1.0,
         description="Maximum planned disk utilization for provisioned Cassandra "
         f"clusters. Defaults to {CASSANDRA_MAX_DISK_UTILIZATION:.0%}. "
-        "This can only be made stricter per workload.",
+        "Lower values are more conservative; higher values allow denser current "
+        "shape planning.",
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary
- allow Cassandra `max_disk_utilization` extra model argument values above the default 55%, up to 100%
- update the field description to make lower-vs-higher density semantics explicit
- add a behavioral regression test proving the override changes the planner storage buffer ratio

## Validation
- `tox -e py312 -- tests/netflix/test_cassandra_disk_utilization.py tests/netflix/test_cassandra.py::TestCassandraExtraModelArguments -q`
- commit pre-commit hooks: ruff, ruff-format, flake8, mypy, pylint, baseline capture
- `git diff --check upstream/main...HEAD`

## Note
This does not by itself bypass attached-drive max-size/headroom constraints such as gp3 max-size/3 in `compute_stateful_zone`; it only makes the Cassandra disk utilization cap caller-tunable above the default.