### PR TITLE
Stop tier-local reservations crossing model composition boundaries

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1488,10 +1488,16 @@ class CapacityPlanner:
             )
 
             # We might have to compose this model with others depending on
-            # the user requirement
+            # the user requirement. What crosses that boundary is the composing
+            # model's call -- see CapacityModel.desires_for_composed_model,
+            # which by default drops reservations describing this model's own
+            # instances. It runs before the per-child transform so a transform
+            # that sets something deliberately still wins.
+            child_desires = self._models[sub_model].desires_for_composed_model(desires)
+
             queue.extend(
                 [
-                    (modify_child_desires(desires), child_model)
+                    (modify_child_desires(child_desires), child_model)
                     for child_model, modify_child_desires in self._models[
                         sub_model
                     ].compose_with(desires, extra_model_arguments)

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1493,14 +1493,21 @@ class CapacityPlanner:
             # which by default drops reservations describing this model's own
             # instances. It runs before the per-child transform so a transform
             # that sets something deliberately still wins.
-            child_desires = self._models[sub_model].desires_for_composed_model(desires)
+            #
+            # Both start from parent_desires, the desires this model was handed,
+            # so a chain composes: GraphKV amplifies logical traffic into KeyValue
+            # operations, and Cassandra sees the amplified figures rather than the
+            # user's original ones.
+            child_desires = self._models[sub_model].desires_for_composed_model(
+                parent_desires
+            )
 
             queue.extend(
                 [
                     (modify_child_desires(child_desires), child_model)
                     for child_model, modify_child_desires in self._models[
                         sub_model
-                    ].compose_with(desires, extra_model_arguments)
+                    ].compose_with(parent_desires, extra_model_arguments)
                 ]
             )
 

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -61,6 +61,7 @@ from service_capacity_modeling.interface import SampleRef
 from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import CostAwareModel
+from service_capacity_modeling.models.common import current_cluster_capacity
 from service_capacity_modeling.models.common import get_disk_size_gib
 from service_capacity_modeling.models.common import merge_plan
 from service_capacity_modeling.models.org import netflix
@@ -1064,7 +1065,9 @@ class CapacityPlanner:
         )
 
     # Calculates the minimum cpu, memory, and network requirements based on desires.
-    def _per_instance_requirements(self, desires: CapacityDesires) -> Tuple[int, float]:
+    def _per_instance_requirements(
+        self, model: CapacityModel, desires: CapacityDesires
+    ) -> Tuple[int, float]:
         # Applications often set fixed reservations of heap or OS memory
         per_instance_mem = (
             desires.data_shape.reserved_instance_app_mem_gib
@@ -1079,12 +1082,9 @@ class CapacityPlanner:
             )
         )
 
-        current_capacity: Optional[CurrentClusterCapacity] = None
-        if desires.current_clusters is not None:
-            if desires.current_clusters.zonal:
-                current_capacity = desires.current_clusters.zonal[0]
-            elif desires.current_clusters.regional:
-                current_capacity = desires.current_clusters.regional[0]
+        current_capacity = current_cluster_capacity(
+            desires, getattr(model, "cluster_type", "")
+        )
         # Return early if we dont have current_capacity set.
         if current_capacity is None or current_capacity.cluster_instance is None:
             return (per_instance_cores, per_instance_mem)
@@ -1128,7 +1128,7 @@ class CapacityPlanner:
         (
             per_instance_cores,
             per_instance_mem,
-        ) = self._per_instance_requirements(desires)
+        ) = self._per_instance_requirements(model, desires)
 
         if model.run_hardware_simulation():
             for instance in hardware.instances.values():

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -331,6 +331,29 @@ class CapacityModel:
         return True
 
     @staticmethod
