### PR TITLE
Read the current cluster that belongs to this model

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1101,7 +1101,7 @@ class CapacityPlanner:
         )
 
         current_capacity = current_cluster_capacity(
-            desires, getattr(model, "cluster_type", "")
+            desires, *model.current_cluster_types()
         )
         # Return early if we dont have current_capacity set.
         if current_capacity is None or current_capacity.cluster_instance is None:

--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -62,6 +62,7 @@ from service_capacity_modeling.interface import ZoneClusterCapacity
 from service_capacity_modeling.models import CapacityModel
 from service_capacity_modeling.models import ChildDesiresConfig
 from service_capacity_modeling.models import CostAwareModel
+from service_capacity_modeling.models.common import current_cluster_capacity
 from service_capacity_modeling.models.common import get_disk_size_gib
 from service_capacity_modeling.models.common import merge_plan
 from service_capacity_modeling.models.org import netflix
@@ -1082,7 +1083,9 @@ class CapacityPlanner:
         )
 
     # Calculates the minimum cpu, memory, and network requirements based on desires.
-    def _per_instance_requirements(self, desires: CapacityDesires) -> Tuple[int, float]:
+    def _per_instance_requirements(
+        self, model: CapacityModel, desires: CapacityDesires
+    ) -> Tuple[int, float]:
         # Applications often set fixed reservations of heap or OS memory
         per_instance_mem = (
             desires.data_shape.reserved_instance_app_mem_gib
@@ -1097,12 +1100,9 @@ class CapacityPlanner:
             )
         )
 
-        current_capacity: Optional[CurrentClusterCapacity] = None
-        if desires.current_clusters is not None:
-            if desires.current_clusters.zonal:
-                current_capacity = desires.current_clusters.zonal[0]
-            elif desires.current_clusters.regional:
-                current_capacity = desires.current_clusters.regional[0]
+        current_capacity = current_cluster_capacity(
+            desires, getattr(model, "cluster_type", "")
+        )
         # Return early if we dont have current_capacity set.
         if current_capacity is None or current_capacity.cluster_instance is None:
             return (per_instance_cores, per_instance_mem)
@@ -1146,7 +1146,7 @@ class CapacityPlanner:
         (
             per_instance_cores,
             per_instance_mem,
-        ) = self._per_instance_requirements(desires)
+        ) = self._per_instance_requirements(model, desires)
 
         if model.run_hardware_simulation():
             for instance in hardware.instances.values():

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -199,6 +199,16 @@ class CapacityModel:
     of its own -- an aggregator that only composes with others.
     """
 
+    @classmethod
+    def current_cluster_types(cls) -> Tuple[str, ...]:
+        """Labels a caller might use for a cluster this model already runs.
+
+        Defaults to ``cluster_type``. Override when a model produces more than
+        one kind of cluster -- Postgres is a facade over Aurora and RDS, so an
+        existing cluster of its may carry either of their labels.
+        """
+        return (cls.cluster_type,) if cls.cluster_type else ()
+
     def __init__(self) -> None:
         pass
 

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -189,6 +189,16 @@ class CapacityModel:
 
     """
 
+    cluster_type: str = ""
+    """The label this model stamps on the clusters it produces.
+
+    Doubles as the name a caller uses in
+    ``CurrentClusterCapacity.cluster_type`` to say which tier an existing
+    cluster belongs to, so a composed request can describe several tiers and
+    each model can find its own. Empty means this model produces no clusters
+    of its own -- an aggregator that only composes with others.
+    """
+
     def __init__(self) -> None:
         pass
 

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -1227,6 +1227,41 @@ class RequirementFromCurrentCapacity(BaseModel):
         )
 
 
