### PR TITLE
Cap the Elasticsearch heap at 32 GiB instead of flooring it there

### DIFF
--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -48,6 +48,17 @@ from service_capacity_modeling.stats import dist_for_interval
 
 logger = logging.getLogger(__name__)
 
+# The JVM uses compressed object pointers below a ~32 GiB heap. Cassandra caps
+# its own heap the same way (DEFAULT_MAX_HEAP_GIB in cassandra_memory).
+#
+# Note this is compared against Instance.ram_gib, which for many families is
+# stored ~4.6% below the advertised figure (an AWS-advertised 32 GiB instance is
+# 30.52 here: 32768 MiB read as MB and converted to GiB). So on a 64 GiB shape
+# the cap yields a 30.52 GiB heap rather than 32 -- under the boundary, which is
+# the safe side. Correcting ram_gib would move sizing for every model and is a
+# separate change.
+ES_MAX_HEAP_GIB = 32
+
 
 def _target_rf(desires: CapacityDesires, user_copies: Optional[int]) -> int:
     if user_copies is not None:
@@ -251,15 +262,18 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
                 bottleneck=Bottleneck.cpu if instance.cpu < 2 else Bottleneck.memory,
             )
 
-        # Sidecars/System takes away memory from Elasticsearch
-        # which uses half of available system max of 32 for compressed oops
+        # Sidecars and the OS take memory away from Elasticsearch, and so does
+        # the JVM heap: it is not page cache and shards cannot use it. Heap is
+        # half of RAM, capped at 32 GiB so the JVM keeps compressed object
+        # pointers -- above that boundary references widen and the larger heap
+        # buys less than it costs.
         base_mem = (
             desires.data_shape.reserved_instance_app_mem_gib
             + desires.data_shape.reserved_instance_system_mem_gib
         )
 
         def reserve_memory(instance_mem_gib: float) -> float:
-            return base_mem + max(32, instance_mem_gib / 2)
+            return base_mem + min(ES_MAX_HEAP_GIB, instance_mem_gib / 2)
 
         # The 24 GiB floor above ignores the workload's reserved memory. If the
         # reserves swallow the whole instance there is nothing left to hold

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -11,6 +11,7 @@ from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.elasticsearch import (
+    ES_MAX_HEAP_GIB,
     NflxElasticsearchArguments,
 )
 from tests.util import assert_similar_compute
@@ -298,10 +299,11 @@ def zonal_summary(zlr):
 def test_es_data_nodes_have_ram_left_after_reserves():
     """Data nodes must have RAM left once sidecars and the heap are carved out.
 
-    Elasticsearch reserves ``base_mem + max(32, ram / 2)`` per node, which
-    overruns shapes at or below ~34 GiB. Those used to yield a negative memory
-    node count that max() discarded, silently dropping the memory constraint
-    and letting an undersized shape win on cost.
+    Elasticsearch reserves ``base_mem + min(ES_MAX_HEAP_GIB, ram / 2)`` per
+    node. A shape can only be chosen if something is left over for shards and
+    page cache -- a negative remainder used to yield a negative memory node
+    count that max() discarded, silently dropping the memory constraint and
+    letting an undersized shape win on cost.
     """
     desires = CapacityDesires(
         service_tier=1,
@@ -338,10 +340,12 @@ def test_es_data_nodes_have_ram_left_after_reserves():
 
     for cluster in data_clusters:
         ram_gib = cluster.instance.ram_gib
-        reserved = base_mem + max(32, ram_gib / 2)
+        reserved = base_mem + min(ES_MAX_HEAP_GIB, ram_gib / 2)
         assert ram_gib > reserved, (
             f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
         )
+        # Heap is capped so the JVM keeps compressed object pointers.
+        assert min(ES_MAX_HEAP_GIB, ram_gib / 2) <= ES_MAX_HEAP_GIB
 
 
 def test_es_rejections_explain_themselves():


### PR DESCRIPTION
**Stack:** PR 5 of 5, based on #306. This Elasticsearch fix does not depend on the planner behavior changed in the earlier layers.

## What am I trying to do?

Cap the Elasticsearch JVM heap at 32 GiB instead of treating 32 GiB as its minimum size.

The current calculation reserves `base_mem + max(32, ram / 2)`. That is backwards: Elasticsearch uses half of instance RAM for heap until the heap reaches 32 GiB, then keeps the 32 GiB cap so the JVM can continue using compressed object pointers.

## What changes?

The reservation becomes:

```python
heap_gib = min(32, instance.ram_gib / 2)
reserved_gib = app_and_system_reserves_gib + heap_gib
usable_gib = instance.ram_gib - reserved_gib
```

Assuming the existing 2 GiB app and system reserve, the corrected calculation works like this:

| Stored instance RAM | Heap before | Heap after | Usable RAM before | Usable RAM after |
|---:|---:|---:|---:|---:|
| 30.52 GiB | 32.00 GiB | 15.26 GiB | -3.48 GiB | 13.26 GiB |
| 61.04 GiB | 32.00 GiB | 30.52 GiB | 27.04 GiB | 28.52 GiB |
| 122.07 GiB | 61.04 GiB | 32.00 GiB | 59.03 GiB | 88.07 GiB |

The middle row explains why the bug was hard to see. On an advertised 64 GiB instance, the old formula happened to produce the expected 32 GiB heap. Smaller instances could end up with no RAM for shards and page cache, while larger instances reserved increasingly oversized heaps.

## What does this change in a capacity plan?

Callers do not need to change anything. Elasticsearch planning automatically evaluates instance shapes with the corrected heap reservation.

Examples from tier 1 data-node plans:

| Workload | Before | After | Annual cost change |
|---|---|---|---:|
| 200 GiB state, 10k RPS | `r5d.2xlarge x1` | `i4i.xlarge x1` | -20% |
| 1 TiB state, 10k RPS | `i3.2xlarge x1` | `i7ie.xlarge x1` | -15% |
| 32 TiB state, 20k RPS | `i3en.2xlarge x12` | `i3en.3xlarge x7` | -12% |

The 8 TiB / 50k RPS example remains `i3en.2xlarge x3`, so the correction does not force every plan onto a different shape.

## Why use a named constant?

`ES_MAX_HEAP_GIB = 32` makes the JVM boundary explicit and gives the test one source of truth.

`Instance.ram_gib` is stored about 4.6% below the advertised value for many AWS families. For example, an advertised 64 GiB shape is stored as 61.04 GiB, so its calculated heap is 30.52 GiB rather than 32 GiB. That stays below the compressed-object-pointer boundary. Correcting the shared RAM data would affect every capacity model and is intentionally outside this PR.

## Are there any tests?

Yes. The regression test verifies that every selected Elasticsearch data node retains RAM for shards and page cache after app, system, and heap reservations, and that the heap never exceeds 32 GiB.

CI passes on Python 3.10, 3.11, and 3.12. Elasticsearch is not present in the generated cost baselines, so this change does not regenerate baseline fixtures.