+    def desires_for_composed_model(desires: CapacityDesires) -> CapacityDesires:
+        """Adjust desires before they cross into a model composed with this one.
+
+        The planner applies this to every model named by compose_with, before
+        that model's own transform runs, so a transform that sets something
+        deliberately still wins.
+
+        The default drops reserved_instance_app_mem_gib. That field is memory
+        per instance of the tier it was written for, and a composed model runs
+        on its own shapes -- a KeyValue request reserving 24 GiB for the dgwkv
+        Java app should not make Cassandra hold back 24 GiB per node for an app
+        that is not on the box. Unsetting it (rather than picking a number)
+        lets the composed model's own default_desires supply the reserve.
+
+        Override to keep it, or to add boundary rules of your own.
+        """
+        data_shape = desires.data_shape.model_dump(exclude_unset=True)
+        data_shape.pop("reserved_instance_app_mem_gib", None)
+        return desires.model_copy(
+            deep=True, update={"data_shape": DataShape(**data_shape)}
+        )
+
+    @staticmethod
     def compose_with(
         user_desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -30,7 +30,6 @@ from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import ClusterCapacity
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import CurrentClusterCapacity
-from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import default_reference_shape
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import Instance
@@ -1258,14 +1257,19 @@ def current_cluster_capacity(
 
 
 def zonal_requirements_from_current(
-    current_cluster: CurrentClusters,
+    current_capacity: Optional[CurrentClusterCapacity],
     buffers: Buffers,
     instance: Instance,
     reference_shape: Instance,
 ) -> CapacityRequirement:
-    if current_cluster is not None and current_cluster.zonal[0] is not None:
-        current_capacity: CurrentClusterCapacity = current_cluster.zonal[0]
+    """Size against a cluster the caller already runs.
 
+    Takes the model's own current cluster rather than the whole
+    CurrentClusters list -- picking one out of that list is the caller's job
+    (see current_cluster_capacity), because in a composed request the list
+    holds a cluster per tier.
+    """
+    if current_capacity is not None:
         # Adjust the CPUs (vCPU + cores) based on generation / instance type
         requirement = RequirementFromCurrentCapacity(
             current_capacity=current_capacity,

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -1227,6 +1227,36 @@ class RequirementFromCurrentCapacity(BaseModel):
         )
 
 
+def current_cluster_capacity(
+    desires: CapacityDesires, cluster_type: str
+) -> Optional[CurrentClusterCapacity]:
+    """The caller's existing cluster for this model, if they described one.
+
+    A composed request carries a current cluster per tier: a KeyValue plan
+    describes dgwkv, Cassandra and EVCache, and Cassandra and EVCache are
+    both zonal. Taking whichever entry came first meant a model could size
+    itself against another tier's topology, so match on ``cluster_type`` --
+    the field exists for exactly this and nothing was reading it.
+
+    Entries written before the field was populated carry no ``cluster_type``.
+    When none of them does, fall back to the first entry so those callers
+    keep working. When some are labelled but none is ours, the caller told us
+    about other tiers and not this one, so there is no current cluster.
+    """
+    clusters = desires.current_clusters
+    if clusters is None:
+        return None
+
+    candidates: List[CurrentClusterCapacity] = [*clusters.zonal, *clusters.regional]
+    for candidate in candidates:
+        if candidate.cluster_type == cluster_type:
+            return candidate
+
+    if any(candidate.cluster_type for candidate in candidates):
+        return None
+    return candidates[0] if candidates else None
+
+
 def zonal_requirements_from_current(
     current_cluster: CurrentClusters,
     buffers: Buffers,

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -539,6 +539,19 @@ def compute_stateless_region(  # pylint: disable=too-many-positional-arguments
 # ---------------------------------------------------------------------------
 
 
+def usable_memory_gib(
+    instance: Instance, reserve_memory: Callable[[float], float]
+) -> float:
+    """RAM one node can give the datastore after reservations.
+
+    Reservations are things like the JVM heap, sidecars, and the OS. Zero or
+    less means the shape cannot host the workload at all: no node count
+    satisfies a memory requirement, so callers must reject the shape rather
+    than size a cluster out of it.
+    """
+    return instance.ram_gib - reserve_memory(instance.ram_gib)
+
+
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-statements
 def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
@@ -574,9 +587,17 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
     count_cpu = math.ceil(needed_cores / instance.cpu)
 
     # Memory (write-buffer floor bumps count when writes dominate)
-    count_memory = math.ceil(
-        needed_memory_gib / (instance.ram_gib - reserve_memory(instance.ram_gib))
-    )
+    memory_per_node_gib = usable_memory_gib(instance, reserve_memory)
+    if memory_per_node_gib <= 0:
+        raise ValueError(
+            f"{instance.name} reserves "
+            f"{instance.ram_gib - memory_per_node_gib} GiB of its "
+            f"{instance.ram_gib} GiB of RAM, leaving {memory_per_node_gib} GiB "
+            "for the datastore. No node count satisfies the memory "
+            "requirement, so this shape must be rejected before sizing "
+            "a cluster."
+        )
+    count_memory = math.ceil(needed_memory_gib / memory_per_node_gib)
     if write_buffer(instance.ram_gib) > 0:
         count_memory = max(
             count_memory,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -678,6 +678,33 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
         )
 
+    # The 16 GiB floor above is workload independent, but the reserved app and
+    # system memory is not. Once the JVM heap and those reserves are carved out
+    # there has to be RAM left for page cache, otherwise Cassandra has nowhere
+    # to keep its working set and this shape cannot run the workload at all.
+    base_mem = base_memory_gib(desires)
+    node_memory = MemoryLayout.for_ram(
+        ram_gib=instance.ram_gib,
+        base_reserves_gib=base_mem,
+        max_page_cache_gib=max_page_cache_gib,
+    )
+    if node_memory.page_cache_capacity_gib <= 0:
+        return Excuse(
+            instance=instance.name,
+            drive=drive_name,
+            reason=(
+                f"No page cache left: {instance.ram_gib:.0f} GiB RAM - "
+                f"{node_memory.heap_gib:.0f} GiB heap - {base_mem:.0f} GiB "
+                f"reserved app and system memory"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "heap_gib": node_memory.heap_gib,
+                "base_reserves_gib": base_mem,
+            },
+            bottleneck=Bottleneck.memory,
+        )
+
     # if we're not allowed to use gp2, skip EBS only types
     if instance.drive is None and require_local_disks:
         return Excuse(
@@ -821,8 +848,6 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         disk_per_node_gib=effective_disk_per_node_gib,
         cluster_size_lambda=cluster_size_lambda,
     )
-
-    base_mem = base_memory_gib(desires)
 
     @lru_cache(maxsize=None)
     def memory_layout(ram_gib: float) -> MemoryLayout:

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -39,6 +39,7 @@ from service_capacity_modeling.explainability import STATEFUL_DATASTORE_FAMILIES
 from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import default_reference_shape
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import normalized_aws_size
 from service_capacity_modeling.interface import Interval
@@ -51,6 +52,7 @@ from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models import RANK_PENALTIES
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
+from service_capacity_modeling.models.common import current_cluster_capacity
 from service_capacity_modeling.models.common import DerivedBuffers
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_disk_size_gib
@@ -239,13 +241,27 @@ def _write_buffer_gib_zone(
     return float(write_buffer_gib) / zones_per_region
 
 
+def _cassandra_reference_shape(desires: CapacityDesires) -> Instance:
+    """The shape Cassandra's core counts are normalized against.
+
+    CapacityDesires.reference_shape reads current_clusters.zonal[0], which in
+    a composed request can be another tier's cluster -- EVCache is zonal too.
+    Normalize against Cassandra's own current shape, or the default when the
+    caller did not describe one.
+    """
+    current_capacity = _get_current_capacity(desires)
+    if current_capacity is not None and current_capacity.cluster_instance is not None:
+        return current_capacity.cluster_instance
+    return default_reference_shape
+
+
 def _get_cores_from_desires(desires: CapacityDesires, instance: Instance) -> int:
     cpu_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BACKGROUND_BUFFER]
     )
 
     # We have no existing utilization to go from
-    reference_shape = desires.reference_shape
+    reference_shape = _cassandra_reference_shape(desires)
     # Keep half of the cores free for background work (compaction, backup, repair).
     needed_cores = math.ceil(sqrt_staffed_cores(desires) * cpu_buffer.ratio)
 
@@ -417,13 +433,13 @@ def _estimate_cassandra_requirement(
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
-    reference_shape = desires.reference_shape
+    reference_shape = _cassandra_reference_shape(desires)
     current_capacity = _get_current_capacity(desires)
 
     # If the cluster is already provisioned
     if current_capacity and desires.current_clusters is not None:
         capacity_requirement = zonal_requirements_from_current(
-            desires.current_clusters,
+            current_capacity,
             desires.buffers,
             instance,
             reference_shape,
@@ -565,13 +581,7 @@ def _get_current_cluster_size(desires: CapacityDesires) -> int:
 
 
 def _get_current_capacity(desires: CapacityDesires) -> Optional[CurrentClusterCapacity]:
-    if desires.current_clusters is None:
-        return None
-    if desires.current_clusters.zonal:
-        return desires.current_clusters.zonal[0]
-    if desires.current_clusters.regional:
-        return desires.current_clusters.regional[0]
-    return None
+    return current_cluster_capacity(desires, NflxCassandraCapacityModel.cluster_type)
 
 
 def _get_cluster_size_lambda(
@@ -1083,11 +1093,8 @@ def _estimate_zonal_data_gib(user_desires: CapacityDesires, rf: int) -> float:
     Prefers actual current_clusters data; falls back to estimated_state_size_gib
     divided by compression ratio (matching the on-disk units of the first path).
     """
-    if (
-        user_desires.current_clusters is not None
-        and user_desires.current_clusters.zonal
-    ):
-        cc = user_desires.current_clusters.zonal[0]
+    cc = _get_current_capacity(user_desires)
+    if cc is not None:
         if (
             cc.disk_utilization_gib is not None
             and cc.disk_utilization_gib.mid > 0

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -14,6 +15,7 @@ from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import Buffers
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
@@ -22,6 +24,7 @@ from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import Interval
@@ -203,7 +206,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         copies_per_region: int = _target_rf(
             desires, extra_model_arguments.get("copies_per_region", None)
         )
@@ -224,7 +227,21 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
 
         # Netflix Elasticsearch doesn't like to deploy on really small instances
         if instance.cpu < 2 or instance.ram_gib < 24:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (min 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (min 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu": 2,
+                    "min_ram_gib": 24,
+                },
+                bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
+            )
 
         # Sidecars/System takes away memory from Elasticsearch
         # which uses half of available system max of 32 for compressed oops
@@ -239,12 +256,32 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         # The 24 GiB floor above ignores the workload's reserved memory. If the
         # reserves swallow the whole instance there is nothing left to hold
         # shards, so no node count works and the shape has to go.
-        if usable_memory_gib(instance, reserve_memory) <= 0:
-            return None
+        usable_gib = usable_memory_gib(instance, reserve_memory)
+        if usable_gib <= 0:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
+                    f"leaves no RAM for shards on a {instance.ram_gib:.0f} GiB shape"
+                ),
+                context={
+                    "ram_gib": instance.ram_gib,
+                    "reserved_gib": reserve_memory(instance.ram_gib),
+                    "usable_gib": usable_gib,
+                },
+                bottleneck=Bottleneck.memory,
+            )
 
         # Right now Elasticsearch doesn't deploy to cloud drives
         if instance.drive is None:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=f"Requires local disks but {instance.name} is EBS-only",
+                context={"has_local_drive": False},
+                bottleneck=Bottleneck.drive_type,
+            )
 
         zones_in_region = context.zones_in_region
 
@@ -338,8 +375,23 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         #    smaller clusters so your restarts don't take months.
         #  * NxN network issues. Sometimes smaller clusters of bigger nodes
         #    are better for network propagation
-        if data_cluster.count > (max_regional_size // zones_in_region):
-            return None
+        max_zonal_size = max_regional_size // zones_in_region
+        if data_cluster.count > max_zonal_size:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Needs {data_cluster.count} nodes per zone, over the "
+                    f"{max_zonal_size} allowed by max_regional_size "
+                    f"({max_regional_size})"
+                ),
+                context={
+                    "count": data_cluster.count,
+                    "max_zonal_size": max_zonal_size,
+                    "max_regional_size": max_regional_size,
+                },
+                bottleneck=Bottleneck.cluster_size,
+            )
 
         ec2_costs = {
             "elasticsearch-data.zonal-clusters": zones_in_region
@@ -368,12 +420,26 @@ class NflxElasticsearchMasterCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(
@@ -413,12 +479,26 @@ class NflxElasticsearchSearchCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -36,6 +36,7 @@ from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_effective_disk_per_node_gib
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import upsert_params
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import working_set_from_drive_and_slo
@@ -225,6 +226,22 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         if instance.cpu < 2 or instance.ram_gib < 24:
             return None
 
+        # Sidecars/System takes away memory from Elasticsearch
+        # which uses half of available system max of 32 for compressed oops
+        base_mem = (
+            desires.data_shape.reserved_instance_app_mem_gib
+            + desires.data_shape.reserved_instance_system_mem_gib
+        )
+
+        def reserve_memory(instance_mem_gib: float) -> float:
+            return base_mem + max(32, instance_mem_gib / 2)
+
+        # The 24 GiB floor above ignores the workload's reserved memory. If the
+        # reserves swallow the whole instance there is nothing left to hold
+        # shards, so no node count works and the shape has to go.
+        if usable_memory_gib(instance, reserve_memory) <= 0:
+            return None
+
         # Right now Elasticsearch doesn't deploy to cloud drives
         if instance.drive is None:
             return None
@@ -260,11 +277,6 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             copies_per_region=copies_per_region,
             max_rps_to_disk=max_rps_to_disk,
         )
-        base_mem = (
-            desires.data_shape.reserved_instance_app_mem_gib
-            + desires.data_shape.reserved_instance_system_mem_gib
-        )
-
         data_write_per_sec = (
             desires.query_pattern.estimated_write_per_second.mid // zones_in_region
         )
@@ -309,9 +321,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             # Elasticsearch clusters can auto-balance via shard placement
             cluster_size=lambda x: x,
             min_count=min_count,
-            # Sidecars/System takes away memory from Elasticsearch
-            # which uses half of available system max of 32 for compressed oops
-            reserve_memory=lambda x: base_mem + max(32, x / 2),
+            reserve_memory=reserve_memory,
         )
         data_cluster.cluster_type = "elasticsearch-data"
 

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -46,6 +46,7 @@ from service_capacity_modeling.models.common import get_effective_disk_per_node_
 from service_capacity_modeling.models.common import network_services
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import upsert_params
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.common import RequirementFromCurrentCapacity
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -301,6 +302,23 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         # OS memory.
         variable_os = int(instance_mem_gib * 0.03)
         return base_mem + variable_os
+
+    # If the reserves swallow the whole instance there is nothing left to cache
+    # with, so no node count works and the shape has to go.
+    if usable_memory_gib(instance, reserve_memory) <= 0:
+        return Excuse(
+            instance=instance.name,
+            drive=drive.name,
+            reason=(
+                f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
+                f"leaves no RAM for EVCache on a {instance.ram_gib:.0f} GiB shape"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "reserved_gib": reserve_memory(instance.ram_gib),
+            },
+            bottleneck=Bottleneck.memory,
+        )
 
     requirement.context["osmem"] = reserve_memory(instance.ram_gib)
     # EVCache clusters aim to be at least 2 nodes per zone to start

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -327,10 +327,30 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     )
 
     # Account for sidecars and base system memory
-    base_mem = (
+    # Kafka currently uses 8GiB fixed, might want to change to min(30, x // 2)
+    reserved_mem_gib = (
         desires.data_shape.reserved_instance_app_mem_gib
         + desires.data_shape.reserved_instance_system_mem_gib
+        + 8
     )
+
+    # The min_instance_memory_gib floor above ignores the workload's reserved
+    # memory. If the reserves swallow the whole instance there is nothing left
+    # to hold partitions, so no node count works and the shape has to go.
+    if instance.ram_gib <= reserved_mem_gib:
+        return Excuse(
+            instance=instance.name,
+            drive=drive.name,
+            reason=(
+                f"Reserved memory ({reserved_mem_gib:.0f} GiB) leaves no RAM "
+                f"for Kafka on a {instance.ram_gib:.0f} GiB shape"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "reserved_gib": reserved_mem_gib,
+            },
+            bottleneck=Bottleneck.memory,
+        )
 
     # Kafka clusters in prod (tier 0+1) need at least 2 nodes per zone
     min_count_for_tier = 1
@@ -392,9 +412,7 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
         ),
         cluster_size=lambda x: x,
         min_count=max(min_count_for_tier, min_count_for_data, required_zone_size or 1),
-        # Sidecars and Variable OS Memory
-        # Kafka currently uses 8GiB fixed, might want to change to min(30, x // 2)
-        reserve_memory=lambda instance_mem_gib: base_mem + 8,
+        reserve_memory=lambda _instance_mem_gib: reserved_mem_gib,
     )
 
     # Communicate to the actual provision that if we want reduced RF

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -151,7 +151,7 @@ def _estimate_kafka_requirement(  # pylint: disable=too-many-positional-argument
             low=curr_network.high, mid=curr_network.high, high=curr_network.high
         )
         capacity_requirement = zonal_requirements_from_current(
-            current_cluster=normalize_midpoint_desires.current_clusters,
+            current_capacity=normalize_midpoint_desires.current_clusters.zonal[0],
             buffers=desires.buffers,
             instance=instance,
             reference_shape=current_zonal_capacity.cluster_instance,

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -46,20 +46,6 @@ class NflxKeyValueArguments(NflxJavaAppArguments):
     )
 
 
-def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
-    """Drop the KV app's memory reserve so the datastore uses its own.
-
-    ``reserved_instance_app_mem_gib`` is per instance of the tier it was
-    written for. Callers set it for the dgwkv Java app, which runs on its own
-    shapes, so carrying it into Cassandra or EVCache reserves memory those
-    nodes never use. Unsetting it (rather than picking a number here) lets
-    each datastore's ``default_desires`` supply its own reserve.
-    """
-    data_shape = desires.data_shape.model_dump(exclude_unset=True)
-    data_shape.pop("reserved_instance_app_mem_gib", None)
-    return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
-
-
 class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
     service_name = "key-value"
     cluster_type = "dgwkv"
@@ -133,7 +119,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_cassandra_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = _without_app_memory_reserve(desires)
+                relaxed = desires.model_copy(deep=True)
 
                 # This is an initial best guess. Parameterizing in case we want to
                 # configure it in the future.
@@ -151,7 +137,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_evcache_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = _without_app_memory_reserve(desires)
+                relaxed = desires.model_copy(deep=True)
                 access_consistency = relaxed.query_pattern.access_consistency
                 access_consistency.same_region.target_consistency = (
                     AccessConsistency.best_effort
@@ -163,7 +149,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
                 ("org.netflix.evcache", _modify_evcache_desires),
             )
         else:
-            return (("org.netflix.cassandra", _without_app_memory_reserve),)
+            return (("org.netflix.cassandra", lambda x: x),)
 
     @staticmethod
     def default_desires(

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -46,6 +46,20 @@ class NflxKeyValueArguments(NflxJavaAppArguments):
     )
 
 
+def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
+    """Drop the KV app's memory reserve so the datastore uses its own.
+
+    ``reserved_instance_app_mem_gib`` is per instance of the tier it was
+    written for. Callers set it for the dgwkv Java app, which runs on its own
+    shapes, so carrying it into Cassandra or EVCache reserves memory those
+    nodes never use. Unsetting it (rather than picking a number here) lets
+    each datastore's ``default_desires`` supply its own reserve.
+    """
+    data_shape = desires.data_shape.model_dump(exclude_unset=True)
+    data_shape.pop("reserved_instance_app_mem_gib", None)
+    return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
+
+
 class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
     service_name = "key-value"
     cluster_type = "dgwkv"
@@ -119,7 +133,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_cassandra_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = desires.model_copy(deep=True)
+                relaxed = _without_app_memory_reserve(desires)
 
                 # This is an initial best guess. Parameterizing in case we want to
                 # configure it in the future.
@@ -137,7 +151,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_evcache_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = desires.model_copy(deep=True)
+                relaxed = _without_app_memory_reserve(desires)
                 access_consistency = relaxed.query_pattern.access_consistency
                 access_consistency.same_region.target_consistency = (
                     AccessConsistency.best_effort
@@ -149,7 +163,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
                 ("org.netflix.evcache", _modify_evcache_desires),
             )
         else:
-            return (("org.netflix.cassandra", lambda x: x),)
+            return (("org.netflix.cassandra", _without_app_memory_reserve),)
 
     @staticmethod
     def default_desires(

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -349,3 +349,44 @@ def test_memory_scale_down_caps_write_buffer():
                 f"<= uncapped ({uncapped_mem}) for {capped_zone.instance.name}"
             )
             break
+
+
+def test_shape_without_page_cache_is_excused():
+    """Large reserved app memory can leave a shape with no page cache at all.
+
+    i4i.xlarge holds 30.52 GiB: a 15 GiB heap plus 25 GiB of reserved app and
+    system memory overruns the box, so page cache capacity clamps to zero.
+    Sizing a cluster out of that shape used to divide by zero, so the shape has
+    to be excused before it reaches compute_stateful_zone.
+    """
+    desires = CapacityDesires(
+        service_tier=0,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(2870),
+            estimated_write_per_second=certain_int(1381),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=certain_int(15205),
+            reserved_instance_app_mem_gib=24,
+        ),
+    )
+
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+    )
+
+    assert explained.plans, "Larger shapes should still produce plans"
+
+    excused = {
+        e.instance
+        for excuses in explained.excuses_by_model.values()
+        for e in excuses
+        if "No page cache left" in e.reason
+    }
+    assert "i4i.xlarge" in excused
+
+    for plan in explained.plans:
+        assert plan.candidate_clusters.zonal[0].instance.ram_gib > 40

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -292,3 +292,52 @@ def zonal_summary(zlr):
         zlr_cost,
         zlr_drive_gib,
     )
+
+
+def test_es_data_nodes_have_ram_left_after_reserves():
+    """Data nodes must have RAM left once sidecars and the heap are carved out.
+
+    Elasticsearch reserves ``base_mem + max(32, ram / 2)`` per node, which
+    overruns shapes at or below ~34 GiB. Those used to yield a negative memory
+    node count that max() discarded, silently dropping the memory constraint
+    and letting an undersized shape win on cost.
+    """
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=1000, mid=10_000, high=100_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            ),
+        ),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.elasticsearch",
+        region="us-east-1",
+        desires=desires,
+    )
+    assert plans, "Expected plans on shapes large enough for the reserves"
+
+    base_mem = (
+        desires.data_shape.reserved_instance_app_mem_gib
+        + desires.data_shape.reserved_instance_system_mem_gib
+    )
+    data_clusters = [
+        cluster
+        for plan in plans
+        for cluster in plan.candidate_clusters.zonal
+        if cluster.cluster_type == "elasticsearch-data"
+    ]
+    assert data_clusters
+
+    for cluster in data_clusters:
+        ram_gib = cluster.instance.ram_gib
+        reserved = base_mem + max(32, ram_gib / 2)
+        assert ram_gib > reserved, (
+            f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
+        )

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import DataShape
@@ -341,3 +342,41 @@ def test_es_data_nodes_have_ram_left_after_reserves():
         assert ram_gib > reserved, (
             f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
         )
+
+
+def test_es_rejections_explain_themselves():
+    """Rejected shapes come back as excuses, not a silent None.
+
+    Cassandra, Kafka and EVCache all excuse the shapes they turn down.
+    Elasticsearch dropped them on the floor, so a caller asking why their
+    instance family was ignored had nothing to read.
+    """
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=1000, mid=10_000, high=100_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            ),
+        ),
+    )
+
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.elasticsearch", region="us-east-1", desires=desires
+    )
+    assert explained.plans, "Expected Elasticsearch to still produce plans"
+
+    excuses = [e for es in explained.excuses_by_model.values() for e in es]
+    assert excuses, "Expected rejected shapes to be explained"
+
+    for excuse in excuses:
+        assert excuse.reason
+        assert excuse.bottleneck is not None
+
+    bottlenecks = {e.bottleneck for e in excuses}
+    assert Bottleneck.drive_type in bottlenecks  # EBS-only shapes
+    assert Bottleneck.memory in bottlenecks  # too small, or reserves overrun

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -2,6 +2,8 @@
 Tests for Netflix key-value model.
 """
 
+from typing import Dict
+
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -83,3 +85,71 @@ def test_large_app_memory_reserve_survives_simulation():
     )
 
     assert plan.least_regret
+
+
+# 200 GiB / 5000 rps sits near Cassandra's memory bound, so a leaked 24 GiB
+# reserve visibly changes the shape it picks. A disk-bound namespace would
+# hide the difference.
+MEMORY_SENSITIVE_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=Interval(
+            low=500, mid=5000, high=50_000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=250, mid=2500, high=25_000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=20, mid=200, high=2000, confidence=0.98),
+    ),
+)
+
+
+def _clusters(app_mem_gib: float) -> Dict[str, str]:
+    desires = MEMORY_SENSITIVE_KV.model_copy(deep=True)
+    desires.data_shape.reserved_instance_app_mem_gib = app_mem_gib
+    plan = planner.plan_certain(
+        model_name="org.netflix.key-value", region="us-east-1", desires=desires
+    )[0]
+    clusters = list(plan.candidate_clusters.zonal) + list(
+        plan.candidate_clusters.regional
+    )
+    return {c.cluster_type: f"{c.instance.name}x{c.count}" for c in clusters}
+
+
+def test_app_memory_reserve_stays_on_the_kv_tier():
+    """The dgwkv app's reserve is not Cassandra's reserve.
+
+    reserved_instance_app_mem_gib is memory per instance of the tier it was
+    written for. Callers set it for the KV Java app, which runs on its own
+    shapes, so raising it must move the dgwkv tier and leave Cassandra alone.
+    """
+    lean = _clusters(4)
+    heavy = _clusters(24)
+
+    assert heavy["cassandra"] == lean["cassandra"]
+    assert heavy["dgwkv"] != lean["dgwkv"]
+
+
+def test_evcache_also_gets_its_own_app_memory_reserve():
+    """EVCache runs on its own shapes too, so the KV reserve stops at KV."""
+    cached = LARGE_APP_RESERVE_KV.model_copy(deep=True)
+    cached.query_pattern.access_consistency.same_region.target_consistency = (
+        AccessConsistency.eventual
+    )
+    cached.query_pattern.estimated_read_per_second = Interval(
+        low=30_000, mid=300_000, high=3_000_000, confidence=0.98
+    )
+
+    plan = planner.plan_certain(
+        model_name="org.netflix.key-value", region="us-east-1", desires=cached
+    )[0]
+    evcache = [c for c in plan.candidate_clusters.zonal if c.cluster_type == "evcache"]
+    assert evcache, "Expected this workload to attach EVCache"
+
+    # EVCache reserves 1 GiB for its own app, so it is free to use small
+    # shapes. A node cannot be holding back 24 GiB of dgwkv heap and still
+    # fit on a box with less RAM than that.
+    for cluster in evcache:
+        assert cluster.instance.ram_gib < 24

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -2,6 +2,16 @@
 Tests for Netflix key-value model.
 """
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
 # Property test configuration for KeyValue model.
 # See tests/netflix/PROPERTY_TESTING.md for configuration options and examples.
 PROPERTY_TEST_CONFIG = {
@@ -9,3 +19,67 @@ PROPERTY_TEST_CONFIG = {
     #     "extra_model_arguments": {},
     # },
 }
+
+# A KV namespace that reserves 24 GiB for the app. That reserve flows through
+# to the composed Cassandra model, where it overruns small shapes.
+LARGE_APP_RESERVE_KV = CapacityDesires(
+    service_tier=0,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        access_consistency=GlobalConsistency(
+            same_region=Consistency(
+                target_consistency=AccessConsistency.read_your_writes
+            ),
+        ),
+        estimated_read_per_second=Interval(
+            low=287, mid=2870, high=28700, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=138.1, mid=1381, high=13810, confidence=0.98
+        ),
+        estimated_mean_write_size_bytes=Interval(
+            low=102.4, mid=1024, high=10240, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(
+            low=1520.5, mid=15205.1, high=152050.7, confidence=0.98
+        ),
+        estimated_state_item_count=Interval(
+            low=10_000_000, mid=100_000_000, high=1_000_000_000, confidence=0.98
+        ),
+        reserved_instance_app_mem_gib=24.0,
+    ),
+)
+
+
+def test_large_app_memory_reserve_plans_on_shapes_that_fit():
+    """Reserved app memory can overrun a small shape's RAM.
+
+    24 GiB of reserved app memory plus the JVM heap leaves no page cache on
+    shapes like i4i.xlarge, which used to divide by zero while sizing the
+    Cassandra cluster. Those shapes are now excused and planning continues on
+    shapes with RAM to spare.
+    """
+    plans = planner.plan_certain(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=LARGE_APP_RESERVE_KV,
+    )
+
+    assert plans, "Expected a plan on shapes large enough for the app reserve"
+    for plan in plans:
+        for cluster in plan.candidate_clusters.zonal:
+            assert cluster.instance.ram_gib > 40
+
+
+def test_large_app_memory_reserve_survives_simulation():
+    """The uncertain path walks the same shapes and must not blow up either."""
+    plan = planner.plan(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=LARGE_APP_RESERVE_KV,
+        simulations=32,
+    )
+
+    assert plan.least_regret

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -1,0 +1,105 @@
+"""Tests for what a composed model inherits from its parent's desires."""
+
+import pytest
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
+# Sized to sit near the memory bound of the backing datastore, so a leaked
+# reserve visibly changes the shape it picks. A disk-bound namespace would
+# hide the difference.
+BASE_QUERY_PATTERN = QueryPattern(
+    estimated_read_per_second=Interval(low=500, mid=5000, high=50_000, confidence=0.98),
+    estimated_write_per_second=Interval(
+        low=250, mid=2500, high=25_000, confidence=0.98
+    ),
+)
+BASE_STATE_SIZE = Interval(low=20, mid=200, high=2000, confidence=0.98)
+
+# Models that plan a datastore of their own on separate shapes. The parent's
+# app memory reserve describes the parent's instances, not theirs.
+COMPOSED_MODELS = [
+    "org.netflix.key-value",
+    "org.netflix.time-series",
+    "org.netflix.graphkv",
+    "org.netflix.entity",
+]
+
+
+def _desires(app_mem_gib: float) -> CapacityDesires:
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=BASE_QUERY_PATTERN.model_copy(deep=True),
+        data_shape=DataShape(
+            estimated_state_size_gib=BASE_STATE_SIZE,
+            reserved_instance_app_mem_gib=app_mem_gib,
+        ),
+    )
+
+
+def _clusters_by_type(model_name: str, app_mem_gib: float) -> dict:
+    plan = planner.plan_certain(
+        model_name=model_name, region="us-east-1", desires=_desires(app_mem_gib)
+    )[0]
+    clusters = list(plan.candidate_clusters.zonal) + list(
+        plan.candidate_clusters.regional
+    )
+    return {c.cluster_type: f"{c.instance.name}x{c.count}" for c in clusters}
+
+
+@pytest.mark.parametrize("model_name", COMPOSED_MODELS)
+def test_app_memory_reserve_does_not_reach_composed_models(model_name):
+    """A parent's app memory reserve stops at the parent's own tier.
+
+    reserved_instance_app_mem_gib is memory per instance of the tier it was
+    written for. Composed models run on their own shapes, so inheriting the
+    value made them hold back memory for an app that is not on the box --
+    shrinking page cache and pushing them onto larger instances.
+    """
+    lean = _clusters_by_type(model_name, 4)
+    heavy = _clusters_by_type(model_name, 24)
+
+    datastore_types = set(lean) - {"dgwkv", "dgwts", "dgwgraphkv", "dgwentity"}
+    assert datastore_types, f"{model_name} composed no datastore"
+
+    for cluster_type in datastore_types:
+        assert heavy[cluster_type] == lean[cluster_type], (
+            f"{model_name}: {cluster_type} changed with the parent's app reserve"
+        )
+
+
+def test_directly_planned_models_keep_the_caller_reserve():
+    """Addressing a datastore by name still applies the caller's reserve.
+
+    Only inheritance across a composition boundary is dropped. Someone who
+    plans Cassandra directly is describing Cassandra's own instances.
+    """
+    lean = _clusters_by_type("org.netflix.cassandra", 4)
+    heavy = _clusters_by_type("org.netflix.cassandra", 24)
+
+    assert heavy["cassandra"] != lean["cassandra"]
+
+
+def test_parent_tier_still_gets_the_caller_reserve():
+    """The reserve is dropped for children, not for the model asked for."""
+    lean = _clusters_by_type("org.netflix.key-value", 4)
+    heavy = _clusters_by_type("org.netflix.key-value", 24)
+
+    assert heavy["dgwkv"] != lean["dgwkv"]
+
+
+def test_the_rule_holds_through_an_aggregator():
+    """org.netflix.elasticsearch owns no instances; it splits into node roles.
+
+    The reserve still stops at the boundary rather than reaching the node
+    roles through it. Entity is the only composition that reaches
+    Elasticsearch in practice, and it strips one level higher anyway, so this
+    keeps the two paths agreeing instead of carving out a second mode.
+    """
+    lean = _clusters_by_type("org.netflix.elasticsearch", 1)
+    heavy = _clusters_by_type("org.netflix.elasticsearch", 64)
+
+    assert heavy["elasticsearch-data"] == lean["elasticsearch-data"]

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -91,6 +91,34 @@ def test_parent_tier_still_gets_the_caller_reserve():
     assert heavy["dgwkv"] != lean["dgwkv"]
 
 
+def test_transforms_compose_through_more_than_one_level():
+    """GraphKV fans out to KeyValue, which fans out to Cassandra.
+
+    Each compose_with transform used to receive the original user desires, so
+    a two-level chain dropped the middle one: Cassandra never saw GraphKV's
+    read and write amplification and was sized for logical graph traffic
+    rather than the backend KeyValue operations it actually serves.
+    """
+    by_model = dict(
+        planner._sub_models(  # pylint: disable=protected-access
+            "org.netflix.graphkv", _desires(24), extra_model_arguments={}
+        )
+    )
+
+    logical = by_model["org.netflix.graphkv"].query_pattern
+    backend = by_model["org.netflix.cassandra"].query_pattern
+
+    assert backend.estimated_read_per_second.mid > (
+        logical.estimated_read_per_second.mid * 10
+    )
+    assert backend.estimated_write_per_second.mid > (
+        logical.estimated_write_per_second.mid
+    )
+    assert by_model["org.netflix.cassandra"].data_shape.estimated_state_size_gib.mid > (
+        by_model["org.netflix.graphkv"].data_shape.estimated_state_size_gib.mid
+    )
+
+
 def test_the_rule_holds_through_an_aggregator():
     """org.netflix.elasticsearch owns no instances; it splits into node roles.
 

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -1,11 +1,17 @@
 """Tests for picking a model's own entry out of desires.current_clusters."""
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentRegionClusterCapacity
 from service_capacity_modeling.interface import CurrentZoneClusterCapacity
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.common import current_cluster_capacity
 
 
@@ -85,3 +91,69 @@ def test_no_current_clusters_at_all():
         current_cluster_capacity(CapacityDesires(service_tier=1), "cassandra") is None
     )
     assert current_cluster_capacity(_desires(), "cassandra") is None
+
+
+def _cassandra_desires(zonal):
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=100, mid=1000, high=10_000, confidence=0.98
+            ),
+            estimated_write_per_second=Interval(
+                low=100, mid=1000, high=10_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            )
+        ),
+        current_clusters=CurrentClusters(zonal=zonal),
+    )
+
+
+def _live_cluster(instance_name, cluster_type, count, disk_gib):
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name=instance_name,
+        cluster_instance=shapes.instance(instance_name),
+        cluster_type=cluster_type,
+        cluster_drive=Drive(name="gp3", drive_type="attached-ssd", size_gib=1000),
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(20),
+        disk_utilization_gib=certain_float(disk_gib),
+        network_utilization_mbps=certain_float(100),
+    )
+
+
+def test_cassandra_ignores_another_tier_in_a_composed_request():
+    """EVCache listed first must not become Cassandra's current cluster.
+
+    Both are zonal, so a composed KeyValue request puts them in the same
+    list. Reading index 0 meant Cassandra sized itself against EVCache's
+    node count and disk.
+    """
+    cassandra_only = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [_live_cluster("i4i.2xlarge", "cassandra", count=4, disk_gib=200)]
+        ),
+    )
+    with_evcache_first = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [
+                _live_cluster("i7ie.large", "evcache", count=40, disk_gib=900),
+                _live_cluster("i4i.2xlarge", "cassandra", count=4, disk_gib=200),
+            ]
+        ),
+    )
+
+    assert cassandra_only and with_evcache_first
+    for own, composed in zip(cassandra_only, with_evcache_first):
+        own_zone = own.candidate_clusters.zonal[0]
+        composed_zone = composed.candidate_clusters.zonal[0]
+        assert own_zone.instance.name == composed_zone.instance.name
+        assert own_zone.count == composed_zone.count

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -1,0 +1,87 @@
+"""Tests for picking a model's own entry out of desires.current_clusters."""
+
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentRegionClusterCapacity
+from service_capacity_modeling.interface import CurrentZoneClusterCapacity
+from service_capacity_modeling.models.common import current_cluster_capacity
+
+
+def _zonal(name: str, cluster_type=None, count: int = 3):
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name=name,
+        cluster_type=cluster_type,
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(10),
+    )
+
+
+def _regional(name: str, cluster_type=None, count: int = 3):
+    return CurrentRegionClusterCapacity(
+        cluster_instance_name=name,
+        cluster_type=cluster_type,
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(10),
+    )
+
+
+def _desires(**kwargs) -> CapacityDesires:
+    return CapacityDesires(service_tier=1, current_clusters=CurrentClusters(**kwargs))
+
+
+def test_picks_the_entry_matching_the_model():
+    """Cassandra and EVCache are both zonal in a composed KeyValue plan."""
+    desires = _desires(
+        zonal=[
+            _zonal("i7ie.large", cluster_type="evcache", count=14),
+            _zonal("i4i.2xlarge", cluster_type="cassandra", count=4),
+        ],
+        regional=[_regional("r8i.xlarge", cluster_type="dgwkv")],
+    )
+
+    assert current_cluster_capacity(desires, "cassandra").cluster_instance_name == (
+        "i4i.2xlarge"
+    )
+    assert current_cluster_capacity(desires, "evcache").cluster_instance_name == (
+        "i7ie.large"
+    )
+    assert current_cluster_capacity(desires, "dgwkv").cluster_instance_name == (
+        "r8i.xlarge"
+    )
+
+
+def test_unlabelled_entries_fall_back_to_the_first():
+    """Callers that predate cluster_type keep the old behaviour."""
+    desires = _desires(zonal=[_zonal("i4i.2xlarge"), _zonal("i3en.xlarge")])
+
+    picked = current_cluster_capacity(desires, "cassandra")
+    assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_labelled_but_unmatched_means_no_current_cluster():
+    """If the caller labelled other tiers and not ours, we have none.
+
+    Falling back to the first entry here is what let Cassandra size itself
+    against EVCache's topology.
+    """
+    desires = _desires(zonal=[_zonal("i7ie.large", cluster_type="evcache")])
+
+    assert current_cluster_capacity(desires, "cassandra") is None
+
+
+def test_zonal_is_preferred_over_regional_for_the_legacy_fallback():
+    desires = _desires(
+        zonal=[_zonal("i4i.2xlarge")], regional=[_regional("r8i.xlarge")]
+    )
+
+    picked = current_cluster_capacity(desires, "cassandra")
+    assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_no_current_clusters_at_all():
+    assert (
+        current_cluster_capacity(CapacityDesires(service_tier=1), "cassandra") is None
+    )
+    assert current_cluster_capacity(_desires(), "cassandra") is None

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -319,3 +319,30 @@ def test_topology_constraints_do_not_override_stronger_resource_limits():
     assert counts["cpu"] == 40
     assert counts["min_count"] == 6
     assert cluster.cluster_params["resource_bottleneck"] == "cpu"
