### PR TITLE
Plan KeyValue namespaces that state no write rate

### DIFF
--- a/service_capacity_modeling/models/org/netflix/key_value.py
+++ b/service_capacity_modeling/models/org/netflix/key_value.py
@@ -94,7 +94,12 @@ class NflxKeyValueCapacityModel(CapacityModel, CostAwareModel):
         rps_interval = query_pattern.estimated_read_per_second
         rps: float = rps_interval.mid
         wps: float = query_pattern.estimated_write_per_second.mid
-        read_write_ratio: float = rps / wps
+        # compose_with reads the request as written, before default_desires has
+        # filled anything in, so a namespace that states no write rate arrives
+        # here with zero. Treat that as read-only: the ratio only gates whether
+        # EVCache is worth attaching, and no writes is the most cache-friendly
+        # shape there is.
+        read_write_ratio: float = rps / wps if wps else float("inf")
 
         # Parameterizing this in case we want to configure it to something else later.
         # The read/write ratio should be relatively high to make EVCache effective.

--- a/tests/netflix/test_key_value.py
+++ b/tests/netflix/test_key_value.py
@@ -2,6 +2,12 @@
 Tests for Netflix key-value model.
 """
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+
 # Property test configuration for KeyValue model.
 # See tests/netflix/PROPERTY_TESTING.md for configuration options and examples.
 PROPERTY_TEST_CONFIG = {
@@ -9,3 +15,37 @@ PROPERTY_TEST_CONFIG = {
     #     "extra_model_arguments": {},
     # },
 }
+
+
+def test_a_namespace_with_no_write_rate_can_be_planned():
+    """compose_with sees the request as written, before defaults are filled.
+
+    A namespace that states only a read rate -- or neither rate -- arrives with
+    a write rate of zero, and dividing reads by it crashed before planning even
+    started. The ratio only gates whether EVCache is worth attaching, so no
+    writes is read-only, not undefined.
+    """
+    for query_pattern in (
+        QueryPattern(
+            estimated_read_per_second=Interval(
+                low=100, mid=1000, high=10_000, confidence=0.98
+            )
+        ),
+        QueryPattern(),
+    ):
+        desires = CapacityDesires(
+            service_tier=2,
+            query_pattern=query_pattern,
+            data_shape=DataShape(
+                estimated_state_size_gib=Interval(
+                    low=10, mid=100, high=1000, confidence=0.98
+                )
+            ),
+        )
+        plans = planner.plan_certain(
+            model_name="org.netflix.key-value", region="us-east-1", desires=desires
+        )
+        assert plans, "a read-only namespace should still produce a plan"
+        assert any(
+            c.cluster_type == "cassandra" for c in plans[0].candidate_clusters.zonal
+        )


### PR DESCRIPTION
Independent of the composition stack (#303–#306, #309) — based on `main`, one line plus a
test.

## The crash

`key_value.compose_with` divides the read rate by the write rate to decide whether EVCache
is worth attaching:

```python
read_write_ratio: float = rps / wps
```

`compose_with` runs on the request **as written**, before `default_desires` has filled
anything in. So a namespace that states no write rate arrives with `wps = 0` and planning
dies before it starts:

```
File "models/org/netflix/key_value.py", line 97, in compose_with
    read_write_ratio: float = rps / wps
ZeroDivisionError: float division by zero
```

## Why now

Found by planning every KeyValue configuration we deploy against the planner. **47 of them
cannot be planned at all** — 45 state no write rate, and two reach the same line another
way. Every one fails identically, and has been failing for as long as the line has existed.

## The fix

No writes is read-only, not undefined — and it is the most cache-friendly shape there is, so
the ratio is unbounded rather than an error.

Nothing else about the decision changes: attaching EVCache still requires eventual or
best-effort consistency *and* a read rate over the threshold, so a read-only namespace below
that rate is unaffected. The two conditions are `and`-ed, and the ratio only participates in
the lower-rate branch.

## Testing

760 passed, 1 skipped. mypy clean, pylint 10.00.
`test_a_namespace_with_no_write_rate_can_be_planned` covers both a read-only pattern and an
empty one, and fails against the unfixed code with the `ZeroDivisionError` above.

## Relationship to the other open PRs

Independent — this touches one expression that none of them modify, and it merges cleanly
with the stack tip. It is worth noting that the stack (#303) fixes a *different*
`ZeroDivisionError`, in `compute_stateful_zone`. Together the two account for every
configuration that currently fails to plan:

| | configurations that crash |
|---|---|
| `main` today | 109 |
| with #303's stack | 47 |
| with this as well | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
