### PR TITLE
Report the desires a composed model was actually planned with

### DIFF
--- a/service_capacity_modeling/capacity_planner.py
+++ b/service_capacity_modeling/capacity_planner.py
@@ -1346,12 +1346,7 @@ class CapacityPlanner:
             explanation=PlanExplanation(
                 regret_params=regret_params,
                 desires_by_model={
-                    model: desires.merge_with(
-                        self._models[model].default_desires(
-                            sample_data.base_desires_by_model[model],
-                            extra_model_arguments,
-                        )
-                    )
+                    model: sample_data.base_desires_by_model[model]
                     for model in regret_details_by_model
                 },
                 regret_clusters_by_model={

--- a/tests/test_reproducible.py
+++ b/tests/test_reproducible.py
@@ -111,6 +111,31 @@ def test_compositional():
         assert 100 > java.count * java.instance.cpu > 20
 
 
+def test_composed_explanation_reports_child_desires_used_for_planning():
+    result = planner.plan(
+        model_name="org.netflix.key-value",
+        region="us-east-1",
+        desires=uncertain_mid,
+        num_results=1,
+        simulations=2,
+        extra_model_arguments={
+            "kv_force_evcache": True,
+            "estimated_kv_cache_hit_rate": 0.8,
+        },
+    )
+
+    desires_by_model = result.explanation.desires_by_model
+    cassandra_rps = desires_by_model[
+        "org.netflix.cassandra"
+    ].query_pattern.estimated_read_per_second.mid
+    evcache_rps = desires_by_model[
+        "org.netflix.evcache"
+    ].query_pattern.estimated_read_per_second.mid
+
+    assert cassandra_rps == pytest.approx(2_000)
+    assert evcache_rps == pytest.approx(10_000)
+
+
 def test_multiple_options_diversify_with_more_simulations():
     """
     This test appears strange at first. The goal is to show that with less


### PR DESCRIPTION
Independent of the composition stack (#303–#306) — based on `main`, five lines deleted.

## Why

`PlanExplanation.desires_by_model` is supposed to report the desires each model was planned
with. It recomputed them from the top-level desires instead:

```python
model: desires.merge_with(
    self._models[model].default_desires(
        sample_data.base_desires_by_model[model], extra_model_arguments)
)
```

That never applies `compose_with`, so any model whose desires were transformed on the way
down is misreported. Two examples on `main` today:

- **TimeSeries** amplifies read rate for Cassandra via `_modify_cassandra_desires`. The
  explanation shows Cassandra's rps as the user's figure, not the amplified one it was sized
  for.
- **GraphKV** recomputes state size for the backend KeyValue items each traversal touches.
  Same story.

The correct value was already sitting in `sample_data.base_desires_by_model` — the
accumulator `_sub_models` fills as it walks. So the fix is to stop recomputing and use it.

## Why it matters beyond tidiness

I hit this while testing the composition work in #303: `desires_by_model` reported
`reserved_instance_app_mem_gib=24.0` for Cassandra *after* the fix that stops it being
inherited. It is not usable as a source of truth for what a model planned with, which makes
it useless as a test oracle and actively misleading in `--explain` output.

Anyone debugging "why did Cassandra get sized like that" reads this field and gets the
wrong answer.

## Testing

`tests/test_reproducible.py` gains a case asserting the reported desires match what the
composed model was actually planned with. 14 passed on that module; full suite green.

Credit: the diagnosis and fix came from a parallel agent branch
(`mho/plan-explanation-composed-desires`); cherry-picked here onto `main` so it can land
without waiting on the composition stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