+
+
+@pytest.mark.parametrize(
+    "reserve_memory",
+    [
+        lambda ram_gib: ram_gib,  # reserves exactly the whole box
+        lambda ram_gib: ram_gib + 8,  # reserves more than the box has
+    ],
+    ids=["reserves-all-ram", "reserves-more-than-ram"],
+)
+def test_shape_with_no_memory_left_over_is_rejected(reserve_memory):
+    """No node count satisfies memory when reservations eat the whole box.
+
+    Dividing by the leftover used to hand back either a ZeroDivisionError or a
+    negative node count that max() quietly discarded, which let an undersized
+    shape pass the memory check entirely.
+    """
+    with pytest.raises(ValueError, match="leaving .* for the datastore"):
+        compute_stateful_zone(
+            instance=M5_4XL,
+            drive=EBS,
+            needed_cores=4,
+            needed_disk_gib=100,
+            needed_memory_gib=1000,
+            needed_network_mbps=100,
+            reserve_memory=reserve_memory,
+        )


### PR DESCRIPTION
## Why

A tier-0 KeyValue plan crashed with `ZeroDivisionError` in `compute_stateful_zone`:

```
File "service_capacity_modeling/models/common.py", line 563, in compute_stateful_zone
    needed_memory_gib / (instance.ram_gib - reserve_memory(instance.ram_gib))
ZeroDivisionError: float division by zero
```

