### PR TITLE
Explain why Elasticsearch turns a shape down

### DIFF
--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -14,6 +15,7 @@ from service_capacity_modeling.interface import AccessPattern
 from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import Buffers
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import CapacityPlan
 from service_capacity_modeling.interface import CapacityRequirement
@@ -22,6 +24,7 @@ from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import Interval
@@ -209,7 +212,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         copies_per_region: int = _target_rf(
             desires, extra_model_arguments.get("copies_per_region", None)
         )
@@ -230,7 +233,21 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
 
         # Netflix Elasticsearch doesn't like to deploy on really small instances
         if instance.cpu < 2 or instance.ram_gib < 24:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (min 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (min 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu": 2,
+                    "min_ram_gib": 24,
+                },
+                bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
+            )
 
         # Sidecars/System takes away memory from Elasticsearch
         # which uses half of available system max of 32 for compressed oops
@@ -245,12 +262,32 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         # The 24 GiB floor above ignores the workload's reserved memory. If the
         # reserves swallow the whole instance there is nothing left to hold
         # shards, so no node count works and the shape has to go.
-        if usable_memory_gib(instance, reserve_memory) <= 0:
-            return None
+        usable_gib = usable_memory_gib(instance, reserve_memory)
+        if usable_gib <= 0:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Reserved memory ({reserve_memory(instance.ram_gib):.0f} GiB) "
+                    f"leaves no RAM for shards on a {instance.ram_gib:.0f} GiB shape"
+                ),
+                context={
+                    "ram_gib": instance.ram_gib,
+                    "reserved_gib": reserve_memory(instance.ram_gib),
+                    "usable_gib": usable_gib,
+                },
+                bottleneck=Bottleneck.memory,
+            )
 
         # Right now Elasticsearch doesn't deploy to cloud drives
         if instance.drive is None:
-            return None
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=f"Requires local disks but {instance.name} is EBS-only",
+                context={"has_local_drive": False},
+                bottleneck=Bottleneck.drive_type,
+            )
 
         zones_in_region = context.zones_in_region
 
@@ -344,8 +381,23 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         #    smaller clusters so your restarts don't take months.
         #  * NxN network issues. Sometimes smaller clusters of bigger nodes
         #    are better for network propagation
-        if data_cluster.count > (max_regional_size // zones_in_region):
-            return None
+        max_zonal_size = max_regional_size // zones_in_region
+        if data_cluster.count > max_zonal_size:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Needs {data_cluster.count} nodes per zone, over the "
+                    f"{max_zonal_size} allowed by max_regional_size "
+                    f"({max_regional_size})"
+                ),
+                context={
+                    "count": data_cluster.count,
+                    "max_zonal_size": max_zonal_size,
+                    "max_regional_size": max_regional_size,
+                },
+                bottleneck=Bottleneck.cluster_size,
+            )
 
         ec2_costs = {
             "elasticsearch-data.zonal-clusters": zones_in_region
@@ -374,12 +426,26 @@ class NflxElasticsearchMasterCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(
@@ -419,12 +485,26 @@ class NflxElasticsearchSearchCapacityModel(CapacityModel):
         context: RegionContext,
         desires: CapacityDesires,
         extra_model_arguments: Dict[str, Any],
-    ) -> Optional[CapacityPlan]:
+    ) -> Union[CapacityPlan, Excuse, None]:
         # Only accept running on instances with a lot of RAM and a few CPUs