+def current_cluster_capacity(
+    desires: CapacityDesires, cluster_type: str
+) -> Optional[CurrentClusterCapacity]:
+    """The caller's existing cluster for this model, if they described one.
+
+    A composed request carries a current cluster per tier: a KeyValue plan
+    describes dgwkv, Cassandra and EVCache, and Cassandra and EVCache are
+    both zonal. Taking whichever entry came first meant a model could size
+    itself against another tier's topology, so match on ``cluster_type`` --
+    the field exists for exactly this and nothing was reading it.
+
+    Entries written before the field was populated carry no ``cluster_type``.
+    When none of them does, fall back to the first entry so those callers
+    keep working. When some are labelled but none is ours, the caller told us
+    about other tiers and not this one, so there is no current cluster.
+    """
+    clusters = desires.current_clusters
+    if clusters is None:
+        return None
+
+    candidates: List[CurrentClusterCapacity] = [*clusters.zonal, *clusters.regional]
+    for candidate in candidates:
+        if candidate.cluster_type == cluster_type:
+            return candidate
+
+    # An unlabelled entry means nobody said whose it is, not that it belongs to
+    # someone else, so it is still the best guess available -- which is what
+    # callers got before cluster_type was read at all. Only entries labelled as
+    # another tier are ruled out, which is the contamination worth stopping.
+    for candidate in candidates:
+        if not candidate.cluster_type:
+            return candidate
+    return None
+
+
 def zonal_requirements_from_current(
     current_cluster: CurrentClusters,
     buffers: Buffers,

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -30,7 +30,6 @@ from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import ClusterCapacity
 from service_capacity_modeling.interface import Clusters
 from service_capacity_modeling.interface import CurrentClusterCapacity
-from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import default_reference_shape
 from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import Instance
@@ -1263,14 +1262,19 @@ def current_cluster_capacity(
 
 
 def zonal_requirements_from_current(
-    current_cluster: CurrentClusters,
+    current_capacity: Optional[CurrentClusterCapacity],
     buffers: Buffers,
     instance: Instance,
     reference_shape: Instance,
 ) -> CapacityRequirement:
-    if current_cluster is not None and current_cluster.zonal[0] is not None:
-        current_capacity: CurrentClusterCapacity = current_cluster.zonal[0]
+    """Size against a cluster the caller already runs.
 
+    Takes the model's own current cluster rather than the whole
+    CurrentClusters list -- picking one out of that list is the caller's job
+    (see current_cluster_capacity), because in a composed request the list
+    holds a cluster per tier.
+    """
+    if current_capacity is not None:
         # Adjust the CPUs (vCPU + cores) based on generation / instance type
         requirement = RequirementFromCurrentCapacity(
             current_capacity=current_capacity,

--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -1227,7 +1227,7 @@ class RequirementFromCurrentCapacity(BaseModel):
 
 
 def current_cluster_capacity(
-    desires: CapacityDesires, cluster_type: str
+    desires: CapacityDesires, *cluster_types: str
 ) -> Optional[CurrentClusterCapacity]:
     """The caller's existing cluster for this model, if they described one.
 
@@ -1236,6 +1236,10 @@ def current_cluster_capacity(
     both zonal. Taking whichever entry came first meant a model could size
     itself against another tier's topology, so match on ``cluster_type`` --
     the field exists for exactly this and nothing was reading it.
+
+    Takes several labels because a model can produce more than one kind of
+    cluster: Postgres is a facade that plans either an Aurora or an RDS
+    cluster, so a caller's existing one may carry either label.
 
     Entries written before the field was populated carry no ``cluster_type``.
     When none of them does, fall back to the first entry so those callers
@@ -1246,9 +1250,10 @@ def current_cluster_capacity(
     if clusters is None:
         return None
 
+    wanted = {t for t in cluster_types if t}
     candidates: List[CurrentClusterCapacity] = [*clusters.zonal, *clusters.regional]
     for candidate in candidates:
-        if candidate.cluster_type == cluster_type:
+        if candidate.cluster_type in wanted:
             return candidate
 
     # An unlabelled entry means nobody said whose it is, not that it belongs to

--- a/service_capacity_modeling/models/org/netflix/aurora.py
+++ b/service_capacity_modeling/models/org/netflix/aurora.py
@@ -328,6 +328,8 @@ class NflxAuroraArguments(BaseModel):
 
 
 class NflxAuroraCapacityModel(CapacityModel):
+    cluster_type = "aurora-cluster"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -581,7 +581,9 @@ def _get_current_cluster_size(desires: CapacityDesires) -> int:
 
 
 def _get_current_capacity(desires: CapacityDesires) -> Optional[CurrentClusterCapacity]:
-    return current_cluster_capacity(desires, NflxCassandraCapacityModel.cluster_type)
+    return current_cluster_capacity(
+        desires, *NflxCassandraCapacityModel.current_cluster_types()
+    )
 
 
 def _get_cluster_size_lambda(

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -39,6 +39,7 @@ from service_capacity_modeling.explainability import STATEFUL_DATASTORE_FAMILIES
 from service_capacity_modeling.interface import Excuse
 from service_capacity_modeling.interface import FixedInterval
 from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import default_reference_shape
 from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.interface import normalized_aws_size
 from service_capacity_modeling.interface import Interval
@@ -51,6 +52,7 @@ from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models import RANK_PENALTIES
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
+from service_capacity_modeling.models.common import current_cluster_capacity
 from service_capacity_modeling.models.common import DerivedBuffers
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_disk_size_gib
@@ -239,13 +241,27 @@ def _write_buffer_gib_zone(
     return float(write_buffer_gib) / zones_per_region
 
 
+def _cassandra_reference_shape(desires: CapacityDesires) -> Instance:
+    """The shape Cassandra's core counts are normalized against.
+
+    CapacityDesires.reference_shape reads current_clusters.zonal[0], which in
+    a composed request can be another tier's cluster -- EVCache is zonal too.
+    Normalize against Cassandra's own current shape, or the default when the
+    caller did not describe one.
+    """
+    current_capacity = _get_current_capacity(desires)
+    if current_capacity is not None and current_capacity.cluster_instance is not None:
+        return current_capacity.cluster_instance
+    return default_reference_shape
+
+
 def _get_cores_from_desires(desires: CapacityDesires, instance: Instance) -> int:
     cpu_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BACKGROUND_BUFFER]
     )
 
     # We have no existing utilization to go from
-    reference_shape = desires.reference_shape
+    reference_shape = _cassandra_reference_shape(desires)
     # Keep half of the cores free for background work (compaction, backup, repair).
     needed_cores = math.ceil(sqrt_staffed_cores(desires) * cpu_buffer.ratio)
 
@@ -417,13 +433,13 @@ def _estimate_cassandra_requirement(
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
-    reference_shape = desires.reference_shape
+    reference_shape = _cassandra_reference_shape(desires)
     current_capacity = _get_current_capacity(desires)
 
     # If the cluster is already provisioned
     if current_capacity and desires.current_clusters is not None:
         capacity_requirement = zonal_requirements_from_current(
-            desires.current_clusters,
+            current_capacity,
             desires.buffers,
             instance,
             reference_shape,
@@ -565,13 +581,7 @@ def _get_current_cluster_size(desires: CapacityDesires) -> int:
 
 
 def _get_current_capacity(desires: CapacityDesires) -> Optional[CurrentClusterCapacity]:
-    if desires.current_clusters is None:
-        return None
-    if desires.current_clusters.zonal:
-        return desires.current_clusters.zonal[0]
-    if desires.current_clusters.regional:
-        return desires.current_clusters.regional[0]
-    return None
+    return current_cluster_capacity(desires, NflxCassandraCapacityModel.cluster_type)
 
 
 def _get_cluster_size_lambda(
@@ -1083,11 +1093,8 @@ def _estimate_zonal_data_gib(user_desires: CapacityDesires, rf: int) -> float:
     Prefers actual current_clusters data; falls back to estimated_state_size_gib
     divided by compression ratio (matching the on-disk units of the first path).
     """
-    if (
-        user_desires.current_clusters is not None
-        and user_desires.current_clusters.zonal
-    ):
-        cc = user_desires.current_clusters.zonal[0]
+    cc = _get_current_capacity(user_desires)
+    if cc is not None:
         if (
             cc.disk_utilization_gib is not None
             and cc.disk_utilization_gib.mid > 0

--- a/service_capacity_modeling/models/org/netflix/control.py
+++ b/service_capacity_modeling/models/org/netflix/control.py
@@ -23,6 +23,8 @@ from service_capacity_modeling.interface import certain_int
 
 
 class NflxControlCapacityModel(CapacityModel):
+    cluster_type = "dgwcontrol"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/counter.py
+++ b/service_capacity_modeling/models/org/netflix/counter.py
@@ -56,6 +56,8 @@ class NflxCounterArguments(NflxJavaAppArguments):
 
 
 class NflxCounterCapacityModel(CapacityModel):
+    cluster_type = "dgwcounter"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -186,6 +186,8 @@ class NflxElasticsearchArguments(BaseModel):
 
 
 class NflxElasticsearchDataCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-data"
+
     @staticmethod
     def default_buffers() -> Buffers:
         return Buffers(
@@ -419,6 +421,8 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
 
 
 class NflxElasticsearchMasterCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-master"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,
@@ -478,6 +482,8 @@ class NflxElasticsearchMasterCapacityModel(CapacityModel):
 
 
 class NflxElasticsearchSearchCapacityModel(CapacityModel):
+    cluster_type = "elasticsearch-search"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/entity.py
+++ b/service_capacity_modeling/models/org/netflix/entity.py
@@ -22,6 +22,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxEntityCapacityModel(CapacityModel):
+    cluster_type = "dgwentity"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -41,6 +41,7 @@ from service_capacity_modeling.models import CostAwareModel
 from service_capacity_modeling.models import RANK_PENALTIES
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import compute_stateful_zone
+from service_capacity_modeling.models.common import current_cluster_capacity
 from service_capacity_modeling.models.common import EFFECTIVE_DISK_PER_NODE_GIB
 from service_capacity_modeling.models.common import get_effective_disk_per_node_gib
 from service_capacity_modeling.models.common import network_services
@@ -112,11 +113,11 @@ def calculate_vitals_for_capacity_planner(
     needed_memory_gib = current_memory_gib
     needed_disk_gib = current_disk_gib
 
-    # Check if we can apply optimizations based on current cluster capacity
-    current_capacity = (
-        desires.current_clusters.zonal[0]
-        if desires.current_clusters and desires.current_clusters.zonal
-        else None
+    # Check if we can apply optimizations based on current cluster capacity.
+    # Cassandra is zonal too, so a composed KeyValue request lists both here
+    # and taking the first entry could size EVCache off Cassandra's cluster.
+    current_capacity = current_cluster_capacity(
+        desires, NflxEVCacheCapacityModel.cluster_type
     )
     if not current_capacity:
         return needed_cores, needed_network_mbps, needed_memory_gib, needed_disk_gib

--- a/service_capacity_modeling/models/org/netflix/evcache.py
+++ b/service_capacity_modeling/models/org/netflix/evcache.py
@@ -117,7 +117,7 @@ def calculate_vitals_for_capacity_planner(
     # Cassandra is zonal too, so a composed KeyValue request lists both here
     # and taking the first entry could size EVCache off Cassandra's cluster.
     current_capacity = current_cluster_capacity(
-        desires, NflxEVCacheCapacityModel.cluster_type
+        desires, *NflxEVCacheCapacityModel.current_cluster_types()
     )
     if not current_capacity:
         return needed_cores, needed_network_mbps, needed_memory_gib, needed_disk_gib

--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -160,6 +160,8 @@ def _read_amplification(args: NflxGraphKVArguments) -> float:
 
 
 class NflxGraphKVCapacityModel(CapacityModel):
+    cluster_type = "dgwgraphkv"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/identifier.py
+++ b/service_capacity_modeling/models/org/netflix/identifier.py
@@ -20,6 +20,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxIdentifierCapacityModel(CapacityModel):
+    cluster_type = "dgwidentifier"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/kafka.py
+++ b/service_capacity_modeling/models/org/netflix/kafka.py
@@ -151,7 +151,7 @@ def _estimate_kafka_requirement(  # pylint: disable=too-many-positional-argument
             low=curr_network.high, mid=curr_network.high, high=curr_network.high
         )
         capacity_requirement = zonal_requirements_from_current(
-            current_cluster=normalize_midpoint_desires.current_clusters,
+            current_capacity=normalize_midpoint_desires.current_clusters.zonal[0],
             buffers=desires.buffers,
             instance=instance,
             reference_shape=current_zonal_capacity.cluster_instance,

--- a/service_capacity_modeling/models/org/netflix/postgres.py
+++ b/service_capacity_modeling/models/org/netflix/postgres.py
@@ -22,6 +22,12 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxPostgresCapacityModel(CapacityModel):
+    @classmethod
+    def current_cluster_types(cls) -> Tuple[str, ...]:
+        # This model stamps no label of its own -- it delegates to Aurora, so a
+        # Postgres cluster the caller already runs carries a backend's label.
+        return ("aurora-cluster", "rds-cluster")
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/rds.py
+++ b/service_capacity_modeling/models/org/netflix/rds.py
@@ -226,6 +226,8 @@ class NflxRDSArguments(BaseModel):
 
 
 class NflxRDSCapacityModel(CapacityModel):
+    cluster_type = "rds-cluster"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/time_series.py
+++ b/service_capacity_modeling/models/org/netflix/time_series.py
@@ -23,6 +23,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxTimeSeriesCapacityModel(CapacityModel):
+    cluster_type = "dgwts"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/wal.py
+++ b/service_capacity_modeling/models/org/netflix/wal.py
@@ -22,6 +22,8 @@ from service_capacity_modeling.models import CapacityModel
 
 
 class NflxWALCapacityModel(CapacityModel):
+    cluster_type = "dgwwal"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/service_capacity_modeling/models/org/netflix/zookeeper.py
+++ b/service_capacity_modeling/models/org/netflix/zookeeper.py
@@ -85,6 +85,8 @@ class NflxZookeeperArguments(BaseModel):
 
 
 class NflxZookeeperCapacityModel(CapacityModel):
+    cluster_type = "zk-zonal"
+
     @staticmethod
     def capacity_plan(
         instance: Instance,

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -169,7 +169,42 @@ def test_cassandra_ignores_another_tier_in_a_composed_request():
     )
 
     assert cassandra_only and with_evcache_first
+    assert len(cassandra_only) == len(with_evcache_first)
     for own, composed in zip(cassandra_only, with_evcache_first):
+        own_zone = own.candidate_clusters.zonal[0]
+        composed_zone = composed.candidate_clusters.zonal[0]
+        assert own_zone.instance.name == composed_zone.instance.name
+        assert own_zone.count == composed_zone.count
+
+
+def test_evcache_ignores_another_tier_in_a_composed_request():
+    """The other half of the same collision.
+
+    Cassandra and EVCache are both zonal, so whichever the caller listed first
+    was the entry both models read. Fixing only Cassandra leaves EVCache
+    sizing itself off Cassandra's node count and disk.
+    """
+    evcache_only = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [_live_cluster("i7ie.large", "evcache", count=6, disk_gib=100)]
+        ),
+    )
+    with_cassandra_first = planner.plan_certain(
+        model_name="org.netflix.evcache",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [
+                _live_cluster("i4i.2xlarge", "cassandra", count=40, disk_gib=900),
+                _live_cluster("i7ie.large", "evcache", count=6, disk_gib=100),
+            ]
+        ),
+    )
+
+    assert evcache_only and with_cassandra_first
+    assert len(evcache_only) == len(with_cassandra_first)
+    for own, composed in zip(evcache_only, with_cassandra_first):
         own_zone = own.candidate_clusters.zonal[0]
         composed_zone = composed.candidate_clusters.zonal[0]
         assert own_zone.instance.name == composed_zone.instance.name

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -1,0 +1,104 @@
+"""Tests for picking a model's own entry out of desires.current_clusters."""
+
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import CurrentClusters
+from service_capacity_modeling.interface import CurrentRegionClusterCapacity
+from service_capacity_modeling.interface import CurrentZoneClusterCapacity
+from service_capacity_modeling.models.common import current_cluster_capacity
+
+
+def _zonal(name: str, cluster_type=None, count: int = 3):
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name=name,
+        cluster_type=cluster_type,
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(10),
+    )
+
+
+def _regional(name: str, cluster_type=None, count: int = 3):
+    return CurrentRegionClusterCapacity(
+        cluster_instance_name=name,
+        cluster_type=cluster_type,
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(10),
+    )
+
+
+def _desires(**kwargs) -> CapacityDesires:
+    return CapacityDesires(service_tier=1, current_clusters=CurrentClusters(**kwargs))
+
+
+def test_picks_the_entry_matching_the_model():
+    """Cassandra and EVCache are both zonal in a composed KeyValue plan."""
+    desires = _desires(
+        zonal=[
+            _zonal("i7ie.large", cluster_type="evcache", count=14),
+            _zonal("i4i.2xlarge", cluster_type="cassandra", count=4),
+        ],
+        regional=[_regional("r8i.xlarge", cluster_type="dgwkv")],
+    )
+
+    assert current_cluster_capacity(desires, "cassandra").cluster_instance_name == (
+        "i4i.2xlarge"
+    )
+    assert current_cluster_capacity(desires, "evcache").cluster_instance_name == (
+        "i7ie.large"
+    )
+    assert current_cluster_capacity(desires, "dgwkv").cluster_instance_name == (
+        "r8i.xlarge"
+    )
+
+
+def test_unlabelled_entries_fall_back_to_the_first():
+    """Callers that predate cluster_type keep the old behaviour."""
+    desires = _desires(zonal=[_zonal("i4i.2xlarge"), _zonal("i3en.xlarge")])
+
+    picked = current_cluster_capacity(desires, "cassandra")
+    assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_a_sibling_being_labelled_does_not_discard_my_unlabelled_entry():
+    """Half-labelled payloads are what a cluster_type rollout looks like.
+
+    Antigravity may start labelling one tier before another. Deciding whether
+    my entry is trustworthy by looking at labels on *other* entries throws
+    mine away for no reason -- Cassandra would lose its node count, disk
+    utilization and reference shape because a sibling got labelled first.
+    """
+    desires = _desires(
+        zonal=[_zonal("i4i.2xlarge"), _zonal("i7ie.large", cluster_type="evcache")]
+    )
+
+    picked = current_cluster_capacity(desires, "cassandra")
+    assert picked is not None
+    assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_labelled_but_unmatched_means_no_current_cluster():
+    """If the caller labelled other tiers and not ours, we have none.
+
+    Falling back to the first entry here is what let Cassandra size itself
+    against EVCache's topology.
+    """
+    desires = _desires(zonal=[_zonal("i7ie.large", cluster_type="evcache")])
+
+    assert current_cluster_capacity(desires, "cassandra") is None
+
+
+def test_zonal_is_preferred_over_regional_for_the_legacy_fallback():
+    desires = _desires(
+        zonal=[_zonal("i4i.2xlarge")], regional=[_regional("r8i.xlarge")]
+    )
+
+    picked = current_cluster_capacity(desires, "cassandra")
+    assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_no_current_clusters_at_all():
+    assert (
+        current_cluster_capacity(CapacityDesires(service_tier=1), "cassandra") is None
+    )
+    assert current_cluster_capacity(_desires(), "cassandra") is None

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -1,11 +1,17 @@
 """Tests for picking a model's own entry out of desires.current_clusters."""
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_float
 from service_capacity_modeling.interface import certain_int
 from service_capacity_modeling.interface import CurrentClusters
 from service_capacity_modeling.interface import CurrentRegionClusterCapacity
 from service_capacity_modeling.interface import CurrentZoneClusterCapacity
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.common import current_cluster_capacity
 
 
@@ -102,3 +108,69 @@ def test_no_current_clusters_at_all():
         current_cluster_capacity(CapacityDesires(service_tier=1), "cassandra") is None
     )
     assert current_cluster_capacity(_desires(), "cassandra") is None
+
+
+def _cassandra_desires(zonal):
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=Interval(
+                low=100, mid=1000, high=10_000, confidence=0.98
+            ),
+            estimated_write_per_second=Interval(
+                low=100, mid=1000, high=10_000, confidence=0.98
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=100, mid=1000, high=4000, confidence=0.98
+            )
+        ),
+        current_clusters=CurrentClusters(zonal=zonal),
+    )
+
+
+def _live_cluster(instance_name, cluster_type, count, disk_gib):
+    return CurrentZoneClusterCapacity(
+        cluster_instance_name=instance_name,
+        cluster_instance=shapes.instance(instance_name),
+        cluster_type=cluster_type,
+        cluster_drive=Drive(name="gp3", drive_type="attached-ssd", size_gib=1000),
+        cluster_instance_count=certain_int(count),
+        cpu_utilization=certain_float(20),
+        disk_utilization_gib=certain_float(disk_gib),
+        network_utilization_mbps=certain_float(100),
+    )
+
+
+def test_cassandra_ignores_another_tier_in_a_composed_request():
+    """EVCache listed first must not become Cassandra's current cluster.
+
+    Both are zonal, so a composed KeyValue request puts them in the same
+    list. Reading index 0 meant Cassandra sized itself against EVCache's
+    node count and disk.
+    """
+    cassandra_only = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [_live_cluster("i4i.2xlarge", "cassandra", count=4, disk_gib=200)]
+        ),
+    )
+    with_evcache_first = planner.plan_certain(
+        model_name="org.netflix.cassandra",
+        region="us-east-1",
+        desires=_cassandra_desires(
+            [
+                _live_cluster("i7ie.large", "evcache", count=40, disk_gib=900),
+                _live_cluster("i4i.2xlarge", "cassandra", count=4, disk_gib=200),
+            ]
+        ),
+    )
+
+    assert cassandra_only and with_evcache_first
+    for own, composed in zip(cassandra_only, with_evcache_first):
+        own_zone = own.candidate_clusters.zonal[0]
+        composed_zone = composed.candidate_clusters.zonal[0]
+        assert own_zone.instance.name == composed_zone.instance.name
+        assert own_zone.count == composed_zone.count