The divide-by-zero turned out to be the visible edge of a class of bug: **things that describe one tier were crossing into another**. Each commit below fixes one instance of that, smallest first.

Draft because commits 3 and 8 change plan output for composed models, and the semantics deserve a second opinion before this is real.

## The chain that produced the crash

`reserved_instance_app_mem_gib: 24.0` is in the request. It comes from `dgi-artifact/deploys/kv/csticketing/prod.yaml`, hand-added in Dec 2024 ("Fixing the app memory") and carried forward untouched by the DABP bot ever since. It sizes the **dgwkv Java app's** heap.

`key_value.compose_with` handed desires to Cassandra with an identity lambda, so Cassandra reserved 24 GiB per node for an app that is not on the box. On `i4i.xlarge`:

```
ram 30.52  -  heap 15.0  -  reserves 25.0  =  -9.48  ->  MemoryLayout clamps to 0
reserve_memory(30.52) = 30.52 - 0 = 30.52
denominator = 30.52 - 30.52 = 0
```

47 shapes hit exactly zero at that reserve. Elasticsearch has no such clamp, so it went **negative** instead — and `math.ceil` of a negative quotient is a negative node count that `max()` silently discards, dropping the memory constraint entirely:

```
r5.xlarge, needed_memory_gib=1000, reserve = 3 + max(32, 15.26)
-> required_nodes_by_type = {'cpu': 1, 'memory': -287, ...}, bottleneck 'cpu', count: 1
```

