### PR TITLE
fix(models): preserve memory boundaries in composed plans

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1556,16 +1556,16 @@ class CapacityPlanner:
             # exception: the caller was describing the composed models all
             # along. Strip before the modifier runs so a model that
             # deliberately sets a child's reservation still wins.
-            child_desires = desires
+            child_desires = parent_desires
             if self._models[sub_model].plans_own_cluster():
-                child_desires = _without_app_memory_reserve(desires)
+                child_desires = _without_app_memory_reserve(parent_desires)
 
             queue.extend(
                 [
                     (modify_child_desires(child_desires), child_model)
                     for child_model, modify_child_desires in self._models[
                         sub_model
-                    ].compose_with(desires, extra_model_arguments)
+                    ].compose_with(parent_desires, extra_model_arguments)
                 ]
             )
 

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -503,6 +503,21 @@ def _resolve_cluster_instances(desires: CapacityDesires) -> None:
                 cap.cluster_instance = shapes.instance(cap.cluster_instance_name)
 
 
+def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
+    """Drop the app memory reserve so a composed model uses its own.
+
+    ``reserved_instance_app_mem_gib`` is memory per instance of the tier it
+    was written for, and composed models run on their own shapes. A KeyValue
+    request that reserves 24 GiB for the dgwkv Java app should not make
+    Cassandra reserve 24 GiB per node for an app that is not there. Unsetting
+    the field (rather than picking a number) lets each model's
+    ``default_desires`` supply the reserve that suits it.
+    """
+    data_shape = desires.data_shape.model_dump(exclude_unset=True)
+    data_shape.pop("reserved_instance_app_mem_gib", None)
+    return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
+
+
 class CapacityPlanner:
     def __init__(
         self,
@@ -1488,10 +1503,21 @@ class CapacityPlanner:
             )
 
             # We might have to compose this model with others depending on