--- a/tests/test_current_cluster_selection.py
+++ b/tests/test_current_cluster_selection.py
@@ -13,6 +13,12 @@ from service_capacity_modeling.interface import Drive
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.common import current_cluster_capacity
+from service_capacity_modeling.models.org.netflix.elasticsearch import (
+    nflx_elasticsearch_capacity_model,
+)
+from service_capacity_modeling.models.org.netflix.postgres import (
+    nflx_postgres_capacity_model,
+)
 
 
 def _zonal(name: str, cluster_type=None, count: int = 3):
@@ -101,6 +107,41 @@ def test_zonal_is_preferred_over_regional_for_the_legacy_fallback():
 
     picked = current_cluster_capacity(desires, "cassandra")
     assert picked.cluster_instance_name == "i4i.2xlarge"
+
+
+def test_a_facade_model_answers_to_each_backend_label():
+    """Postgres plans an Aurora cluster, so its existing one carries that label.
+
+    A single cluster_type cannot express that, which is why the selector takes
+    several and the model declares them.
+    """
+    assert set(nflx_postgres_capacity_model.current_cluster_types()) == {
+        "aurora-cluster",
+        "rds-cluster",
+    }
+
+    for label in ("aurora-cluster", "rds-cluster"):
+        desires = _desires(regional=[_regional("db.r6g.xlarge", cluster_type=label)])
+        picked = current_cluster_capacity(
+            desires, *nflx_postgres_capacity_model.current_cluster_types()
+        )
+        assert picked is not None, f"{label} should match Postgres"
+        assert picked.cluster_instance_name == "db.r6g.xlarge"
+
+
+def test_a_model_declaring_no_label_matches_nothing_by_name():
+    """An aggregator owns no clusters, so it has no label to match on.
+
+    It still gets the unlabelled fallback, which is what callers had before
+    cluster_type was read at all.
+    """
+    assert not nflx_elasticsearch_capacity_model.current_cluster_types()
+
+    labelled = _desires(zonal=[_zonal("i4i.2xlarge", cluster_type="cassandra")])
+    assert current_cluster_capacity(labelled) is None
+
+    unlabelled = _desires(zonal=[_zonal("i4i.2xlarge")])
+    assert current_cluster_capacity(unlabelled) is not None
 
 
 def test_no_current_clusters_at_all():