One 30.52 GiB node "satisfying" a 1000 GiB requirement. That is why the fix is not a `max(1, ...)` on the denominator — ceiling it converts the crash you can see into the undersized cluster you cannot.

## Commits

| | commit | what |
|---|---|---|
| 1 | `7ed071b` | Reject shapes whose reservations leave no usable memory |
| 2 | `204a839` | Keep the KeyValue app memory reserve on the KeyValue tier |
| 3 | `2d3f0a1` | Let a model decide what crosses into the models it composes with |
| 4 | `12e8665` | Explain why Elasticsearch turns a shape down |
| 5 | `17b31fc` | Add a selector for a model's own entry in `current_clusters` |
| 6 | `9148142` | Read Cassandra's own current cluster, not whichever came first |
| 7 | `402ff06` | Screen shapes against the model's own current cluster |
| 8 | `404ca11` | Compose desires down a chain, not from the original request |

**1** — `compute_stateful_zone` raises instead of guessing when per-node usable memory is `<= 0`; Cassandra/Kafka/EVCache/Elasticsearch reject the shape first. Cassandra excuses with the arithmetic in the reason.

**2–3** — `reserved_instance_app_mem_gib` is memory per instance of the tier it was written for. `CapacityModel.desires_for_composed_model` is a new overridable hook the planner applies to everything a model composes with; the default drops the reserve so the composed model's own `default_desires` supplies it. Commit 2 fixes KeyValue narrowly and ships on its own; commit 3 generalises and removes the special case. It runs *before* the per-child transform, so a model with a reason to pass its reserve down can still say so.

