### PR TITLE
EVCache: soft-penalize instance-family migrations (different_family_regret)

### DIFF
--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -226,6 +226,7 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
     max_regional_size: int = 10000,
     min_instance_memory_gib: int = 12,
     cross_region_replication: Replication = Replication.none,
+    different_family_regret: float = 0.0,
 ) -> Union[CapacityPlan, Excuse, None]:
     # EVCache doesn't like to deploy on single CPU instances
     if instance.cpu < 2:
@@ -353,13 +354,11 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
     }
     upsert_params(cluster, params)
 
-    # Penalize under-spread clusters via rank (deterministic sort) and
-    # regret (stochastic robustness). Uses the same additive dollar formula
-    # as before, but applied to plan.rank instead of annual_costs — keeping
-    # total_annual_cost honest while preserving identical selection order.
+    # Penalize under-spread clusters via rank (deterministic sort) and regret
+    # (stochastic robustness). Additive dollar formula applied to plan.rank
+    # instead of annual_costs — keeping total_annual_cost honest. Combined with
+    # the family-migration penalty into RANK_PENALTIES below.
     spread_cost = calculate_spread_cost(cluster.count)
-    if spread_cost > 0:
-        upsert_params(cluster, {RANK_PENALTIES: {"under_spread": spread_cost}})
 
     # evcache clusters generally should try to stay under some total number
     # of nodes. Orgs do this for all kinds of reasons such as
@@ -398,10 +397,45 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
     cluster.cluster_type = NflxEVCacheCapacityModel.cluster_type
     zonal_clusters = [cluster] * copies_per_region
 