--- a/tests/test_generate_scenarios.py
+++ b/tests/test_generate_scenarios.py
@@ -20,6 +20,8 @@ def test_generate_scenarios():
     model.allowed_platforms.return_value = {Platform.amd64}
     model.allowed_cloud_drives.return_value = {}
     model.run_hardware_simulation.return_value = True
+    # No existing cluster: the planner asks which labels this model answers to.
+    model.current_cluster_types.return_value = ()
 
     region = "us-east-1"
     desires = CapacityDesires()
@@ -48,6 +50,8 @@ def test_generate_scenarios_limit_family():
     model.allowed_platforms.return_value = {Platform.amd64}
     model.allowed_cloud_drives.return_value = {}
     model.run_hardware_simulation.return_value = True
+    # No existing cluster: the planner asks which labels this model answers to.
+    model.current_cluster_types.return_value = ()
 
     region = "us-east-1"
     desires = CapacityDesires()
@@ -79,6 +83,8 @@ def test_generate_scenarios_desire_resources():
     model.allowed_platforms.return_value = {Platform.amd64}
     model.allowed_cloud_drives.return_value = {}
     model.run_hardware_simulation.return_value = True
+    # No existing cluster: the planner asks which labels this model answers to.
+    model.current_cluster_types.return_value = ()
 
     region = "us-east-1"
     num_regions = 3