**4** — Elasticsearch returned bare `None` from all eight rejection paths while every other stateful model returned an `Excuse`. The base class already allowed it.

**5–7** — `CurrentClusterCapacity.cluster_type` is documented as "required metadata for identifying which model this capacity belongs to" and nothing read it; every consumer took `zonal[0]`. Cassandra and EVCache are both zonal, so a composed request could hand Cassandra EVCache's node count, disk and **instance shape** (via `CapacityDesires.reference_shape`, which also reads `zonal[0]` — Cassandra was normalizing its core counts against a cache node). Unlabelled entries fall back to the first, so existing callers are unaffected.

**8** — `compose_with` transforms received the original user desires, so only the first level of a chain took effect. GraphKV → KeyValue → Cassandra dropped GraphKV's amplification: Cassandra was sized for 5k logical reads/sec when it serves 275k.

## Plan impact

24 GiB reserve, memory-bound namespace, per zone:

| model | before | after |
|---|---|---|
| key-value, time-series | `cassandra i4i.2xlarge` | `i4i.xlarge` (−21%) |
| entity | | −14% |
| graphkv | `i4i.xlarge x2` | `c6id.4xlarge x16` (fan-out finally provisioned for) |
| elasticsearch data nodes | `i4i.xlarge x9` | `i4i.2xlarge x5` (dropped constraint applied) |
| cassandra, kafka, evcache, wal, control (direct) | unchanged | unchanged |