-            # the user requirement
+            # the user requirement. When this model sizes instances of its
+            # own, the caller's per-instance reservations describe those
+            # instances, and the models it composes with run on separate
+            # shapes -- so the reservation stops here. Aggregators that own no
+            # instances (Elasticsearch splitting into node roles) are the
+            # exception: the caller was describing the composed models all
+            # along. Strip before the modifier runs so a model that
+            # deliberately sets a child's reservation still wins.
+            child_desires = desires
+            if self._models[sub_model].plans_own_cluster():
+                child_desires = _without_app_memory_reserve(desires)
+
             queue.extend(
                 [
-                    (modify_child_desires(desires), child_model)
+                    (modify_child_desires(child_desires), child_model)
                     for child_model, modify_child_desires in self._models[
                         sub_model
                     ].compose_with(desires, extra_model_arguments)

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -529,10 +529,9 @@ def _with_current_clusters_for_model(
 ) -> CapacityDesires:
     """Give a model only the current clusters whose type it owns.
 
-    Untyped current clusters predate composed-model routing. Preserve an
-    entirely untyped input for backward compatibility; once any cluster is
-    typed, untyped and sibling clusters are excluded from model-specific
-    sizing.
+    Untyped current clusters predate composed-model routing. Prefer exact
+    typed matches; when a model has no typed match, retain untyped rows as its
+    legacy fallback so partial adoption does not erase current-capacity data.
     """
     if current_clusters is None:
         return desires
@@ -543,16 +542,31 @@ def _with_current_clusters_for_model(
     if not cluster_types or not has_typed_clusters:
         selected = current_clusters
     else:
+        matching_zonal = [
+            cluster
+            for cluster in current_clusters.zonal
+            if cluster.cluster_type in cluster_types
+        ]
+        matching_regional = [
+            cluster
+            for cluster in current_clusters.regional
+            if cluster.cluster_type in cluster_types
+        ]
+        has_typed_match = bool(matching_zonal or matching_regional)
         selected = CurrentClusters(
-            zonal=[
+            zonal=matching_zonal
+            if has_typed_match
+            else [
                 cluster
                 for cluster in current_clusters.zonal
-                if cluster.cluster_type in cluster_types
+                if cluster.cluster_type is None
             ],
-            regional=[
+            regional=matching_regional
+            if has_typed_match
+            else [
                 cluster
                 for cluster in current_clusters.regional
-                if cluster.cluster_type in cluster_types
+                if cluster.cluster_type is None
             ],
             services=current_clusters.services,
         )

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -61,6 +61,7 @@ from service_capacity_modeling.interface import UncertainCapacityPlan
 from service_capacity_modeling.interface import SampleRef
 from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models import CapacityModel
+from service_capacity_modeling.models import ChildDesiresConfig
 from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models.common import get_disk_size_gib
 from service_capacity_modeling.models.common import merge_plan
@@ -504,16 +505,18 @@ def _resolve_cluster_instances(desires: CapacityDesires) -> None:
                 cap.cluster_instance = shapes.instance(cap.cluster_instance_name)
 
 
-def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
-    """Drop the app memory reserve so a composed model uses its own.
+def _configure_child_desires(
+    desires: CapacityDesires, config: ChildDesiresConfig
+) -> CapacityDesires:
+    """Apply a parent's composition policy before its child transform.
 
-    ``reserved_instance_app_mem_gib`` is memory per instance of the tier it
-    was written for, and composed models run on their own shapes. A KeyValue
-    request that reserves 24 GiB for the dgwkv Java app should not make
-    Cassandra reserve 24 GiB per node for an app that is not there. Unsetting
-    the field (rather than picking a number) lets each model's
-    ``default_desires`` supply the reserve that suits it.
+    Unsetting a field rather than assigning a replacement lets the child
+    model's ``default_desires`` provide its own value. The edge transform runs
+    afterward and can still set an intentional child-specific override.
     """
+    if config.inherit_app_memory_reservation:
+        return desires
+
     data_shape = desires.data_shape.model_dump(exclude_unset=True)
     data_shape.pop("reserved_instance_app_mem_gib", None)
     return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
@@ -1547,27 +1550,13 @@ class CapacityPlanner:
                 )
             )
 
-            # We might have to compose this model with others depending on
-            # the user requirement. When this model sizes instances of its
-            # own, the caller's per-instance reservations describe those
-            # instances, and the models it composes with run on separate
-            # shapes -- so the reservation stops here. Aggregators that own no
-            # instances (Elasticsearch splitting into node roles) are the
-            # exception: the caller was describing the composed models all
-            # along. Strip before the modifier runs so a model that
-            # deliberately sets a child's reservation still wins.
-            child_desires = parent_desires
-            if self._models[sub_model].plans_own_cluster():
-                child_desires = _without_app_memory_reserve(parent_desires)
-
-            queue.extend(
-                [
-                    (modify_child_desires(child_desires), child_model)
-                    for child_model, modify_child_desires in self._models[
-                        sub_model
-                    ].compose_with(parent_desires, extra_model_arguments)
-                ]
-            )
+            parent_model = self._models[sub_model]
+            for child_model, modify_child_desires in parent_model.compose_with(
+                parent_desires, extra_model_arguments
+            ):
+                config = parent_model.child_desires_config(child_model)
+                child_desires = _configure_child_desires(parent_desires, config)
+                queue.append((modify_child_desires(child_desires), child_model))
 
             yield sub_model, sub_desires
 

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -508,12 +508,7 @@ def _resolve_cluster_instances(desires: CapacityDesires) -> None:
 def _configure_child_desires(
     desires: CapacityDesires, config: ChildDesiresConfig
 ) -> CapacityDesires:
-    """Apply a parent's composition policy before its child transform.
-
-    Unsetting a field rather than assigning a replacement lets the child
-    model's ``default_desires`` provide its own value. The edge transform runs
-    afterward and can still set an intentional child-specific override.
-    """
+    """Apply ``ChildDesiresConfig`` before the child edge transform."""
     if config.inherit_app_memory_reservation:
         return desires
 
@@ -527,12 +522,7 @@ def _with_current_clusters_for_model(
     model: CapacityModel,
     current_clusters: Optional[CurrentClusters],
 ) -> CapacityDesires:
-    """Give a model only the current clusters whose type it owns.
-
-    Untyped current clusters predate composed-model routing. Prefer exact
-    typed matches; when a model has no typed match, retain untyped rows as its
-    legacy fallback so partial adoption does not erase current-capacity data.
-    """
+    """Route current clusters according to ``model.current_cluster_types()``."""
     if current_clusters is None:
         return desires
 

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -26,6 +26,7 @@ from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import ClusterCapacity
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import CurrentClusterCapacity
+from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import ExcludeUnsetModel
@@ -516,6 +517,44 @@ def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
     data_shape = desires.data_shape.model_dump(exclude_unset=True)
     data_shape.pop("reserved_instance_app_mem_gib", None)
     return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
+
+
+def _with_current_clusters_for_model(
+    desires: CapacityDesires,
+    model: CapacityModel,
+    current_clusters: Optional[CurrentClusters],
+) -> CapacityDesires:
+    """Give a model only the current clusters whose type it owns.
+
+    Untyped current clusters predate composed-model routing. Preserve an
+    entirely untyped input for backward compatibility; once any cluster is
+    typed, untyped and sibling clusters are excluded from model-specific
+    sizing.
+    """
+    if current_clusters is None:
+        return desires
+
+    cluster_types = model.current_cluster_types()
+    all_clusters = (*current_clusters.zonal, *current_clusters.regional)
+    has_typed_clusters = any(cluster.cluster_type for cluster in all_clusters)
+    if not cluster_types or not has_typed_clusters:
+        selected = current_clusters
+    else:
+        selected = CurrentClusters(
+            zonal=[
+                cluster
+                for cluster in current_clusters.zonal
+                if cluster.cluster_type in cluster_types
+            ],
+            regional=[
+                cluster
+                for cluster in current_clusters.regional
+                if cluster.cluster_type in cluster_types
+            ],
+            services=current_clusters.services,
+        )
+
+    return desires.model_copy(deep=True, update={"current_clusters": selected})
 
 
 class CapacityPlanner:
@@ -1488,6 +1527,7 @@ class CapacityPlanner:
     ) -> Generator[Tuple[str, CapacityDesires], None, None]:
         queue: List[Tuple[CapacityDesires, str]] = [(desires, model_name)]
         models_used = []
+        current_clusters = desires.current_clusters
 
         while queue:
             parent_desires, sub_model = queue.pop()
@@ -1496,9 +1536,14 @@ class CapacityPlanner:
                 continue
             models_used.append(sub_model)
 
-            sub_desires = parent_desires.merge_with(
+            model_desires = _with_current_clusters_for_model(
+                parent_desires,
+                self._models[sub_model],
+                current_clusters,
+            )
+            sub_desires = model_desires.merge_with(
                 self._models[sub_model].default_desires(
-                    parent_desires, extra_model_arguments
+                    model_desires, extra_model_arguments
                 )
             )
 

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -846,9 +846,9 @@ class CurrentClusterCapacity(ExcludeUnsetModel):
     cluster_instance: Optional[Instance] = None
     cluster_drive: Optional[Drive] = None
     cluster_instance_count: Interval
-    # Optional: if not set, extract_baseline_plan
-    # Required metadata for identifying which model
-    # this capacity belongs to
+    # Identifies the model that owns this capacity during composed planning and
+    # baseline extraction. Optional for legacy rows during composed planning;
+    # required by extract_baseline_plan.
     cluster_type: Optional[str] = None
     # The distribution cpu utilization in the cluster.
     cpu_utilization: Interval = certain_float(0.0)

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -331,6 +331,22 @@ class CapacityModel:
         return True
 
     @staticmethod
+    def plans_own_cluster() -> bool:
+        """Whether this model sizes instances of its own.
+
+        Most models do: they plan their tier and compose_with other services
+        that run on separate shapes. A few plan nothing themselves and only
+        split one service into node roles (Elasticsearch into data, master
+        and search nodes), so the caller's desires describe the composed
+        models rather than a tier of this model's own.
+
+        The planner uses this to decide whether per-instance reservations
+        such as reserved_instance_app_mem_gib belong to this model or to the
+        models it composes with.
+        """
+        return True
+
+    @staticmethod
     def compose_with(
         user_desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -8,6 +8,8 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
+from pydantic import BaseModel
+
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import CapacityDesires
@@ -40,6 +42,7 @@ __all__ = [
     "CapacityDesires",
     "CapacityPlan",
     "CapacityRegretParameters",
+    "ChildDesiresConfig",
     "certain_float",
     "Consistency",
     "DataShape",
@@ -56,6 +59,13 @@ __all__ = [
 ]
 
 __common_regrets__ = frozenset(("spend", "disk", "mem"))
+
+
+class ChildDesiresConfig(BaseModel):
+    """Controls which parent desires cross one composition edge."""
+
+    inherit_app_memory_reservation: bool = False
+    """Pass the parent's per-instance app memory reservation to the child."""
 
 
 def _disk_regret(  # noqa: C901
@@ -331,20 +341,16 @@ class CapacityModel:
         return True
 
     @staticmethod
-    def plans_own_cluster() -> bool:
-        """Whether this model sizes instances of its own.
+    def child_desires_config(child_model: str) -> ChildDesiresConfig:
+        """Configure desires inherited by one composed child model.
 
-        Most models do: they plan their tier and compose_with other services
-        that run on separate shapes. A few plan nothing themselves and only
-        split one service into node roles (Elasticsearch into data, master
-        and search nodes), so the caller's desires describe the composed
-        models rather than a tier of this model's own.
-
-        The planner uses this to decide whether per-instance reservations
-        such as reserved_instance_app_mem_gib belong to this model or to the
-        models it composes with.
+        Workload desires and accumulated transforms pass to children by
+        default. Per-instance application memory does not: each child uses
+        its own model default unless this parent opts into inheritance or its
+        edge transform supplies an explicit value.
         """
-        return True
+        _ = child_model
+        return ChildDesiresConfig()
 
     @classmethod
     def current_cluster_types(cls) -> Tuple[str, ...]:
@@ -367,7 +373,9 @@ class CapacityModel:
         The second element of the tuple is a capacity desire transform that
         takes the user desires, including transforms from ancestor models, and
         modifies them for the composed model. Model-specific defaults do not
-        cross this boundary; each child supplies its own defaults later.
+        cross this boundary; each child supplies its own defaults later. Models
+        can override ``child_desires_config`` to control inherited fields for a
+        particular child edge.
 
         (("model1", lambda x: x),
          ("model2", lambda x: transform(x)))

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -62,7 +62,15 @@ __common_regrets__ = frozenset(("spend", "disk", "mem"))
 
 
 class ChildDesiresConfig(BaseModel):
-    """Controls which parent desires cross one composition edge."""
+    """Controls which desires cross one parent-to-child composition edge.
+
+    Caller-supplied workload desires and transforms from ancestor models pass
+    to the child. Parent model defaults do not. By default, the planner unsets
+    the parent's per-instance application memory reservation before running the
+    edge transform, allowing the child model's default to apply. A parent can
+    opt a child into inheriting that reservation instead, and an edge transform
+    can supply an explicit child reservation after the reset.
+    """
 
     inherit_app_memory_reservation: bool = False
     """Pass the parent's per-instance app memory reservation to the child."""
@@ -342,13 +350,7 @@ class CapacityModel:
 
     @staticmethod
     def child_desires_config(child_model: str) -> ChildDesiresConfig:
-        """Configure desires inherited by one composed child model.
-
-        Workload desires and accumulated transforms pass to children by
-        default. Per-instance application memory does not: each child uses
-        its own model default unless this parent opts into inheritance or its
-        edge transform supplies an explicit value.
-        """
+        """Return the desire inheritance policy for one composed child model."""
         _ = child_model
         return ChildDesiresConfig()
 
@@ -358,7 +360,10 @@ class CapacityModel:
 
         Cost-aware models already declare a single ``cluster_type`` for cost
         attribution. Other models can either declare the same class attribute
-        or override this method when they own multiple cluster types.
+        or override this method when they own multiple cluster types. During
+        composition, the planner passes matching typed rows to their owner. A
+        model with no typed match receives untyped legacy rows as a fallback;
+        a model that declares no cluster types receives all rows.
         """
         cluster_type = getattr(cls, "cluster_type", None)
         return (cluster_type,) if cluster_type else ()

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -346,6 +346,17 @@ class CapacityModel:
         """
         return True
 
+    @classmethod
+    def current_cluster_types(cls) -> Tuple[str, ...]:
+        """Cluster types from ``current_clusters`` that belong to this model.
+
+        Cost-aware models already declare a single ``cluster_type`` for cost
+        attribution. Other models can either declare the same class attribute
+        or override this method when they own multiple cluster types.
+        """
+        cluster_type = getattr(cls, "cluster_type", None)
+        return (cluster_type,) if cluster_type else ()
+
     @staticmethod
     def compose_with(
         user_desires: CapacityDesires,

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -365,8 +365,9 @@ class CapacityModel:
         """Return additional model names to compose with this one
 
         The second element of the tuple is a capacity desire transform that
-        takes the original user desire and modifies it for the composed
-        model.
+        takes the user desires, including transforms from ancestor models, and
+        modifies them for the composed model. Model-specific defaults do not
+        cross this boundary; each child supplies its own defaults later.
 
         (("model1", lambda x: x),
          ("model2", lambda x: transform(x)))

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -539,6 +539,19 @@ def compute_stateless_region(  # pylint: disable=too-many-positional-arguments
 # ---------------------------------------------------------------------------
 
 
+def usable_memory_gib(
+    instance: Instance, reserve_memory: Callable[[float], float]
+) -> float:
+    """RAM one node can give the datastore after reservations.
+
+    Reservations are things like the JVM heap, sidecars, and the OS. Zero or
+    less means the shape cannot host the workload at all: no node count
+    satisfies a memory requirement, so callers must reject the shape rather
+    than size a cluster out of it.
+    """
+    return instance.ram_gib - reserve_memory(instance.ram_gib)
+
+
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-statements
 def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
@@ -574,9 +587,17 @@ def compute_stateful_zone(  # pylint: disable=too-many-positional-arguments
     count_cpu = math.ceil(needed_cores / instance.cpu)
 
     # Memory (write-buffer floor bumps count when writes dominate)
-    count_memory = math.ceil(
-        needed_memory_gib / (instance.ram_gib - reserve_memory(instance.ram_gib))
-    )
+    memory_per_node_gib = usable_memory_gib(instance, reserve_memory)
+    if memory_per_node_gib <= 0:
+        raise ValueError(
+            f"{instance.name} reserves "
+            f"{instance.ram_gib - memory_per_node_gib} GiB of its "
+            f"{instance.ram_gib} GiB of RAM, leaving {memory_per_node_gib} GiB "
+            "for the datastore. No node count satisfies the memory "
+            "requirement, so this shape must be rejected before sizing "
+            "a cluster."
+        )
+    count_memory = math.ceil(needed_memory_gib / memory_per_node_gib)
     if write_buffer(instance.ram_gib) > 0:
         count_memory = max(
             count_memory,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -678,6 +678,33 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
         )
 
+    # The 16 GiB floor above is workload independent, but the reserved app and
+    # system memory is not. Once the JVM heap and those reserves are carved out
+    # there has to be RAM left for page cache, otherwise Cassandra has nowhere
+    # to keep its working set and this shape cannot run the workload at all.
+    base_mem = base_memory_gib(desires)
+    node_memory = MemoryLayout.for_ram(
+        ram_gib=instance.ram_gib,
+        base_reserves_gib=base_mem,
+        max_page_cache_gib=max_page_cache_gib,
+    )
+    if node_memory.page_cache_capacity_gib <= 0:
+        return Excuse(
+            instance=instance.name,
+            drive=drive_name,
+            reason=(
+                f"No page cache left: {instance.ram_gib:.0f} GiB RAM - "
+                f"{node_memory.heap_gib:.0f} GiB heap - {base_mem:.0f} GiB "
+                f"reserved app and system memory"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "heap_gib": node_memory.heap_gib,
+                "base_reserves_gib": base_mem,
+            },
+            bottleneck=Bottleneck.memory,
+        )
+
     # if we're not allowed to use gp2, skip EBS only types
     if instance.drive is None and require_local_disks:
         return Excuse(
@@ -821,8 +848,6 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         disk_per_node_gib=effective_disk_per_node_gib,
         cluster_size_lambda=cluster_size_lambda,
     )
-
-    base_mem = base_memory_gib(desires)
 
     @lru_cache(maxsize=None)
     def memory_layout(ram_gib: float) -> MemoryLayout:

--- a/service_capacity_modeling/models/org/netflix/control.py
+++ b/service_capacity_modeling/models/org/netflix/control.py
@@ -23,6 +23,8 @@ from service_capacity_modeling.interface import certain_int
 
 
 class NflxControlCapacityModel(CapacityModel):
+    cluster_type = "dgwcontrol"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/counter.py
+++ b/service_capacity_modeling/models/org/netflix/counter.py
@@ -56,6 +56,8 @@ class NflxCounterArguments(NflxJavaAppArguments):
 
 
 class NflxCounterCapacityModel(CapacityModel):
+    cluster_type = "dgwcounter"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -185,6 +185,8 @@ class NflxElasticsearchArguments(BaseModel):
 
 
 class NflxElasticsearchDataCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-data"
+
     @staticmethod
     def default_buffers() -> Buffers:
         return Buffers(
@@ -413,6 +415,8 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
 
 
 class NflxElasticsearchMasterCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-master"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,
@@ -472,6 +476,8 @@ class NflxElasticsearchMasterCapacityModel(CapacityModel):
 
 
 class NflxElasticsearchSearchCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-search"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,
@@ -529,6 +535,14 @@ class NflxElasticsearchSearchCapacityModel(CapacityModel):
 
 
 class NflxElasticsearchCapacityModel(CapacityModel):
+    @classmethod
+    def current_cluster_types(cls) -> Tuple[str, ...]:
+        return (
+            "elasticsearch-data",
+            "elasticsearch-master",
+            "elasticsearch-search",
+        )
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -460,6 +460,13 @@ class NflxElasticsearchCapacityModel(CapacityModel):
         return None
 
     @staticmethod
+    def plans_own_cluster() -> bool:
+        # This model owns no instances; it splits Elasticsearch into its data,
+        # master and search node roles. The caller's desires describe those
+        # nodes, so per-instance reservations belong to them.
+        return False
+
+    @staticmethod
     def description() -> str:
         return "Netflix Streaming Elasticsearch Model"
 

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -570,15 +570,15 @@ class NflxElasticsearchCapacityModel(CapacityModel):
         user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
     ) -> Tuple[Tuple[str, Callable[[CapacityDesires], CapacityDesires]], ...]:
         def _modify_data_desires(desires: CapacityDesires) -> CapacityDesires:
-            # data node's model use the full desires
+            # Data nodes use the full Elasticsearch workload desires.
             return desires
 
         def _modify_master_desires(desires: CapacityDesires) -> CapacityDesires:
-            # master node's model doesn't use anything from the desires
+            # Master nodes inherit the Elasticsearch app memory reservation.
             return desires
 
         def _modify_search_desires(desires: CapacityDesires) -> CapacityDesires:
-            # search node's model doesn't use anything from the desires
+            # Search nodes inherit the Elasticsearch app memory reservation.
             return desires
 
         return (

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -36,6 +36,7 @@ from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_effective_disk_per_node_gib
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import upsert_params
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.common import working_set_from_drive_and_slo
@@ -225,6 +226,22 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         if instance.cpu < 2 or instance.ram_gib < 24:
             return None
 
+        # Sidecars/System takes away memory from Elasticsearch
+        # which uses half of available system max of 32 for compressed oops
+        base_mem = (
+            desires.data_shape.reserved_instance_app_mem_gib
+            + desires.data_shape.reserved_instance_system_mem_gib
+        )
+
+        def reserve_memory(instance_mem_gib: float) -> float:
+            return base_mem + max(32, instance_mem_gib / 2)
+
+        # The 24 GiB floor above ignores the workload's reserved memory. If the
+        # reserves swallow the whole instance there is nothing left to hold
+        # shards, so no node count works and the shape has to go.
+        if usable_memory_gib(instance, reserve_memory) <= 0:
+            return None
+
         # Right now Elasticsearch doesn't deploy to cloud drives
         if instance.drive is None:
             return None
@@ -260,11 +277,6 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             copies_per_region=copies_per_region,
             max_rps_to_disk=max_rps_to_disk,
         )
-        base_mem = (
-            desires.data_shape.reserved_instance_app_mem_gib
-            + desires.data_shape.reserved_instance_system_mem_gib
-        )
-
         data_write_per_sec = (
             desires.query_pattern.estimated_write_per_second.mid // zones_in_region
         )
@@ -309,9 +321,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
             # Elasticsearch clusters can auto-balance via shard placement
             cluster_size=lambda x: x,
             min_count=min_count,
-            # Sidecars/System takes away memory from Elasticsearch
-            # which uses half of available system max of 32 for compressed oops
-            reserve_memory=lambda x: base_mem + max(32, x / 2),
+            reserve_memory=reserve_memory,
         )
         data_cluster.cluster_type = "elasticsearch-data"
 

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -14,6 +15,7 @@ from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import Buffers
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
@@ -21,6 +23,7 @@ from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import Instance
@@ -203,7 +206,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         copies_per_region: int = _target_rf(
             desires, extra_model_arguments.get("copies_per_region", None)
         )
@@ -224,7 +227,21 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
 
         # Netflix Elasticsearch doesn't like to deploy on really small instances
         if instance.cpu < 2 or instance.ram_gib < 24:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (min 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (min 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu": 2,
+                    "min_ram_gib": 24,
+                },
+                bottleneck=(Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory),
+            )
 
         # Sidecars/System takes away memory from Elasticsearch
         # which uses half of available system max of 32 for compressed oops
@@ -239,12 +256,32 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         # The 24 GiB floor above ignores the workload's reserved memory. If the
         # reserves swallow the whole instance there is nothing left to hold
         # shards, so no node count works and the shape has to go.
-        if usable_memory_gib(instance, reserve_memory) <= 0:
-            return None
+        usable_gib = usable_memory_gib(instance, reserve_memory)
+        if usable_gib <= 0:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
+                    f"leaves no RAM for shards on a {instance.ram_gib:.0f} GiB shape"
+                ),
+                context={
+                    "ram_gib": instance.ram_gib,
+                    "reserved_gib": reserve_memory(instance.ram_gib),
+                    "usable_gib": usable_gib,
+                },
+                bottleneck=Bottleneck.memory,
+            )
 
         # Right now Elasticsearch doesn't deploy to cloud drives
         if instance.drive is None:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=f"Requires local disks but {instance.name} is EBS-only",
+                context={"has_local_drive": False},
+                bottleneck=Bottleneck.drive_type,
+            )
 
         zones_in_region = context.zones_in_region
 
@@ -338,8 +375,23 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         #    smaller clusters so your restarts don't take months.
         #  * NxN network issues. Sometimes smaller clusters of bigger nodes
         #    are better for network propagation
-        if data_cluster.count > (max_regional_size // zones_in_region):
-            return None
+        max_zonal_size = max_regional_size // zones_in_region
+        if data_cluster.count > max_zonal_size:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Needs {data_cluster.count} nodes per zone, over the "
+                    f"{max_zonal_size} allowed by max_regional_size "
+                    f"({max_regional_size})"
+                ),
+                context={
+                    "count": data_cluster.count,
+                    "max_zonal_size": max_zonal_size,
+                    "max_regional_size": max_regional_size,
+                },
+                bottleneck=Bottleneck.cluster_size,
+            )
 
         ec2_costs = {
             "elasticsearch-data.zonal-clusters": zones_in_region
@@ -368,12 +420,26 @@ class NflxElasticsearchMasterCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(
@@ -413,12 +479,26 @@ class NflxElasticsearchSearchCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -33,6 +33,7 @@ from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.interface import Requirements
 from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models import CapacityModel
+from service_capacity_modeling.models import ChildDesiresConfig
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
@@ -554,11 +555,11 @@ class NflxElasticsearchCapacityModel(CapacityModel):
         return None
 
     @staticmethod
-    def plans_own_cluster() -> bool:
-        # This model owns no instances; it splits Elasticsearch into its data,
-        # master and search node roles. The caller's desires describe those
-        # nodes, so per-instance reservations belong to them.
-        return False
+    def child_desires_config(child_model: str) -> ChildDesiresConfig:
+        # This model expands Elasticsearch into data, master, and search node
+        # roles. The caller's Elasticsearch reservation applies to those roles.
+        _ = child_model
+        return ChildDesiresConfig(inherit_app_memory_reservation=True)
 
     @staticmethod
     def description() -> str:

--- a/service_capacity_modeling/models/org/netflix/entity.py
+++ b/service_capacity_modeling/models/org/netflix/entity.py
@@ -22,6 +22,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxEntityCapacityModel(CapacityModel):
+    cluster_type = "dgwentity"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -46,7 +46,6 @@ from service_capacity_modeling.models.common import get_effective_disk_per_node_
 from service_capacity_modeling.models.common import network_services
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import upsert_params
-from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.common import RequirementFromCurrentCapacity
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -302,23 +301,6 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         # OS memory.
         variable_os = int(instance_mem_gib * 0.03)
         return base_mem + variable_os
-
-    # If the reserves swallow the whole instance there is nothing left to cache
-    # with, so no node count works and the shape has to go.
-    if usable_memory_gib(instance, reserve_memory) <= 0:
-        return Excuse(
-            instance=instance.name,
-            drive=drive.name,
-            reason=(
-                f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
-                f"leaves no RAM for EVCache on a {instance.ram_gib:.0f} GiB shape"
-            ),
-            context={
-                "ram_gib": instance.ram_gib,
-                "reserved_gib": reserve_memory(instance.ram_gib),
-            },
-            bottleneck=Bottleneck.memory,
-        )
 
     requirement.context["osmem"] = reserve_memory(instance.ram_gib)
     # EVCache clusters aim to be at least 2 nodes per zone to start

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -46,6 +46,7 @@ from service_capacity_modeling.models.common import get_effective_disk_per_node_
 from service_capacity_modeling.models.common import network_services
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import upsert_params
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.common import RequirementFromCurrentCapacity
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
@@ -301,6 +302,23 @@ def _estimate_evcache_cluster_zonal(  # noqa: C901,E501 pylint: disable=too-many
         # OS memory.
         variable_os = int(instance_mem_gib * 0.03)
         return base_mem + variable_os
+
+    # If the reserves swallow the whole instance there is nothing left to cache
+    # with, so no node count works and the shape has to go.
+    if usable_memory_gib(instance, reserve_memory) <= 0:
+        return Excuse(
+            instance=instance.name,
+            drive=drive.name,
+            reason=(
+                f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
+                f"leaves no RAM for EVCache on a {instance.ram_gib:.0f} GiB shape"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "reserved_gib": reserve_memory(instance.ram_gib),
+            },
+            bottleneck=Bottleneck.memory,
+        )
 
     requirement.context["osmem"] = reserve_memory(instance.ram_gib)
     # EVCache clusters aim to be at least 2 nodes per zone to start

--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -160,6 +160,8 @@ def _read_amplification(args: NflxGraphKVArguments) -> float:
 
 
 class NflxGraphKVCapacityModel(CapacityModel):
+    cluster_type = "dgwgraphkv"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/identifier.py
+++ b/service_capacity_modeling/models/org/netflix/identifier.py
@@ -20,6 +20,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxIdentifierCapacityModel(CapacityModel):
+    cluster_type = "dgwidentifier"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -327,10 +327,30 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
     )
 
     # Account for sidecars and base system memory
-    base_mem = (
+    # Kafka currently uses 8GiB fixed, might want to change to min(30, x // 2)
+    reserved_mem_gib = (
         desires.data_shape.reserved_instance_app_mem_gib
         + desires.data_shape.reserved_instance_system_mem_gib
+        + 8
     )
+
+    # The min_instance_memory_gib floor above ignores the workload's reserved
+    # memory. If the reserves swallow the whole instance there is nothing left
+    # to hold partitions, so no node count works and the shape has to go.
+    if instance.ram_gib <= reserved_mem_gib:
+        return Excuse(
+            instance=instance.name,
+            drive=drive.name,
+            reason=(
+                f"Reserved memory ({reserved_mem_gib:.0f} GiB) leaves no RAM "
+                f"for Kafka on a {instance.ram_gib:.0f} GiB shape"
+            ),
+            context={
+                "ram_gib": instance.ram_gib,
+                "reserved_gib": reserved_mem_gib,
+            },
+            bottleneck=Bottleneck.memory,
+        )
 
     # Kafka clusters in prod (tier 0+1) need at least 2 nodes per zone
     min_count_for_tier = 1
@@ -392,9 +412,7 @@ def _estimate_kafka_cluster_zonal(  # noqa: C901
         ),
         cluster_size=lambda x: x,
         min_count=max(min_count_for_tier, min_count_for_data, required_zone_size or 1),
-        # Sidecars and Variable OS Memory
-        # Kafka currently uses 8GiB fixed, might want to change to min(30, x // 2)
-        reserve_memory=lambda instance_mem_gib: base_mem + 8,
+        reserve_memory=lambda _instance_mem_gib: reserved_mem_gib,
     )
 
     # Communicate to the actual provision that if we want reduced RF

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -46,20 +46,6 @@ class NflxKeyValueArguments(NflxJavaAppArguments):
     )
 
 
-def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
-    """Drop the KV app's memory reserve so the datastore uses its own.
-
-    ``reserved_instance_app_mem_gib`` is per instance of the tier it was
-    written for. Callers set it for the dgwkv Java app, which runs on its own
-    shapes, so carrying it into Cassandra or EVCache reserves memory those
-    nodes never use. Unsetting it (rather than picking a number here) lets
-    each datastore's ``default_desires`` supply its own reserve.
-    """
-    data_shape = desires.data_shape.model_dump(exclude_unset=True)
-    data_shape.pop("reserved_instance_app_mem_gib", None)
-    return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
-
-
 class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
     service_name = "key-value"
     cluster_type = "dgwkv"
@@ -133,7 +119,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_cassandra_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = _without_app_memory_reserve(desires)
+                relaxed = desires.model_copy(deep=True)
 
                 # This is an initial best guess. Parameterizing in case we want to
                 # configure it in the future.
@@ -151,7 +137,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_evcache_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = _without_app_memory_reserve(desires)
+                relaxed = desires.model_copy(deep=True)
                 access_consistency = relaxed.query_pattern.access_consistency
                 access_consistency.same_region.target_consistency = (
                     AccessConsistency.best_effort
@@ -163,7 +149,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
                 ("org.netflix.evcache", _modify_evcache_desires),
             )
         else:
-            return (("org.netflix.cassandra", _without_app_memory_reserve),)
+            return (("org.netflix.cassandra", lambda x: x),)
 
     @staticmethod
     def default_desires(

--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -46,6 +46,20 @@ class NflxKeyValueArguments(NflxJavaAppArguments):
     )
 
 
+def _without_app_memory_reserve(desires: CapacityDesires) -> CapacityDesires:
+    """Drop the KV app's memory reserve so the datastore uses its own.
+
+    ``reserved_instance_app_mem_gib`` is per instance of the tier it was
+    written for. Callers set it for the dgwkv Java app, which runs on its own
+    shapes, so carrying it into Cassandra or EVCache reserves memory those
+    nodes never use. Unsetting it (rather than picking a number here) lets
+    each datastore's ``default_desires`` supply its own reserve.
+    """
+    data_shape = desires.data_shape.model_dump(exclude_unset=True)
+    data_shape.pop("reserved_instance_app_mem_gib", None)
+    return desires.model_copy(deep=True, update={"data_shape": DataShape(**data_shape)})
+
+
 class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
     service_name = "key-value"
     cluster_type = "dgwkv"
@@ -119,7 +133,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_cassandra_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = desires.model_copy(deep=True)
+                relaxed = _without_app_memory_reserve(desires)
 
                 # This is an initial best guess. Parameterizing in case we want to
                 # configure it in the future.
@@ -137,7 +151,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
             def _modify_evcache_desires(
                 desires: CapacityDesires,
             ) -> CapacityDesires:
-                relaxed = desires.model_copy(deep=True)
+                relaxed = _without_app_memory_reserve(desires)
                 access_consistency = relaxed.query_pattern.access_consistency
                 access_consistency.same_region.target_consistency = (
                     AccessConsistency.best_effort
@@ -149,7 +163,7 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
                 ("org.netflix.evcache", _modify_evcache_desires),
             )
         else:
-            return (("org.netflix.cassandra", lambda x: x),)
+            return (("org.netflix.cassandra", _without_app_memory_reserve),)
 
     @staticmethod
     def default_desires(

--- a/service_capacity_modeling/models/org/netflix/postgres.py
+++ b/service_capacity_modeling/models/org/netflix/postgres.py
@@ -22,6 +22,10 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxPostgresCapacityModel(CapacityModel):
+    @classmethod
+    def current_cluster_types(cls) -> Tuple[str, ...]:
+        return ("aurora-cluster", "rds-cluster")
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/time_series.py
+++ b/service_capacity_modeling/models/org/netflix/time_series.py
@@ -23,6 +23,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxTimeSeriesCapacityModel(CapacityModel):
+    cluster_type = "dgwts"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/wal.py
+++ b/service_capacity_modeling/models/org/netflix/wal.py
@@ -22,6 +22,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxWALCapacityModel(CapacityModel):
+    cluster_type = "dgwwal"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -381,7 +381,10 @@ def test_shape_without_page_cache_is_excused():
     assert explained.plans, "Larger shapes should still produce plans"
 
     excused = {
-        e.instance for e in explained.excuses if "No page cache left" in e.reason
+        excuse.instance
+        for model_excuses in explained.excuses_by_model.values()
+        for excuse in model_excuses
+        if "No page cache left" in excuse.reason
     }
     assert "i4i.xlarge" in excused
 

--- a/tests/netflix/test_cassandra_resource_counts.py
+++ b/tests/netflix/test_cassandra_resource_counts.py
@@ -349,3 +349,41 @@ def test_memory_scale_down_caps_write_buffer():
                 f"<= uncapped ({uncapped_mem}) for {capped_zone.instance.name}"
             )
             break
+
+
+def test_shape_without_page_cache_is_excused():
+    """Large reserved app memory can leave a shape with no page cache at all.
+
+    i4i.xlarge holds 30.52 GiB: a 15 GiB heap plus 25 GiB of reserved app and
+    system memory overruns the box, so page cache capacity clamps to zero.
+    Sizing a cluster out of that shape used to divide by zero, so the shape has
+    to be excused before it reaches compute_stateful_zone.
+    """
+    desires = CapacityDesires(
+        service_tier=0,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.latency,
+            estimated_read_per_second=certain_int(2870),
+            estimated_write_per_second=certain_int(1381),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=certain_int(15205),
+            reserved_instance_app_mem_gib=24,
+        ),
+    )
+
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=desires,
+    )
+
+    assert explained.plans, "Larger shapes should still produce plans"
+
+    excused = {
+        e.instance for e in explained.excuses if "No page cache left" in e.reason
+    }
+    assert "i4i.xlarge" in excused
+
+    for plan in explained.plans:
+        assert plan.candidate_clusters.zonal[0].instance.ram_gib > 40

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -369,12 +369,17 @@ def test_es_rejections_explain_themselves():
         model_name="org.netflix.elasticsearch", region="us-east-1", desires=desires
     )
     assert explained.plans, "Expected Elasticsearch to still produce plans"
-    assert explained.excuses, "Expected rejected shapes to be explained"
+    excuses = [
+        excuse
+        for model_excuses in explained.excuses_by_model.values()
+        for excuse in model_excuses
+    ]
+    assert excuses, "Expected rejected shapes to be explained"
 
-    for excuse in explained.excuses:
+    for excuse in excuses:
         assert excuse.reason
         assert excuse.bottleneck is not None
 
-    bottlenecks = {e.bottleneck for e in explained.excuses}
+    bottlenecks = {e.bottleneck for e in excuses}
     assert Bottleneck.drive_type in bottlenecks  # EBS-only shapes
     assert Bottleneck.memory in bottlenecks  # too small, or reserves overrun

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -292,3 +292,52 @@ def zonal_summary(zlr):
         zlr_cost,
         zlr_drive_gib,
     )
+
+
+def test_es_data_nodes_have_ram_left_after_reserves():
+    """Data nodes must have RAM left once sidecars and the heap are carved out.
+
+    Elasticsearch reserves ``base_mem + max(32, ram / 2)`` per node, which
+    overruns shapes at or below ~34 GiB. Those used to yield a negative memory
+    node count that max() discarded, silently dropping the memory constraint
+    and letting an undersized shape win on cost.
+    """
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=1000, mid=10_000, high=100_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            ),
+        ),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.elasticsearch",
+        region="us-east-1",
+        desires=desires,
+    )
+    assert plans, "Expected plans on shapes large enough for the reserves"
+
+    base_mem = (
+        desires.data_shape.reserved_instance_app_mem_gib
+        + desires.data_shape.reserved_instance_system_mem_gib
+    )
+    data_clusters = [
+        cluster
+        for plan in plans
+        for cluster in plan.candidate_clusters.zonal
+        if cluster.cluster_type == "elasticsearch-data"
+    ]
+    assert data_clusters
+
+    for cluster in data_clusters:
+        ram_gib = cluster.instance.ram_gib
+        reserved = base_mem + max(32, ram_gib / 2)
+        assert ram_gib > reserved, (
+            f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
+        )

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import DataShape
@@ -341,3 +342,39 @@ def test_es_data_nodes_have_ram_left_after_reserves():
         assert ram_gib > reserved, (
             f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
         )
+
+
+def test_es_rejections_explain_themselves():
+    """Rejected shapes come back as excuses, not a silent None.
+
+    Cassandra, Kafka and EVCache all excuse the shapes they turn down.
+    Elasticsearch dropped them on the floor, so a caller asking why their
+    instance family was ignored had nothing to read.
+    """
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=1000, mid=10_000, high=100_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            ),
+        ),
+    )
+
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.elasticsearch", region="us-east-1", desires=desires
+    )
+    assert explained.plans, "Expected Elasticsearch to still produce plans"
+    assert explained.excuses, "Expected rejected shapes to be explained"
+
+    for excuse in explained.excuses:
+        assert excuse.reason
+        assert excuse.bottleneck is not None
+
+    bottlenecks = {e.bottleneck for e in explained.excuses}
+    assert Bottleneck.drive_type in bottlenecks  # EBS-only shapes
+    assert Bottleneck.memory in bottlenecks  # too small, or reserves overrun

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -2,6 +2,8 @@
 Tests for Netflix key-value model.
 """
 
+from typing import Dict
+
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -83,3 +85,71 @@ def test_large_app_memory_reserve_survives_simulation():
     )
 
     assert plan.least_regret
+
+
+# 200 GiB / 5000 rps sits near Cassandra's memory bound, so a leaked 24 GiB
+# reserve visibly changes the shape it picks. A disk-bound namespace would
+# hide the difference.
+MEMORY_SENSITIVE_KV = CapacityDesires(
+    service_tier=1,
+    query_pattern=QueryPattern(
+        estimated_read_per_second=Interval(
+            low=500, mid=5000, high=50_000, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=250, mid=2500, high=25_000, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(low=20, mid=200, high=2000, confidence=0.98),
+    ),
+)
+
+
+def _clusters(app_mem_gib: float) -> Dict[str, str]:
+    desires = MEMORY_SENSITIVE_KV.model_copy(deep=True)
+    desires.data_shape.reserved_instance_app_mem_gib = app_mem_gib
+    plan = planner.plan_certain(
+        model_name="org.netflix.key-value", region="us-east-1", desires=desires
+    )[0]
+    clusters = list(plan.candidate_clusters.zonal) + list(
+        plan.candidate_clusters.regional
+    )
+    return {c.cluster_type: f"{c.instance.name}x{c.count}" for c in clusters}
+
+
+def test_app_memory_reserve_stays_on_the_kv_tier():
+    """The dgwkv app's reserve is not Cassandra's reserve.
+
+    reserved_instance_app_mem_gib is memory per instance of the tier it was
+    written for. Callers set it for the KV Java app, which runs on its own
+    shapes, so raising it must move the dgwkv tier and leave Cassandra alone.
+    """
+    lean = _clusters(4)
+    heavy = _clusters(24)
+
+    assert heavy["cassandra"] == lean["cassandra"]
+    assert heavy["dgwkv"] != lean["dgwkv"]
+
+
+def test_evcache_also_gets_its_own_app_memory_reserve():
+    """EVCache runs on its own shapes too, so the KV reserve stops at KV."""
+    cached = LARGE_APP_RESERVE_KV.model_copy(deep=True)
+    cached.query_pattern.access_consistency.same_region.target_consistency = (
+        AccessConsistency.eventual
+    )
+    cached.query_pattern.estimated_read_per_second = Interval(
+        low=30_000, mid=300_000, high=3_000_000, confidence=0.98
+    )
+
+    plan = planner.plan_certain(
+        model_name="org.netflix.key-value", region="us-east-1", desires=cached
+    )[0]
+    evcache = [c for c in plan.candidate_clusters.zonal if c.cluster_type == "evcache"]
+    assert evcache, "Expected this workload to attach EVCache"
+
+    # EVCache reserves 1 GiB for its own app, so it is free to use small
+    # shapes. A node cannot be holding back 24 GiB of dgwkv heap and still
+    # fit on a box with less RAM than that.
+    for cluster in evcache:
+        assert cluster.instance.ram_gib < 24

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -2,6 +2,16 @@
 Tests for Netflix key-value model.
 """
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
 # Property test configuration for KeyValue model.
 # See tests/netflix/PROPERTY_TESTING.md for configuration options and examples.
 PROPERTY_TEST_CONFIG = {
@@ -9,3 +19,67 @@ PROPERTY_TEST_CONFIG = {
     #     "extra_model_arguments": {},
     # },
 }
+
+# A KV namespace that reserves 24 GiB for the app. That reserve flows through
+# to the composed Cassandra model, where it overruns small shapes.
+LARGE_APP_RESERVE_KV = CapacityDesires(
+    service_tier=0,
+    query_pattern=QueryPattern(
+        access_pattern=AccessPattern.latency,
+        access_consistency=GlobalConsistency(
+            same_region=Consistency(
+                target_consistency=AccessConsistency.read_your_writes
+            ),
+        ),
+        estimated_read_per_second=Interval(
+            low=287, mid=2870, high=28700, confidence=0.98
+        ),
+        estimated_write_per_second=Interval(
+            low=138.1, mid=1381, high=13810, confidence=0.98
+        ),
+        estimated_mean_write_size_bytes=Interval(
+            low=102.4, mid=1024, high=10240, confidence=0.98
+        ),
+    ),
+    data_shape=DataShape(
+        estimated_state_size_gib=Interval(
+            low=1520.5, mid=15205.1, high=152050.7, confidence=0.98
+        ),
+        estimated_state_item_count=Interval(
+            low=10_000_000, mid=100_000_000, high=1_000_000_000, confidence=0.98
+        ),
+        reserved_instance_app_mem_gib=24.0,
+    ),
+)
+
+
+def test_large_app_memory_reserve_plans_on_shapes_that_fit():
+    """Reserved app memory can overrun a small shape's RAM.
+
+    24 GiB of reserved app memory plus the JVM heap leaves no page cache on
+    shapes like i4i.xlarge, which used to divide by zero while sizing the
+    Cassandra cluster. Those shapes are now excused and planning continues on
+    shapes with RAM to spare.
+    """
+    plans = planner.plan_certain(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=LARGE_APP_RESERVE_KV,
+    )
+
+    assert plans, "Expected a plan on shapes large enough for the app reserve"
+    for plan in plans:
+        for cluster in plan.candidate_clusters.zonal:
+            assert cluster.instance.ram_gib > 40
+
+
+def test_large_app_memory_reserve_survives_simulation():
+    """The uncertain path walks the same shapes and must not blow up either."""
+    plan = planner.plan(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=LARGE_APP_RESERVE_KV,
+        simulations=32,
+    )
+
+    assert plan.least_regret

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -219,3 +219,22 @@ def test_untyped_current_cluster_remains_available_to_direct_model():
     by_model = _submodels("org.netflix.cassandra", desires)
 
     assert _current_types(by_model["org.netflix.cassandra"]) == {None}
+
+
+def test_multilevel_composition_preserves_ancestor_transforms():
+    desires = _desires(4)
+
+    by_model = _submodels("org.netflix.graphkv", desires)
+
+    key_value = by_model["org.netflix.key-value"].query_pattern
+    cassandra = by_model["org.netflix.cassandra"].query_pattern
+    assert key_value.estimated_read_per_second.mid == 55 * 5000
+    assert key_value.estimated_write_per_second.mid == 3 * 2500
+    assert (
+        cassandra.estimated_read_per_second.mid
+        == key_value.estimated_read_per_second.mid
+    )
+    assert (
+        cassandra.estimated_write_per_second.mid
+        == key_value.estimated_write_per_second.mid
+    )

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -4,6 +4,10 @@ import pytest
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentRegionClusterCapacity
+from service_capacity_modeling.interface import CurrentZoneClusterCapacity
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
@@ -108,3 +112,110 @@ def test_aggregators_pass_the_reserve_to_their_node_roles():
     heavy = _clusters_by_type("org.netflix.elasticsearch", 64)
 
     assert heavy["elasticsearch-data"] != lean["elasticsearch-data"]
+
+
+def _current_zonal(cluster_type=None):
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name="m5.xlarge",
+        cluster_instance_count=certain_int(3),
+        cluster_type=cluster_type,
+        cpu_utilization=certain_int(50),
+        memory_utilization_gib=certain_int(8),
+        network_utilization_mbps=certain_int(100),
+        disk_utilization_gib=certain_int(100),
+    )
+
+
+def _current_regional(cluster_type=None):
+    return CurrentRegionClusterCapacity(
+        cluster_instance_name="m5.xlarge",
+        cluster_instance_count=certain_int(3),
+        cluster_type=cluster_type,
+        cpu_utilization=certain_int(50),
+        memory_utilization_gib=certain_int(8),
+        network_utilization_mbps=certain_int(100),
+        disk_utilization_gib=certain_int(100),
+    )
+
+
+def _current_types(desires):
+    current = desires.current_clusters
+    assert current is not None
+    return {cluster.cluster_type for cluster in (*current.zonal, *current.regional)}
+
+
+def _submodels(model_name, desires, extra_model_arguments=None):
+    return dict(
+        planner._sub_models(  # pylint: disable=protected-access
+            model_name,
+            desires,
+            extra_model_arguments=extra_model_arguments or {},
+        )
+    )
+
+
+def test_composed_models_receive_only_their_current_cluster_type():
+    desires = _desires(24)
+    desires.current_clusters = CurrentClusters(
+        zonal=[_current_zonal("evcache"), _current_zonal("cassandra")],
+        regional=[_current_regional("dgwkv")],
+    )
+
+    by_model = _submodels(
+        "org.netflix.key-value",
+        desires,
+        extra_model_arguments={"kv_force_evcache": True},
+    )
+
+    assert _current_types(by_model["org.netflix.key-value"]) == {"dgwkv"}
+    assert _current_types(by_model["org.netflix.cassandra"]) == {"cassandra"}
+    assert _current_types(by_model["org.netflix.evcache"]) == {"evcache"}
+
+
+def test_composite_plan_accepts_typed_regional_and_zonal_current_clusters():
+    desires = _desires(24)
+    desires.current_clusters = CurrentClusters(
+        zonal=[_current_zonal("cassandra")],
+        regional=[_current_regional("dgwkv")],
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=desires,
+        num_results=1,
+    )
+
+    assert plans
+
+
+def test_role_split_models_filter_current_clusters_by_role():
+    desires = _desires(1)
+    desires.current_clusters = CurrentClusters(
+        zonal=[
+            _current_zonal("elasticsearch-data"),
+            _current_zonal("elasticsearch-master"),
+            _current_zonal("elasticsearch-search"),
+        ]
+    )
+
+    by_model = _submodels("org.netflix.elasticsearch", desires)
+
+    assert _current_types(by_model["org.netflix.elasticsearch.node"]) == {
+        "elasticsearch-data"
+    }
+    assert _current_types(by_model["org.netflix.elasticsearch.master"]) == {
+        "elasticsearch-master"
+    }
+    assert _current_types(by_model["org.netflix.elasticsearch.search"]) == {
+        "elasticsearch-search"
+    }
+
+
+def test_untyped_current_cluster_remains_available_to_direct_model():
+    desires = _desires(4)
+    desires.current_clusters = CurrentClusters(zonal=[_current_zonal()])
+
+    by_model = _submodels("org.netflix.cassandra", desires)
+
+    assert _current_types(by_model["org.netflix.cassandra"]) == {None}

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -3,12 +3,15 @@
 import pytest
 
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import Buffer
+from service_capacity_modeling.interface import Buffers
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentRegionClusterCapacity
 from service_capacity_modeling.interface import CurrentZoneClusterCapacity
 from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.elasticsearch import (
@@ -278,3 +281,37 @@ def test_multilevel_composition_preserves_ancestor_transforms():
         cassandra.estimated_write_per_second.mid
         == key_value.estimated_write_per_second.mid
     )
+
+
+def test_composition_only_resets_parent_app_memory():
+    desires = _desires(24)
+    desires.data_shape.reserved_instance_system_mem_gib = 7
+    desires.query_pattern.estimated_read_parallelism = certain_int(13)
+    desires.query_pattern.estimated_write_parallelism = certain_int(17)
+    desires.query_pattern.read_latency_slo_ms = FixedInterval(
+        low=2, mid=8, high=20, confidence=0.98
+    )
+    desires.query_pattern.write_latency_slo_ms = FixedInterval(
+        low=3, mid=9, high=24, confidence=0.98
+    )
+    desires.buffers = Buffers(default=Buffer(ratio=1.75, components=["cpu"]))
+
+    by_model = _submodels(
+        "org.netflix.graphkv",
+        desires,
+        extra_model_arguments={"kv_force_evcache": True},
+    )
+
+    for model_name in (
+        "org.netflix.graphkv",
+        "org.netflix.key-value",
+        "org.netflix.cassandra",
+        "org.netflix.evcache",
+    ):
+        child = by_model[model_name]
+        assert child.data_shape.reserved_instance_system_mem_gib == 7
+        assert child.query_pattern.estimated_read_parallelism.mid == 13
+        assert child.query_pattern.estimated_write_parallelism.mid == 17
+        assert child.query_pattern.read_latency_slo_ms.mid == 8
+        assert child.query_pattern.write_latency_slo_ms.mid == 9
+        assert child.buffers.default.ratio == 1.75

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -197,6 +197,19 @@ def test_composed_models_receive_only_their_current_cluster_type():
     assert _current_types(by_model["org.netflix.evcache"]) == {"evcache"}
 
 
+def test_untyped_current_cluster_is_fallback_during_partial_adoption():
+    desires = _desires(24)
+    desires.current_clusters = CurrentClusters(
+        zonal=[_current_zonal()],
+        regional=[_current_regional("dgwkv")],
+    )
+
+    by_model = _submodels("org.netflix.key-value", desires)
+
+    assert _current_types(by_model["org.netflix.key-value"]) == {"dgwkv"}
+    assert _current_types(by_model["org.netflix.cassandra"]) == {None}
+
+
 def test_composite_plan_accepts_typed_regional_and_zonal_current_clusters():
     desires = _desires(24)
     desires.current_clusters = CurrentClusters(

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -168,6 +168,17 @@ def test_elasticsearch_role_models_keep_the_caller_app_memory_reserve():
         assert by_model[model_name].data_shape.reserved_instance_app_mem_gib == 64
 
 
+def test_composed_datastores_use_their_own_app_memory_defaults():
+    by_model = _submodels(
+        "org.netflix.key-value",
+        _desires(24),
+        extra_model_arguments={"kv_force_evcache": True},
+    )
+
+    assert by_model["org.netflix.cassandra"].data_shape.reserved_instance_app_mem_gib == 4
+    assert by_model["org.netflix.evcache"].data_shape.reserved_instance_app_mem_gib == 1
+
+
 def test_composed_models_receive_only_their_current_cluster_type():
     desires = _desires(24)
     desires.current_clusters = CurrentClusters(

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -26,8 +26,8 @@ BASE_QUERY_PATTERN = QueryPattern(
 )
 BASE_STATE_SIZE = Interval(low=20, mid=200, high=2000, confidence=0.98)
 
-# Models that plan a datastore of their own on separate shapes. The parent's
-# app memory reserve describes the parent's instances, not theirs.
+# Models whose composed datastores do not run the parent application. The
+# parent's app memory reserve describes the parent model's instances, not theirs.
 COMPOSED_MODELS = [
     "org.netflix.key-value",
     "org.netflix.time-series",
@@ -59,7 +59,7 @@ def _clusters_by_type(model_name: str, app_mem_gib: float) -> dict:
 
 @pytest.mark.parametrize("model_name", COMPOSED_MODELS)
 def test_app_memory_reserve_does_not_reach_composed_models(model_name):
-    """A parent's app memory reserve stops at the parent's own tier.
+    """A parent's app memory reserve does not reach dependency models.
 
     reserved_instance_app_mem_gib is memory per instance of the tier it was
     written for. Composed models run on their own shapes, so inheriting the
@@ -90,7 +90,7 @@ def test_directly_planned_models_keep_the_caller_reserve():
     assert heavy["cassandra"] != lean["cassandra"]
 
 
-def test_parent_tier_still_gets_the_caller_reserve():
+def test_parent_model_still_gets_the_caller_reserve():
     """The reserve is dropped for children, not for the model asked for."""
     lean = _clusters_by_type("org.netflix.key-value", 4)
     heavy = _clusters_by_type("org.netflix.key-value", 24)
@@ -99,14 +99,17 @@ def test_parent_tier_still_gets_the_caller_reserve():
 
 
 def test_aggregators_pass_the_reserve_to_their_node_roles():
-    """A model that owns no instances is not a tier boundary.
+    """A role expansion can explicitly inherit the caller's reservation.
 
     org.netflix.elasticsearch plans nothing itself; it splits Elasticsearch
     into data, master and search nodes. The caller's reserve describes those
     nodes, so dropping it there would discard an explicit input rather than
     stop a leak.
     """
-    assert not nflx_elasticsearch_capacity_model.plans_own_cluster()
+    config = nflx_elasticsearch_capacity_model.child_desires_config(
+        "org.netflix.elasticsearch.node"
+    )
+    assert config.inherit_app_memory_reservation
 
     lean = _clusters_by_type("org.netflix.elasticsearch", 1)
     heavy = _clusters_by_type("org.netflix.elasticsearch", 64)

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -175,7 +175,9 @@ def test_composed_datastores_use_their_own_app_memory_defaults():
         extra_model_arguments={"kv_force_evcache": True},
     )
 
-    assert by_model["org.netflix.cassandra"].data_shape.reserved_instance_app_mem_gib == 4
+    assert (
+        by_model["org.netflix.cassandra"].data_shape.reserved_instance_app_mem_gib == 4
+    )
     assert by_model["org.netflix.evcache"].data_shape.reserved_instance_app_mem_gib == 1
 
 

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -1,0 +1,110 @@
+"""Tests for what a composed model inherits from its parent's desires."""
+
+import pytest
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.models.org.netflix.elasticsearch import (
+    nflx_elasticsearch_capacity_model,
+)
+
+# Sized to sit near the memory bound of the backing datastore, so a leaked
+# reserve visibly changes the shape it picks. A disk-bound namespace would
+# hide the difference.
+BASE_QUERY_PATTERN = QueryPattern(
+    estimated_read_per_second=Interval(low=500, mid=5000, high=50_000, confidence=0.98),
+    estimated_write_per_second=Interval(
+        low=250, mid=2500, high=25_000, confidence=0.98
+    ),
+)
+BASE_STATE_SIZE = Interval(low=20, mid=200, high=2000, confidence=0.98)
+
+# Models that plan a datastore of their own on separate shapes. The parent's
+# app memory reserve describes the parent's instances, not theirs.
+COMPOSED_MODELS = [
+    "org.netflix.key-value",
+    "org.netflix.time-series",
+    "org.netflix.graphkv",
+    "org.netflix.entity",
+]
+
+
+def _desires(app_mem_gib: float) -> CapacityDesires:
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=BASE_QUERY_PATTERN.model_copy(deep=True),
+        data_shape=DataShape(
+            estimated_state_size_gib=BASE_STATE_SIZE,
+            reserved_instance_app_mem_gib=app_mem_gib,
+        ),
+    )
+
+
+def _clusters_by_type(model_name: str, app_mem_gib: float) -> dict:
+    plan = planner.plan_certain(
+        model_name=model_name, region="us-east-1", desires=_desires(app_mem_gib)
+    )[0]
+    clusters = list(plan.candidate_clusters.zonal) + list(
+        plan.candidate_clusters.regional
+    )
+    return {c.cluster_type: f"{c.instance.name}x{c.count}" for c in clusters}
+
+
+@pytest.mark.parametrize("model_name", COMPOSED_MODELS)
+def test_app_memory_reserve_does_not_reach_composed_models(model_name):
+    """A parent's app memory reserve stops at the parent's own tier.
+
+    reserved_instance_app_mem_gib is memory per instance of the tier it was
+    written for. Composed models run on their own shapes, so inheriting the
+    value made them hold back memory for an app that is not on the box --
+    shrinking page cache and pushing them onto larger instances.
+    """
+    lean = _clusters_by_type(model_name, 4)
+    heavy = _clusters_by_type(model_name, 24)
+
+    datastore_types = set(lean) - {"dgwkv", "dgwts", "dgwgraphkv", "dgwentity"}
+    assert datastore_types, f"{model_name} composed no datastore"
+
+    for cluster_type in datastore_types:
+        assert heavy[cluster_type] == lean[cluster_type], (
+            f"{model_name}: {cluster_type} changed with the parent's app reserve"
+        )
+
+
+def test_directly_planned_models_keep_the_caller_reserve():
+    """Addressing a datastore by name still applies the caller's reserve.
+
+    Only inheritance across a composition boundary is dropped. Someone who
+    plans Cassandra directly is describing Cassandra's own instances.
+    """
+    lean = _clusters_by_type("org.netflix.cassandra", 4)
+    heavy = _clusters_by_type("org.netflix.cassandra", 24)
+
+    assert heavy["cassandra"] != lean["cassandra"]
+
+
+def test_parent_tier_still_gets_the_caller_reserve():
+    """The reserve is dropped for children, not for the model asked for."""
+    lean = _clusters_by_type("org.netflix.key-value", 4)
+    heavy = _clusters_by_type("org.netflix.key-value", 24)
+
+    assert heavy["dgwkv"] != lean["dgwkv"]
+
+
+def test_aggregators_pass_the_reserve_to_their_node_roles():
+    """A model that owns no instances is not a tier boundary.
+
+    org.netflix.elasticsearch plans nothing itself; it splits Elasticsearch
+    into data, master and search nodes. The caller's reserve describes those
+    nodes, so dropping it there would discard an explicit input rather than
+    stop a leak.
+    """
+    assert not nflx_elasticsearch_capacity_model.plans_own_cluster()
+
+    lean = _clusters_by_type("org.netflix.elasticsearch", 1)
+    heavy = _clusters_by_type("org.netflix.elasticsearch", 64)
+
+    assert heavy["elasticsearch-data"] != lean["elasticsearch-data"]

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -154,6 +154,17 @@ def _submodels(model_name, desires, extra_model_arguments=None):
     )
 
 
+def test_elasticsearch_role_models_keep_the_caller_app_memory_reserve():
+    by_model = _submodels("org.netflix.elasticsearch", _desires(64))
+
+    for model_name in (
+        "org.netflix.elasticsearch.node",
+        "org.netflix.elasticsearch.master",
+        "org.netflix.elasticsearch.search",
+    ):
+        assert by_model[model_name].data_shape.reserved_instance_app_mem_gib == 64
+
+
 def test_composed_models_receive_only_their_current_cluster_type():
     desires = _desires(24)
     desires.current_clusters = CurrentClusters(

--- a/tests/test_resource_counts.py
+++ b/tests/test_resource_counts.py
@@ -319,3 +319,30 @@ def test_topology_constraints_do_not_override_stronger_resource_limits():
     assert counts["cpu"] == 40
     assert counts["min_count"] == 6
     assert cluster.cluster_params["resource_bottleneck"] == "cpu"
+
+
+@pytest.mark.parametrize(
+    "reserve_memory",
+    [
+        lambda ram_gib: ram_gib,  # reserves exactly the whole box
+        lambda ram_gib: ram_gib + 8,  # reserves more than the box has
+    ],
+    ids=["reserves-all-ram", "reserves-more-than-ram"],
+)
+def test_shape_with_no_memory_left_over_is_rejected(reserve_memory):
+    """No node count satisfies memory when reservations eat the whole box.
+
+    Dividing by the leftover used to hand back either a ZeroDivisionError or a
+    negative node count that max() quietly discarded, which let an undersized
+    shape pass the memory check entirely.
+    """
+    with pytest.raises(ValueError, match="leaving .* for the datastore"):
+        compute_stateful_zone(
+            instance=M5_4XL,
+            drive=EBS,
+            needed_cores=4,
+            needed_disk_gib=100,
+            needed_memory_gib=1000,
+            needed_network_mbps=100,
+            reserve_memory=reserve_memory,
+        )


### PR DESCRIPTION
## What am I trying to do?

Fix the KeyValue planner crash caused when a parent application's per-instance memory reservation reaches composed Cassandra nodes and leaves no usable memory. The planner should reject infeasible instance shapes cleanly, while composition preserves workload transforms such as GraphKV fanout without applying one service's app-memory reservation to another service's hosts.

This is a draft implementation for review because `compose_with` currently serves both service composition and Elasticsearch role expansion.

## Why did I do it this way?

### Configure inheritance on each parent-to-child edge

`ChildDesiresConfig` is a typed Pydantic policy exposed by the base `CapacityModel`. Its narrow initial setting controls whether `reserved_instance_app_mem_gib` crosses a specific composition edge.

The default resets that field before the existing edge transform runs. This lets Cassandra and EVCache receive their own model defaults instead of KeyValue's app reservation. Elasticsearch explicitly opts its data, master, and search roles into inheritance because those children are roles of the same service rather than separately hosted dependencies.

The edge transform runs after the reset, so a model can still deliberately assign a child-specific reservation.

### Preserve workload transformations through multi-level composition

Composition now starts each child from desires already transformed by its ancestors. For example, GraphKV's read/write fanout reaches KeyValue and then Cassandra; parent model defaults remain local and do not leak into children.

```mermaid
flowchart LR
    A[Caller workload] --> B[Graph service fanout]
    B --> C[Key/value workload]
    C --> D[Cassandra workload]
    C --> E[Cache workload]
```

Read/write rates and other caller workload settings continue through the chain. Only the parent app-memory reservation is reset by default.

### Reject impossible memory shapes explicitly

Shared stateful sizing now refuses shapes whose reservations leave zero or negative usable memory. Cassandra and Elasticsearch reject those candidates with structured memory `Excuse` values, allowing the planner to continue evaluating feasible shapes instead of dividing by zero or silently dropping the constraint.

### Route current deployment state to its owner

When composed requests contain typed `current_clusters`, each model receives only cluster types it owns. Untyped rows remain a fallback during partial adoption so existing callers are not cut over abruptly.

## Alternatives considered

- **Special-case KeyValue:** narrow for the reported request, but leaves the same ambiguous inheritance behavior at every other composition edge.
- **Strip app memory globally with an “owns a tier” flag:** cannot accurately represent Elasticsearch's role expansion and makes the policy an indirect property of the parent rather than an explicit child-edge decision.
- **Pass either all desires or no desires:** breaks legitimate propagation such as GraphKV → KeyValue → Cassandra RPS/WPS fanout.
- **Hardcode Cassandra or EVCache reserve values in the parent:** duplicates child defaults in the wrong model and would drift as those defaults change.
- **Strip additional fields now:** system memory, buffers, parallelism, and latency semantics are less clearly service-local. This PR leaves them unchanged rather than expanding the behavioral contract without evidence.
- **Change the existing `compose_with` tuple shape or add decorators:** creates broader API churn. A base-model policy hook keeps existing composition implementations compatible and allows per-child overrides.

## Are there any tests?

Yes. Regression coverage verifies the original 24 GiB request no longer crashes, infeasible shapes produce memory excuses, KeyValue's reservation does not reach Cassandra or EVCache, Elasticsearch role models explicitly inherit it, multi-level RPS/WPS transforms survive, and typed/untyped current-cluster routing remains compatible.

The no-mistakes gate passed focused tests and lint. GitHub Actions passed the end-to-end suite and linters on Python 3.10, 3.11, and 3.12.

## How would I use the new code?

Most composed-service edges use the safe default:

```python
ChildDesiresConfig()
```

A same-service role expansion can explicitly inherit the reservation:

```python
@staticmethod
def child_desires_config(child_model: str) -> ChildDesiresConfig:
    return ChildDesiresConfig(inherit_app_memory_reservation=True)
```

## Deliberately deferred

`PlanExplanation.desires_by_model` currently reconstructs composed children from root desires, so its explanation can disagree with the accumulated transforms/defaults used by planning. The no-mistakes review caught this; it is fixed separately in #307 so this behavioral fix remains reviewable.

Changes to dgi-artifact inputs and broader desire-field inheritance semantics are also outside this PR.