-    evcache_costs = NflxEVCacheCapacityModel.cluster_costs(
+    compute_costs = NflxEVCacheCapacityModel.cluster_costs(
         service_type=NflxEVCacheCapacityModel.service_name,
         zonal_clusters=zonal_clusters,
     )
+    compute_cost = float(sum(compute_costs.values()))
+
+    # Bias scale-up toward the currently running instance family: a different
+    # family must be meaningfully cheaper (on compute) to out-rank the
+    # incumbent. Applied to plan.rank (and RANK_PENALTIES) so total_annual_cost
+    # stays honest. Unlike a hard exclude this never drops the candidate, so a
+    # different family still wins when it is genuinely much cheaper or when the
+    # current family cannot satisfy the requirement — which avoids failing the
+    # plan with empty results. Penalties are stored as dollar amounts (like
+    # under_spread), not as coefficients. Upserted before Clusters() is built so
+    # the params live on the cluster object the plan carries.
+    current_zonal = (
+        desires.current_clusters.zonal[0]
+        if desires.current_clusters and desires.current_clusters.zonal
+        else None
+    )
+    family_migration_cost = 0.0
+    if different_family_regret > 0 and current_zonal is not None:
+        current_family = (
+            current_zonal.cluster_instance.family
+            if current_zonal.cluster_instance is not None
+            else current_zonal.cluster_instance_name.rsplit(".", 1)[0]
+        )
+        if instance.family != current_family:
+            family_migration_cost = different_family_regret * compute_cost
+
+    penalties: Dict[str, float] = {}
+    if spread_cost > 0:
+        penalties["under_spread"] = spread_cost
+    if family_migration_cost > 0:
+        penalties["family_migration"] = family_migration_cost
+    if penalties:
+        upsert_params(cluster, {RANK_PENALTIES: penalties})
+
+    evcache_costs = dict(compute_costs)
     evcache_costs.update({s.service_type: s.annual_cost for s in services})
 
     clusters = Clusters(
@@ -411,7 +445,7 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         services=services,
     )
 
-    plan_rank = clusters.total_annual_cost + spread_cost
+    plan_rank = clusters.total_annual_cost + spread_cost + family_migration_cost
 
     return CapacityPlan(
         requirements=Requirements(
@@ -445,6 +479,20 @@ class NflxEVCacheArguments(BaseModel):
         description=(
             "Whether this evcache service does cross region replication. "
             "By default we do no replication"
+        ),
+    )
+    different_family_regret: float = Field(
+        default=0.0,
+        description=(
+            "Soft cost penalty (fraction of compute cost) added to the plan "
+            "rank when a candidate is a different instance family than the "
+            "currently running cluster. Biases scale-up recommendations toward "
+            "the incumbent family without excluding alternatives, so a "
+            "different family still wins when it is meaningfully cheaper "
+            "or when the current family cannot satisfy the requirement. Only "
+            "applies when a current cluster is provided. Defaults to 0 (off) so "
+            "general and right-sizing planning is unchanged; callers scaling an "
+            "existing cluster opt in (e.g. 0.10)."
         ),
     )
 
@@ -532,6 +580,12 @@ class NflxEVCacheCapacityModel(CapacityModel, CostAwareModel):
         cross_region_replication = Replication(
             extra_model_arguments.get("cross_region_replication", "none")
         )
+        # Soft preference for the currently running instance family on a
+        # scale-up: a different family must be this fraction cheaper (on
+        # compute) to be recommended over the incumbent. 0 disables it.
+        different_family_regret: float = float(
+            extra_model_arguments.get("different_family_regret", 0.0)
+        )
 
         return _estimate_evcache_cluster_zonal(
             instance=instance,
@@ -542,6 +596,7 @@ class NflxEVCacheCapacityModel(CapacityModel, CostAwareModel):
             max_local_data_per_node_gib=max_local_data_per_node_gib,
             min_instance_memory_gib=min_instance_memory_gib,
             cross_region_replication=cross_region_replication,
+            different_family_regret=different_family_regret,
             context=context,
         )
 

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -26,6 +26,7 @@ from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import CurrentZoneClusterCapacity
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import FixedInterval
@@ -215,6 +216,29 @@ def _estimate_evcache_requirement(
     )
 
 
+def _current_evcache_cluster(
+    desires: CapacityDesires,
+) -> Optional[CurrentZoneClusterCapacity]:
+    """Pick the current cluster the family-migration penalty should key off.
+
+    Prefer a zonal cluster explicitly tagged as evcache: when EVCache is a
+    sub-model of a composite (key-value / read-only-kv / graphkv), the current
+    clusters may also carry the Cassandra tier, so zonal[0] is not reliably the
+    EVCache cluster. When nothing is tagged, only a single current cluster is
+    unambiguously ours (direct EVCache planning); if several untagged clusters
+    are present we cannot identify ours, so return None (skip the penalty).
+    """
+    zonal = desires.current_clusters.zonal if desires.current_clusters else []
+    if not zonal:
+        return None
+    typed = [
+        c for c in zonal if c.cluster_type == NflxEVCacheCapacityModel.cluster_type
+    ]
+    if typed:
+        return typed[0]
+    return zonal[0] if len(zonal) == 1 else None
+
+
 def _compute_evcache_penalties(
     instance: Instance,
     desires: CapacityDesires,
@@ -232,8 +256,8 @@ def _compute_evcache_penalties(
       already runs; a different family must be meaningfully cheaper (on compute)
       to out-rank the incumbent. Soft, so a different family still wins when it
       is genuinely much cheaper or when the current family cannot satisfy the
-      requirement -- avoiding empty results. Only applies when a current cluster
-      is provided.
+      requirement -- avoiding empty results. Only applies when the current
+      EVCache cluster can be identified (see _current_evcache_cluster).
     """
     penalties: Dict[str, float] = {}
 
@@ -241,11 +265,7 @@ def _compute_evcache_penalties(
     if spread_cost > 0:
         penalties["under_spread"] = spread_cost
 
-    current = (
-        desires.current_clusters.zonal[0]
-        if desires.current_clusters and desires.current_clusters.zonal
-        else None
-    )
+    current = _current_evcache_cluster(desires)
     if different_family_regret > 0 and current is not None:
         current_family = (
             current.cluster_instance.family
@@ -504,17 +524,17 @@ class NflxEVCacheArguments(BaseModel):
         ),
     )
     different_family_regret: float = Field(
-        default=0.0,
+        default=0.05,
         description=(
             "Soft cost penalty (fraction of compute cost) added to the plan "
             "rank when a candidate is a different instance family than the "
-            "currently running cluster. Biases scale-up recommendations toward "
-            "the incumbent family without excluding alternatives, so a "
-            "different family still wins when it is meaningfully cheaper "
-            "or when the current family cannot satisfy the requirement. Only "
-            "applies when a current cluster is provided. Defaults to 0 (off) so "
-            "general and right-sizing planning is unchanged; callers scaling an "
-            "existing cluster opt in (e.g. 0.10)."
+            "current cluster. Biases re-plan / right-sizing recommendations "
+            "toward the incumbent family without excluding alternatives, so a "
+            "different family still wins when it is meaningfully cheaper or when "
+            "the current family cannot satisfy the requirement. Defaults to 0.05 "
+            "as an anti-thrashing floor (don't migrate families for <5% compute "
+            "savings); set to 0 to disable. Only applies when the current "
+            "EVCache cluster can be identified (see cluster_type)."
         ),
     )
 
@@ -606,7 +626,7 @@ class NflxEVCacheCapacityModel(CapacityModel, CostAwareModel):
         # scale-up: a different family must be this fraction cheaper (on
         # compute) to be recommended over the incumbent. 0 disables it.
         different_family_regret: float = float(
-            extra_model_arguments.get("different_family_regret", 0.0)
+            extra_model_arguments.get("different_family_regret", 0.05)
         )
 
         return _estimate_evcache_cluster_zonal(

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -215,6 +215,49 @@ def _estimate_evcache_requirement(
     )
 
 
+def _compute_evcache_penalties(
+    instance: Instance,
+    desires: CapacityDesires,
+    cluster_count: int,
+    compute_cost: float,
+    different_family_regret: float,
+) -> Dict[str, float]:
+    """Named rank penalties (in dollars) for an EVCache plan.
+
+    Penalties inflate plan.rank without touching total_annual_cost:
+        rank = total_annual_cost + sum(penalties.values())
+
+    - under_spread: discourages small / under-spread clusters.
+    - family_migration: biases scale-up toward the instance family the cluster
+      already runs; a different family must be meaningfully cheaper (on compute)
+      to out-rank the incumbent. Soft, so a different family still wins when it
+      is genuinely much cheaper or when the current family cannot satisfy the
+      requirement -- avoiding empty results. Only applies when a current cluster
+      is provided.
+    """
+    penalties: Dict[str, float] = {}
+
+    spread_cost = calculate_spread_cost(cluster_count)
+    if spread_cost > 0:
+        penalties["under_spread"] = spread_cost
+
+    current = (
+        desires.current_clusters.zonal[0]
+        if desires.current_clusters and desires.current_clusters.zonal
+        else None
+    )
+    if different_family_regret > 0 and current is not None:
+        current_family = (
+            current.cluster_instance.family
+            if current.cluster_instance is not None
+            else current.cluster_instance_name.rsplit(".", 1)[0]
+        )
+        if instance.family != current_family:
+            penalties["family_migration"] = different_family_regret * compute_cost
+
+    return penalties
+
+
 # pylint: disable=too-many-locals
 def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many-positional-arguments
     instance: Instance,
@@ -354,12 +397,6 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
     }
     upsert_params(cluster, params)
 
-    # Penalize under-spread clusters via rank (deterministic sort) and regret
-    # (stochastic robustness). Additive dollar formula applied to plan.rank
-    # instead of annual_costs — keeping total_annual_cost honest. Combined with
-    # the family-migration penalty into RANK_PENALTIES below.
-    spread_cost = calculate_spread_cost(cluster.count)
-
     # evcache clusters generally should try to stay under some total number
     # of nodes. Orgs do this for all kinds of reasons such as
     #   * Security group limits. Since you must have < 500 rules if you're
@@ -403,35 +440,20 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
     )
     compute_cost = float(sum(compute_costs.values()))
 
-    # Bias scale-up toward the currently running instance family: a different
-    # family must be meaningfully cheaper (on compute) to out-rank the
-    # incumbent. Applied to plan.rank (and RANK_PENALTIES) so total_annual_cost
-    # stays honest. Unlike a hard exclude this never drops the candidate, so a
-    # different family still wins when it is genuinely much cheaper or when the
-    # current family cannot satisfy the requirement — which avoids failing the
-    # plan with empty results. Penalties are stored as dollar amounts (like
-    # under_spread), not as coefficients. Upserted before Clusters() is built so
-    # the params live on the cluster object the plan carries.
-    current_zonal = (
-        desires.current_clusters.zonal[0]
-        if desires.current_clusters and desires.current_clusters.zonal
-        else None
+    # Rank penalties (under-spread + family-migration) bias plan.rank without
+    # touching total_annual_cost. Family-migration is a soft bias toward the
+    # currently running instance family: unlike a hard exclude it never drops
+    # the candidate, so a different family still wins when it is meaningfully
+    # cheaper or when the current family cannot satisfy the requirement. Upserted
+    # before Clusters() is built so the params live on the cluster object the
+    # plan carries; stored as dollar amounts (like under_spread).
+    penalties = _compute_evcache_penalties(
+        instance=instance,
+        desires=desires,
+        cluster_count=cluster.count,
+        compute_cost=compute_cost,
+        different_family_regret=different_family_regret,
     )
-    family_migration_cost = 0.0
-    if different_family_regret > 0 and current_zonal is not None:
-        current_family = (
-            current_zonal.cluster_instance.family
-            if current_zonal.cluster_instance is not None
-            else current_zonal.cluster_instance_name.rsplit(".", 1)[0]
-        )
-        if instance.family != current_family:
-            family_migration_cost = different_family_regret * compute_cost
-
-    penalties: Dict[str, float] = {}
-    if spread_cost > 0:
-        penalties["under_spread"] = spread_cost
-    if family_migration_cost > 0:
-        penalties["family_migration"] = family_migration_cost
     if penalties:
         upsert_params(cluster, {RANK_PENALTIES: penalties})
 
@@ -445,7 +467,7 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         services=services,
     )
 
-    plan_rank = clusters.total_annual_cost + spread_cost + family_migration_cost
+    plan_rank = clusters.total_annual_cost + sum(penalties.values())
 
     return CapacityPlan(
         requirements=Requirements(

--- a/tests/netflix/test_evcache.py
+++ b/tests/netflix/test_evcache.py
@@ -4,7 +4,16 @@ from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import (
     CapacityDesires,
 )
+from service_capacity_modeling.interface import Buffer
+from service_capacity_modeling.interface import BufferComponent
+from service_capacity_modeling.interface import BufferIntent
+from service_capacity_modeling.interface import Buffers
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentZoneClusterCapacity
 from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import DriveType
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.evcache import (
@@ -639,3 +648,135 @@ def test_evcache_spread_invariants(desires):
         else:
             # Well-spread clusters should not have under_spread penalty
             assert "under_spread" not in penalties
+
+
+def _disk_heavy_evcache_desires(
+    current_instance: str = "i3en.2xlarge",
+) -> CapacityDesires:
+    """A large, disk-bound EVCache cluster already running on `current_instance`
+    (default i3en.2xlarge). Exercises the family-migration penalty when scaling
+    up an existing cluster."""
+    nodes = 100
+    current = CurrentZoneClusterCapacity(
+        cluster_instance_name=current_instance,
+        cluster_instance_count=Interval(
+            low=nodes, mid=nodes, high=nodes, confidence=1.0
+        ),
+        cluster_drive=Drive(
+            name="ephem", drive_type=DriveType.local_ssd, size_gib=4657
+        ),
+        cpu_utilization=certain_float(15.0),
+        memory_utilization_gib=certain_float(48.0),
+        network_utilization_mbps=certain_float(200.0),
+        disk_utilization_gib=certain_float(3000.0),
+    )
+    buffers = Buffers(
+        derived={
+            "scale_compute": Buffer(
+                intent=BufferIntent.scale,
+                ratio=1.3,
+                components=[BufferComponent.compute],
+            ),
+            "preserve_storage": Buffer(
+                intent=BufferIntent.preserve,
+                components=[BufferComponent.storage],
+            ),
+        }
+    )
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=200000, mid=400000, high=480000, confidence=0.98
+            ),
+            estimated_write_per_second=Interval(
+                low=20000, mid=40000, high=48000, confidence=0.98
+            ),
+            estimated_mean_read_size_bytes=Interval(
+                low=1000, mid=40000, high=100000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=280000, mid=300000, high=320000, confidence=0.98
+            ),
+            estimated_state_item_count=Interval(
+                low=8_000_000_000,
+                mid=8_000_000_000,
+                high=8_000_000_000,
+                confidence=0.98,
+            ),
+        ),
+        current_clusters=CurrentClusters(zonal=[current]),
+        buffers=buffers,
+    )
+
+
+def test_evcache_different_family_regret():
+    from service_capacity_modeling.models import RANK_PENALTIES
+
+    desires = _disk_heavy_evcache_desires()
+
+    # Default (0.0): no family-migration penalty is applied anywhere, so
+    # behavior is unchanged from before the feature.
+    plan_default = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+    )
+    for p in plan_default:
+        penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
+        assert "family_migration" not in penalties
+
+    # Opted in: the incumbent family (i3en) is preferred (ranked first) but
+    # alternatives are NOT excluded -- this is a soft bias, so a scale-up never
+    # fails for lack of same-family candidates.
+    plan_on = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+        extra_model_arguments={"different_family_regret": 0.10},
+    )
+    families_on = [p.candidate_clusters.zonal[0].instance.family for p in plan_on]
+    assert families_on[0] == "i3en", f"incumbent should rank first, got {families_on}"
+    assert len(set(families_on)) > 1, (
+        f"alternatives should remain available, got {families_on}"
+    )
+
+    # The incumbent carries no migration penalty; a different family carries the
+    # penalty, which inflates its rank above the (honest) total_annual_cost.
+    for p in plan_on:
+        family = p.candidate_clusters.zonal[0].instance.family
+        penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
+        if family == "i3en":
+            assert "family_migration" not in penalties
+        else:
+            assert penalties.get("family_migration", 0) > 0
+            assert p.rank > p.candidate_clusters.total_annual_cost
+
+
+def test_evcache_different_family_regret_flips_selection():
+    # A cluster already on i7ie: without a penalty the cheaper i3en family wins
+    # the top slot ...
+    desires = _disk_heavy_evcache_desires(current_instance="i7ie.2xlarge")
+    no_penalty = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+    )
+    assert no_penalty[0].candidate_clusters.zonal[0].instance.family == "i3en"
+
+    # ... but a large enough migration penalty flips the top pick back to the
+    # incumbent family (i7ie). This proves the penalty actually changes the
+    # selected plan, not merely annotates it.
+    with_penalty = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+        extra_model_arguments={"different_family_regret": 0.5},
+    )
+    assert with_penalty[0].candidate_clusters.zonal[0].instance.family == "i7ie"

--- a/tests/netflix/test_evcache.py
+++ b/tests/netflix/test_evcache.py
@@ -712,42 +712,43 @@ def _disk_heavy_evcache_desires(
     )
 
 
+def _zone_cluster(
+    instance_name: str, cluster_type: str | None = None
+) -> CurrentZoneClusterCapacity:
+    """A single disk-bound current zonal cluster, optionally tier-tagged."""
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name=instance_name,
+        cluster_type=cluster_type,
+        cluster_instance_count=Interval(low=100, mid=100, high=100, confidence=1.0),
+        cluster_drive=Drive(
+            name="ephem", drive_type=DriveType.local_ssd, size_gib=4657
+        ),
+        cpu_utilization=certain_float(15.0),
+        memory_utilization_gib=certain_float(48.0),
+        network_utilization_mbps=certain_float(200.0),
+        disk_utilization_gib=certain_float(3000.0),
+    )
+
+
 def test_evcache_different_family_regret():
     from service_capacity_modeling.models import RANK_PENALTIES
 
     desires = _disk_heavy_evcache_desires()
 
-    # Default (0.0): no family-migration penalty is applied anywhere, so
-    # behavior is unchanged from before the feature.
-    plan_default = planner.plan_certain(
+    # The default (0.05) applies the family-migration penalty: the incumbent
+    # (i3en) carries none, a different family carries it (rank > honest cost),
+    # and the incumbent ranks first while alternatives remain available (soft
+    # bias -- a scale-up never fails for lack of same-family candidates).
+    plans = planner.plan_certain(
         model_name="org.netflix.evcache",
         region="us-east-1",
         desires=desires,
         num_results=6,
     )
-    for p in plan_default:
-        penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
-        assert "family_migration" not in penalties
-
-    # Opted in: the incumbent family (i3en) is preferred (ranked first) but
-    # alternatives are NOT excluded -- this is a soft bias, so a scale-up never
-    # fails for lack of same-family candidates.
-    plan_on = planner.plan_certain(
-        model_name="org.netflix.evcache",
-        region="us-east-1",
-        desires=desires,
-        num_results=6,
-        extra_model_arguments={"different_family_regret": 0.10},
-    )
-    families_on = [p.candidate_clusters.zonal[0].instance.family for p in plan_on]
-    assert families_on[0] == "i3en", f"incumbent should rank first, got {families_on}"
-    assert len(set(families_on)) > 1, (
-        f"alternatives should remain available, got {families_on}"
-    )
-
-    # The incumbent carries no migration penalty; a different family carries the
-    # penalty, which inflates its rank above the (honest) total_annual_cost.
-    for p in plan_on:
+    families = [p.candidate_clusters.zonal[0].instance.family for p in plans]
+    assert families[0] == "i3en", f"incumbent should rank first, got {families}"
+    assert len(set(families)) > 1, f"alternatives should remain, got {families}"
+    for p in plans:
         family = p.candidate_clusters.zonal[0].instance.family
         penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
         if family == "i3en":
@@ -756,22 +757,34 @@ def test_evcache_different_family_regret():
             assert penalties.get("family_migration", 0) > 0
             assert p.rank > p.candidate_clusters.total_annual_cost
 
+    # Explicitly disabling (0.0) removes the family-migration penalty entirely.
+    plans_off = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+        extra_model_arguments={"different_family_regret": 0.0},
+    )
+    for p in plans_off:
+        penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
+        assert "family_migration" not in penalties
+
 
 def test_evcache_different_family_regret_flips_selection():
-    # A cluster already on i7ie: without a penalty the cheaper i3en family wins
-    # the top slot ...
+    # A cluster already on i7ie: with the penalty disabled the cheaper i3en
+    # family wins the top slot ...
     desires = _disk_heavy_evcache_desires(current_instance="i7ie.2xlarge")
     no_penalty = planner.plan_certain(
         model_name="org.netflix.evcache",
         region="us-east-1",
         desires=desires,
         num_results=6,
+        extra_model_arguments={"different_family_regret": 0.0},
     )
     assert no_penalty[0].candidate_clusters.zonal[0].instance.family == "i3en"
 
     # ... but a large enough migration penalty flips the top pick back to the
-    # incumbent family (i7ie). This proves the penalty actually changes the
-    # selected plan, not merely annotates it.
+    # incumbent family (i7ie), proving the penalty changes the selected plan.
     with_penalty = planner.plan_certain(
         model_name="org.netflix.evcache",
         region="us-east-1",
@@ -780,3 +793,71 @@ def test_evcache_different_family_regret_flips_selection():
         extra_model_arguments={"different_family_regret": 0.5},
     )
     assert with_penalty[0].candidate_clusters.zonal[0].instance.family == "i7ie"
+
+
+def test_evcache_family_penalty_targets_evcache_typed_current_cluster():
+    # Composed-style current state: a non-EVCache tier (i4i, tagged cassandra)
+    # at zonal[0], then the EVCache tier (i3en, tagged evcache). The penalty
+    # must key off the evcache-typed cluster, NOT zonal[0].
+    from service_capacity_modeling.models import RANK_PENALTIES
+
+    desires = _disk_heavy_evcache_desires().model_copy(
+        update={
+            "current_clusters": CurrentClusters(
+                zonal=[
+                    _zone_cluster("i4i.2xlarge", cluster_type="cassandra"),
+                    _zone_cluster("i3en.2xlarge", cluster_type="evcache"),
+                ]
+            )
+        }
+    )
+    plans = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=8,
+        extra_model_arguments={"different_family_regret": 0.5},
+    )
+    by_family = {p.candidate_clusters.zonal[0].instance.family: p for p in plans}
+    # i3en is the evcache-typed incumbent -> no penalty. Had the selection used
+    # zonal[0] (i4i), i3en would be "different" and carry a penalty instead.
+    assert "i3en" in by_family
+    i3en_penalties = (
+        by_family["i3en"]
+        .candidate_clusters.zonal[0]
+        .cluster_params.get(RANK_PENALTIES, {})
+    )
+    assert "family_migration" not in i3en_penalties
+    penalized = [
+        family
+        for family, p in by_family.items()
+        if p.candidate_clusters.zonal[0]
+        .cluster_params.get(RANK_PENALTIES, {})
+        .get("family_migration", 0)
+        > 0
+    ]
+    assert penalized and "i3en" not in penalized
+
+
+def test_evcache_family_penalty_skipped_for_ambiguous_untyped_current():
+    # Two untagged current clusters -> the model can't tell which is the EVCache
+    # tier, so it skips the family-migration penalty rather than guess.
+    from service_capacity_modeling.models import RANK_PENALTIES
+
+    desires = _disk_heavy_evcache_desires().model_copy(
+        update={
+            "current_clusters": CurrentClusters(
+                zonal=[_zone_cluster("i4i.2xlarge"), _zone_cluster("i3en.2xlarge")]
+            )
+        }
+    )
+    plans = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=desires,
+        num_results=6,
+        extra_model_arguments={"different_family_regret": 0.5},
+    )
+    for p in plans:
+        penalties = p.candidate_clusters.zonal[0].cluster_params.get(RANK_PENALTIES, {})
+        assert "family_migration" not in penalties


### PR DESCRIPTION
## Summary
Adds `different_family_regret` to `NflxEVCacheCapacityModel` — a soft penalty
that biases recommendations toward the instance family a cluster is already
running on, without excluding alternatives. **Defaults to `0.05`** (a 5%
anti-thrashing floor); set to `0` to disable.

## Motivation
When re-planning an existing EVCache cluster, the planner ranks purely by cost,
so it can recommend migrating to a *different* instance family that ranks only
marginally cheaper. Reservations are family-specific, so a family migration
carries real switching cost (on-demand premium until new reservations land) —
it isn't worth it for a couple percent of savings. A small default penalty
prevents this migration thrashing: don't switch families for <5% compute
savings.

This mirrors mechanisms already in the sibling models — Cassandra's
`different_family_regret` (also a soft rank penalty) and Kafka's
`require_same_instance_family` — and follows Cassandra's soft-penalty design.

## Behavior
- When `different_family_regret > 0` and a current EVCache cluster is present,
  a candidate whose `instance.family` differs from the current cluster's family
  gets `different_family_regret * compute_cost` added to its `plan.rank`
  (recorded under `RANK_PENALTIES`).
- **Soft, not hard:** a different family still wins when it is meaningfully
  cheaper, or when the current family can't satisfy the requirement — a plan is
  never returned empty for lack of same-family candidates.
- `total_annual_cost` stays honest (only `rank` is adjusted). The penalty
  applies to compute cost only, not fixed service (network) costs. `regret()`
  is unaffected — family migration is a fixed switching cost, so it biases the
  deterministic rank only (matching Cassandra's rationale).
- Only applies when the current EVCache cluster can be identified (see
  Composability below); no effect on greenfield planning (no current cluster).

## Composability (EVCache as a sub-model)
EVCache is composed by `key-value` / `read-only-kv` / `graphkv`, where
`current_clusters` may also carry the Cassandra tier — so `zonal[0]` is not
reliably the EVCache cluster. The new `_current_evcache_cluster` selects the
current cluster the penalty keys off:
- prefer a zonal entry tagged `cluster_type == "evcache"`;
- else fall back to `zonal[0]` **only** when there is a single current cluster
  (unambiguous, direct EVCache planning);
- else return `None` and skip the penalty (can't identify our tier → don't guess).

This keeps composite plans from being biased toward the Cassandra family.

## Tests
- `test_evcache_different_family_regret`: default applies the penalty (incumbent
  carries none; a different family carries one that inflates `rank` above the
  honest `total_annual_cost`; alternatives remain available); `0.0` disables it.
- `test_evcache_different_family_regret_flips_selection`: a cheaper family wins
  with the penalty off, and a large penalty flips the top pick back to the
  incumbent — proving the penalty changes the selected plan, not just annotates
  it.
- `test_evcache_family_penalty_targets_evcache_typed_current_cluster` and
  `test_evcache_family_penalty_skipped_for_ambiguous_untyped_current`: verify
  the composability rules above.

## Verification
- `pytest tests/netflix/` full suite passes; composed `key-value` /
  `read-only-kv` / `graphkv` suites unchanged.
- `ruff` (check + format), `flake8`, `mypy` (strict), `pylint` (10/10, no new
  waivers) all clean; `tox -e capture-baseline` produces no diff