@@ -118,6 +124,8 @@ def test_generate_scenarios_current_resources():
     model.allowed_platforms.return_value = {Platform.amd64}
     model.allowed_cloud_drives.return_value = {}
     model.run_hardware_simulation.return_value = True
+    # No existing cluster: the planner asks which labels this model answers to.
+    model.current_cluster_types.return_value = ()
 
     region = "us-east-1"
     num_regions = 3


### PR DESCRIPTION
**PR 3 of 4**, stacked on #304. Review #303 and #304 first.

## Why

`CurrentClusterCapacity.cluster_type` carries this comment in `interface.py`:

```python
# Optional: if not set, extract_baseline_plan
# Required metadata for identifying which model
# this capacity belongs to
cluster_type: Optional[str] = None
```

Nothing read it. Every consumer took `current_clusters.zonal[0]` or `regional[0]`.

That is fine for a single-model request and wrong for a composed one. **Cassandra and
EVCache are both zonal**, so a KeyValue request describing both tiers put them in one list
and each model read whichever entry the caller happened to list first. Reorder the list and
the plan changes.

This is squarely a confusing-provisioning bug: Cassandra sized against a cache tier's node
count, disk utilization and instance shape, with nothing in the output saying so.

## Commits

| commit | what |
|---|---|
| `308d3e5` | Give every model that owns clusters a `cluster_type` |
| `ad158ee` | Add a selector for a model's own entry in `current_clusters` |
| `dbd7ef0` | Read Cassandra's own current cluster, not whichever came first |
| `76c9a48` | Screen shapes against the model's own current cluster |
| `0d85709` | Read EVCache's own current cluster too |

