### PR TITLE
fix: report resolved desires in plan explanations

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1346,12 +1346,7 @@ class CapacityPlanner:
             explanation=PlanExplanation(
                 regret_params=regret_params,
                 desires_by_model={
-                    model: desires.merge_with(
-                        self._models[model].default_desires(
-                            sample_data.base_desires_by_model[model],
-                            extra_model_arguments,
-                        )
-                    )
+                    model: sample_data.base_desires_by_model[model]
                     for model in regret_details_by_model
                 },
                 regret_clusters_by_model={

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -1524,6 +1524,13 @@ class RegretPlanSummary(ExcludeUnsetModel):
 
 
 class PlanExplanation(ExcludeUnsetModel):
+    """Inputs and regret details for an uncertain capacity plan.
+
+    ``desires_by_model`` contains each model's resolved base desires after
+    composition transforms and model defaults. These desires are the inputs to
+    uncertainty sampling.
+    """
+
     regret_params: CapacityRegretParameters
     regret_clusters_by_model: Dict[
         str, Sequence[Tuple[CapacityPlan, CapacityDesires, float]]

--- a/tests/test_reproducible.py
+++ b/tests/test_reproducible.py
@@ -111,6 +111,31 @@ def test_compositional():
         assert 100 > java.count * java.instance.cpu > 20
 
 
+def test_composed_explanation_reports_child_desires_used_for_planning():
+    result = planner.plan(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=uncertain_mid,
+        num_results=1,
+        simulations=2,
+        extra_model_arguments={
+            "kv_force_evcache": True,
+            "estimated_kv_cache_hit_rate": 0.8,
+        },
+    )
+
+    desires_by_model = result.explanation.desires_by_model
+    cassandra_rps = desires_by_model[
+        "org.netflix.cassandra"
+    ].query_pattern.estimated_read_per_second.mid
+    evcache_rps = desires_by_model[
+        "org.netflix.evcache"
+    ].query_pattern.estimated_read_per_second.mid
+
+    assert cassandra_rps == pytest.approx(2_000)
+    assert evcache_rps == pytest.approx(10_000)
+
+
 def test_multiple_options_diversify_with_more_simulations():
     """
     This test appears strange at first. The goal is to show that with less


### PR DESCRIPTION
## Intent

Fix PlanExplanation.desires_by_model so it reports the exact resolved per-model desires already used by uncertain planning, including composed child transforms and child model defaults, instead of reconstructing each entry from the root request. Keep this separate from PR #302 and narrowly scoped to explanation output only: do not change planning decisions, composition inheritance semantics, model inputs, or dgi-artifact. Add a public-output regression using forced KeyValue EVCache composition to prove Cassandra reports the cache-adjusted RPS while EVCache retains the original RPS. Deliver as a separate draft PR.

## What Changed

- Populate `PlanExplanation.desires_by_model` from the resolved per-model desires used for uncertainty sampling, preserving composition transforms and child defaults.
- Document the field’s resolved-input semantics.
- Add a forced KeyValue EVCache composition regression proving Cassandra reports cache-adjusted RPS while EVCache retains the original RPS.

## Risk Assessment

✅ Low: The narrowly scoped change reuses the resolved per-model desires that uncertain planning actually consumed, and the regression covers the required composed Cassandra/EVCache behavior without altering planning.

## Testing

Targeted Python 3.12 regressions passed. A public planner call confirmed Cassandra reports cache-adjusted ~2,000 RPS, EVCache retains 10,000 RPS, and child defaults appear in the explanation. The unavailable Newt tox wrapper was replaced with direct tox.

<details>
<summary>Evidence: Forced KeyValue public plan explanation</summary>

```text
{
  "request": {
    "model_name": "org.netflix.key-value",
    "read_rps_mid": 10000.0,
    "kv_force_evcache": true,
    "estimated_kv_cache_hit_rate": 0.8
  },
  "public_plan_explanation": {
    "org.netflix.cassandra": {
      "read_rps_mid": 1999.9999999999995,
      "read_latency_ms_mid_default": 2.0,
      "compression_ratio_mid_default": 3.0,
      "reserved_instance_app_mem_gib_default": 4.0
    },
    "org.netflix.evcache": {
      "read_rps_mid": 10000.0,
      "same_region_consistency": "best-effort",
      "read_latency_ms_mid_default": 0.06654972754449773,
      "reserved_instance_app_mem_gib_default": 1.0,
      "reserved_instance_system_mem_gib_default": 3.0
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tox -e py312 --override 'testenv.commands=pytest -q tests/test_reproducible.py::test_composed_explanation_reports_child_desires_used_for_planning'`
- `.tox/py312/bin/pytest -q tests/test_reproducible.py::test_compositional`
- <code>Public `planner.plan(...)` call using forced KeyValue EVCache composition, with serialized explanation evidence and assertions for transformed RPS and child defaults</code>
- `Inspected the base-to-target diff for explanation-only scope and cleaned transient test artifacts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