Directly planning a model still applies the caller's reserve to it — there is a test for that.

## What I deliberately did not do

- **No override of `desires_for_composed_model` anywhere.** `org.netflix.elasticsearch` looked like a candidate (it owns no instances, only splits into node roles) but it is never planned directly — dgi-artifact names nine models and that is not one of them. Entity is the only composition reaching Elasticsearch and it strips a level higher anyway, so an override changes nothing except adding a second mode. Verified by diffing plan output with and without it.
- **`reserved_instance_system_mem_gib` still propagates.** Kernel/OS overhead is roughly shape-independent and no model overrides the default, so stripping it would change nothing today while removing the caller's ability to state it.
- **`elasticsearch.py` reserves `base_mem + max(32, ram / 2)`** where its own comment says "half of available system max of 32 for compressed oops" — i.e. `min`. Very likely a bug, but flipping it is an ES heap-sizing decision for whoever owns that model. Commit 1 rejects the shapes it overruns rather than changing the formula.
- **`key_value.compose_with` divides `rps / wps`** on unmerged desires, so a read-only KeyValue request crashes before planning starts. Found while tracing this; separate bug, untouched.

## Testing

782 passed, 1 skipped. mypy clean, pylint 10.00, cost baselines unchanged. Every new test verified to fail against the pre-fix code.

`test_all_models_tier_capacity_relationship` is flaky on `main` independently of this branch — it draws random workloads and some violate the property. Three different falsifying draws (R:47480/W:19623, R:50000/W:14583, R:49307/W:15969, all at 100 GiB) produce byte-identical tier-0-worse-than-tier-2 numbers on `main` and on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