**`308d3e5` — the prerequisite.** For a model to find its own entry it has to know its own
name, and only six did. `cluster_type` was declared on the `CostAwareModel` mixin, where
its documented job is filtering which clusters a model *costs*; identifying your own
current cluster is a modeling concern, so it moves to `CapacityModel` with an empty
default. Thirteen models now declare the label they already stamp on the clusters they
produce — `dgwcontrol`, `dgwcounter`, `dgwentity`, `dgwgraphkv`, `dgwidentifier`, `dgwts`,
`dgwwal`, `aurora-cluster`, `rds-cluster`, `zk-zonal`, and the three Elasticsearch node
roles. No new names; every value is lifted from a literal already in the file.

Three keep the empty default: `org.netflix.elasticsearch` owns no clusters, which is what
empty means, and Postgres and DynamoDB stamp no label and read no current cluster.

**`ad158ee` — the selector.** `current_cluster_capacity(desires, cluster_type)` matches on
the label, then falls back to the first *unlabelled* entry, then returns `None`:

```
payload                      before this PR    with the selector
both labelled                evcache's         mine
partial: mine unlabelled     mine              mine
none labelled                first             first
only someone else's          evcache's         None
```

The fallback matters. An unlabelled entry means *nobody said whose it is*, not *it belongs
to someone else* — so it is still the best guess available, exactly as before. Only entries
labelled as another tier are ruled out. Getting that wrong is a 3.5× under-provision
(Cassandra 8 nodes → 2) the moment a caller labels one tier before another, which is what
a rollout looks like.