-        if instance.ram_gib <= 24:
-            return None
-        if instance.cpu <= 2:
-            return None
+        if instance.ram_gib <= 24 or instance.cpu <= 2:
+            return Excuse(
+                instance=instance.name,
+                drive=drive.name,
+                reason=(
+                    f"Instance too small: {instance.cpu} vCPUs (requires > 2), "
+                    f"{instance.ram_gib:.0f} GiB RAM (requires > 24 GiB)"
+                ),
+                context={
+                    "cpu": instance.cpu,
+                    "ram_gib": instance.ram_gib,
+                    "min_cpu_exclusive": 2,
+                    "min_ram_gib_exclusive": 24,
+                },
+                bottleneck=(
+                    Bottleneck.memory if instance.ram_gib <= 24 else Bottleneck.cpu
+                ),
+            )
 
         zones_in_region = context.zones_in_region
         requirement = CapacityRequirement(

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import Bottleneck
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import DataShape
@@ -341,3 +342,41 @@ def test_es_data_nodes_have_ram_left_after_reserves():
         assert ram_gib > reserved, (
             f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
         )
+
+
+def test_es_rejections_explain_themselves():
+    """Rejected shapes come back as excuses, not a silent None.
+
+    Cassandra, Kafka and EVCache all excuse the shapes they turn down.
+    Elasticsearch dropped them on the floor, so a caller asking why their
+    instance family was ignored had nothing to read.
+    """
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=1000, mid=10_000, high=100_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            ),
+        ),
+    )
+
+    explained = planner.plan_certain_explained(
+        model_name="org.netflix.elasticsearch", region="us-east-1", desires=desires
+    )
+    assert explained.plans, "Expected Elasticsearch to still produce plans"
+
+    excuses = [e for es in explained.excuses_by_model.values() for e in es]
+    assert excuses, "Expected rejected shapes to be explained"
+
+    for excuse in excuses:
+        assert excuse.reason
+        assert excuse.bottleneck is not None
+
+    bottlenecks = {e.bottleneck for e in excuses}
+    assert Bottleneck.drive_type in bottlenecks  # EBS-only shapes
+    assert Bottleneck.memory in bottlenecks  # too small, or reserves overrun


### PR DESCRIPTION
**PR 2 of 4**, stacked on #303. Review #303 first — this only makes sense on top of it.

## Why

Cassandra, Kafka and EVCache each return an `Excuse` naming the reason and the bottleneck
when they turn an instance down, and the planner collects those into
`plan_certain_explained().excuses_by_model`. Elasticsearch returned a bare `None` from all
eight of its rejection paths, so a caller asking why their instance family never appeared
had nothing to read.

This is the "confusing provisioning" case: a shape silently vanishes from consideration and
the plan gives no account of it.

The base `CapacityModel.capacity_plan` already declares
`Union[CapacityPlan, Excuse, None]` and `_plan_certain` already has a `case Excuse()` arm.
Elasticsearch had simply narrowed its own annotation to `Optional[CapacityPlan]` and never
adopted the mechanism.

## What changed

The data, master and search node models now excuse instead of returning `None`:

| bottleneck | reason |
|---|---|
| `cpu` / `memory` | `Instance too small: 2 vCPUs (min 2), 15 GiB RAM (min 24 GiB)` |
| `memory` | `Reserved memory (35 GiB) leaves no RAM for shards on a 29 GiB shape` |
| `drive_type` | `Requires local disks but m6a.4xlarge is EBS-only` |
| `cluster_size` | `Needs 41 nodes per zone, over the 40 allowed by max_regional_size (120)` |

The aggregator's `capacity_plan` keeps returning `None` — that one is not a rejection, it
owns no instances at all and exists only to split the service into node roles.

Two mechanical tidies came with it: `max_zonal_size` extracted from the inline
`max_regional_size // zones_in_region`, and the master/search `ram <= 24` and `cpu <= 2`
checks merged into one condition so the excuse can attribute the right bottleneck. Both are
logically identical to what they replace.

## Behavior

No plan changes. `Excuse` and `None` are treated identically for control flow in
`_plan_certain`, and the aggregator never invokes the node models directly, so there is no
`is None` check an `Excuse` could slip past. The only observable difference is that
`excuses_by_model` is now populated for Elasticsearch.

## Testing

Full suite green. `test_es_rejections_explain_themselves` asserts every excuse carries a
reason and a bottleneck, and that both `drive_type` and `memory` are represented — it fails
against the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
