### PR TITLE
Compose desires down a chain, not from the original request

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1511,12 +1511,17 @@ class CapacityPlanner:
             # default holds back reservations describing this model's own
             # instances. It is applied before the per-child transform so a
             # transform that sets something deliberately still wins.
+            #
+            # Both start from parent_desires, the desires this model was handed,
+            # so a chain composes: GraphKV amplifies logical traffic into KeyValue
+            # operations, and Cassandra sees the amplified figures rather than the
+            # user's original ones.
             parent_model = self._models[sub_model]
             for child_model, modify_child_desires in parent_model.compose_with(
-                desires, extra_model_arguments
+                parent_desires, extra_model_arguments
             ):
                 config = parent_model.child_desires_config(child_model)
-                child_desires = _configure_child_desires(desires, config)
+                child_desires = _configure_child_desires(parent_desires, config)
                 queue.append((modify_child_desires(child_desires), child_model))
 
             yield sub_model, sub_desires

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -3,12 +3,20 @@
 import pytest
 
 from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import Consistency
 from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import GlobalConsistency
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.elasticsearch import (
     nflx_elasticsearch_capacity_model,
+)
+from service_capacity_modeling.models.org.netflix.graphkv import (
+    _read_amplification,
+    _write_amplification,
+    NflxGraphKVArguments,
 )
 from service_capacity_modeling.models.org.netflix.key_value import (
     nflx_key_value_capacity_model,
@@ -118,15 +126,42 @@ def test_transforms_compose_through_more_than_one_level():
 
     logical = by_model["org.netflix.graphkv"].query_pattern
     backend = by_model["org.netflix.cassandra"].query_pattern
+    args = NflxGraphKVArguments.model_validate({})
 
-    assert backend.estimated_read_per_second.mid > (
-        logical.estimated_read_per_second.mid * 10
+    # Exact factors, not lower bounds: applying the amplification twice would
+    # satisfy "much bigger than logical" just as well.
+    assert backend.estimated_read_per_second.mid == pytest.approx(
+        logical.estimated_read_per_second.mid * _read_amplification(args)
     )
-    assert backend.estimated_write_per_second.mid > (
-        logical.estimated_write_per_second.mid
+    assert backend.estimated_write_per_second.mid == pytest.approx(
+        logical.estimated_write_per_second.mid * _write_amplification(args)
     )
-    assert by_model["org.netflix.cassandra"].data_shape.estimated_state_size_gib.mid > (
-        by_model["org.netflix.graphkv"].data_shape.estimated_state_size_gib.mid
+
+
+def test_amplified_traffic_can_change_which_tiers_are_composed():
+    """compose_with is a decision, so feeding it amplified traffic moves more
+    than sizing.
+
+    KeyValue attaches EVCache above an rps threshold. Handed GraphKV's
+    amplified figures it now crosses that threshold, so the plan grows a whole
+    cache tier. This is the largest observable effect of composing down the
+    chain and is easy to miss, because the default consistency keeps EVCache
+    off and hides it.
+    """
+    desires = _desires(4)
+    desires.query_pattern.access_consistency = GlobalConsistency(
+        same_region=Consistency(target_consistency=AccessConsistency.eventual)
+    )
+
+    composed = [
+        model
+        for model, _ in planner._sub_models(  # pylint: disable=protected-access
+            "org.netflix.graphkv", desires, extra_model_arguments={}
+        )
+    ]
+
+    assert "org.netflix.evcache" in composed, (
+        f"expected amplified rps to attach EVCache, got {composed}"
     )
 
 

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -102,6 +102,34 @@ def test_parent_tier_still_gets_the_caller_reserve():
     assert heavy["dgwkv"] != lean["dgwkv"]
 
 
+def test_transforms_compose_through_more_than_one_level():
+    """GraphKV fans out to KeyValue, which fans out to Cassandra.
+
+    Each compose_with transform used to receive the original user desires, so
+    a two-level chain dropped the middle one: Cassandra never saw GraphKV's
+    read and write amplification and was sized for logical graph traffic
+    rather than the backend KeyValue operations it actually serves.
+    """
+    by_model = dict(
+        planner._sub_models(  # pylint: disable=protected-access
+            "org.netflix.graphkv", _desires(24), extra_model_arguments={}
+        )
+    )
+
+    logical = by_model["org.netflix.graphkv"].query_pattern
+    backend = by_model["org.netflix.cassandra"].query_pattern
+
+    assert backend.estimated_read_per_second.mid > (
+        logical.estimated_read_per_second.mid * 10
+    )
+    assert backend.estimated_write_per_second.mid > (
+        logical.estimated_write_per_second.mid
+    )
+    assert by_model["org.netflix.cassandra"].data_shape.estimated_state_size_gib.mid > (
+        by_model["org.netflix.graphkv"].data_shape.estimated_state_size_gib.mid
+    )
+
+
 def test_a_model_that_owns_no_instances_passes_the_reserve_down():
     """org.netflix.elasticsearch owns no instances; it splits into node roles.
 


### PR DESCRIPTION
**PR 4 of 4**, stacked on #305. This is the largest behavior change of the four — it is last
deliberately, and none of the earlier PRs need it.

## Why

`CapacityModel.compose_with`'s docstring says the transform "takes the original user desire
and modifies it for the composed model", and `_sub_models` implemented exactly that. So only
the **first** level of a chain took effect.

GraphKV fans out to KeyValue, which fans out to Cassandra. GraphKV amplifies the logical
read and write rates and recomputes state size for the backend items each traversal actually
touches. KeyValue passed that along. Cassandra was then handed the user's original figures.

```
                        rps          state
org.netflix.graphkv       5,000      1,000 GiB   <- what the user asked for
org.netflix.key-value   275,000      3,000 GiB   <- 55x read, 3x write amplification
org.netflix.cassandra   275,000      3,000 GiB   <- with this PR
                          5,000      1,000 GiB   <- before it
```

Cassandra was sized for 5k reads/sec while serving 275k. That is the whole point of the
GraphKV model, thrown away one hop from where it mattered.

## The fix

Both the boundary adjustment and the per-child transform now start from `parent_desires` —
the desires the composing model was itself handed — so each level builds on the last. The
model the caller named still gets the request as written.

Both sides had to move together: `_modify_cassandra_desires` closes over `compose_with`'s
`rps_interval`, so changing only the transform's argument would have left the closure and
the argument disagreeing silently.

## This changes topology, not just sizing

`compose_with` is a **decision** function, so feeding it different traffic changes which
models get composed. KeyValue attaches EVCache above an rps threshold; GraphKV's amplified
figures cross it:

```
GraphKV, eventual consistency, logical rps mid 3000 -> 165,000 after amplification

before  ['graphkv', 'key-value', 'cassandra']
after   ['graphkv', 'key-value', 'evcache', 'cassandra']
```

An entire extra zonal tier with its own annual cost. It follows correctly from the fix — the
KeyValue tier genuinely does see 165k rps — but it is the single most surprising consequence
here, so `test_amplified_traffic_can_change_which_tiers_are_composed` pins it. Nothing did
before, because the default consistency keeps EVCache off and hides the change.

## Plan impact

| model | before | after |
|---|---|---|
| graphkv | `cassandra i4i.xlarge ×2` | `c6id.4xlarge ×16` per zone |
| graphkv, eventual consistency | no cache tier | EVCache attached |
| every model that composes one level deep | unchanged | unchanged |

The GraphKV jump is ~2.8× and is the fan-out finally being provisioned for. Anyone running a
graph namespace today has a Cassandra tier sized for logical traffic rather than backend
operations, so this is worth landing — but it deserves its own review rather than riding
along with a memory fix.

## Known limitation, not addressed here

`_sub_models` dedups by model name over a LIFO queue. Before this change every child received
the same original desires, so "first visit wins" was harmless. Now children differ by parent,
so if two paths ever reach the same model, one parent's transform is silently dropped and
which one depends on pop order. No such diamond exists in the built-in graphs today — checked
entity, graphkv and time-series — but the traversal now has an order dependence it did not
have before. Worth an assert or a comment; it is a property of the traversal rather than of
this fix.

## Testing

785 passed, 1 skipped. mypy clean, pylint 10.00. Both new tests fail against the previous
commit's planner. The amplification assertions compare against `_read_amplification` /
`_write_amplification` directly rather than using lower bounds, so applying a transform twice
would now fail rather than pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