**`dbd7ef0`** — Cassandra read `zonal[0]` in three places: `_get_current_capacity` (cluster
size, derived buffers, family-change penalty), `_estimate_zonal_data_gib` (observed disk),
and its reference shape. That last one came from `CapacityDesires.reference_shape`, a
property with no model context that also reads `zonal[0]` — so Cassandra was normalizing
its core counts against a cache node. `zonal_requirements_from_current` now takes the
caller's chosen entry rather than the whole list, since picking one needs a `cluster_type`
the helper does not have.

**`76c9a48`** — `generate_scenarios` screens out shapes below a floor derived partly from
the current cluster's observed memory. That floor came from `zonal[0]` too, so one tier's
utilization could screen shapes out of another tier's search.

**`0d85709`** — the other half of the collision. Fixing only Cassandra left EVCache sizing
itself off Cassandra's cluster.

## Behavior

Unchanged unless the caller labels their current clusters with `cluster_type`, which is
what makes any of this reachable. Existing unlabelled payloads take the same path as
before.

## Known limitation, not addressed here

`CapacityDesires.reference_shape` raises `ValueError` when `current_clusters` holds both
zonal and regional entries. A composed KeyValue request has regional `dgwkv` plus zonal
`cassandra`/`evcache`, so **that full payload cannot be planned today** — pre-existing, and
why the zonal+zonal Cassandra/EVCache case is the one this PR fixes. Routing the two
remaining `desires.reference_shape` readers (`stateless_java.py`, `evcache.py`) through the
selector would lift that, and belongs in its own change.

## Testing

782 passed, 1 skipped; the one failure is `test_all_models_tier_capacity_relationship`,
which is flaky on `main` independently of this branch (three falsifying draws all give
byte-identical numbers on `main`). Both integration tests — Cassandra and EVCache each
ignoring the other's entry — fail without their respective fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
