### PR TITLE
fix(models): restore Elasticsearch memory reservation behavior after central fix

### DIFF
--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -74,6 +74,10 @@ class ChildDesiresConfig(BaseModel):
     Off by default: the reservation describes the instances of the tier it was
     written for. Turn it on for a child that runs on the parent's own
     instances, such as a model that only splits one service into node roles.
+
+    Either way only a reservation the caller set crosses: composition hands
+    children the caller's desires, so a parent model's own default_desires
+    reservation applies to that model alone.
     """
 
 

--- a/service_capacity_modeling/models/__init__.py
+++ b/service_capacity_modeling/models/__init__.py
@@ -74,10 +74,6 @@ class ChildDesiresConfig(BaseModel):
     Off by default: the reservation describes the instances of the tier it was
     written for. Turn it on for a child that runs on the parent's own
     instances, such as a model that only splits one service into node roles.
-
-    Either way only a reservation the caller set crosses: composition hands
-    children the caller's desires, so a parent model's own default_desires
-    reservation applies to that model alone.
     """
 
 

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -571,9 +571,7 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar. This model plans no
-                    # instances, so the figure stops here -- see
-                    # child_desires_config for what reaches the node roles.
+                    # Elasticsearch has a 1 GiB sidecar
                     reserved_instance_app_mem_gib=1,
                 ),
             )
@@ -635,9 +633,7 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar. This model plans no
-                    # instances, so the figure stops here -- see
-                    # child_desires_config for what reaches the node roles.
+                    # Elasticsearch has a 1 GiB sidecar
                     reserved_instance_app_mem_gib=1,
                 ),
             )

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -195,10 +195,7 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
     ) -> CapacityDesires:
         desires = CapacityModel.default_desires(user_desires, extra_model_arguments)
         desires.buffers = NflxElasticsearchDataCapacityModel.default_buffers()
-        # Elasticsearch has a 1 GiB sidecar. That figure was only stated on the
-        # aggregator model, which owns no instances, so the nodes that actually
-        # reserve the memory fell through to the DataShape default of 2. State
-        # it here, where the instances are.
+        # Elasticsearch data nodes run a 1 GiB sidecar.
         desires.data_shape.reserved_instance_app_mem_gib = 1
         return desires
 
@@ -470,8 +467,8 @@ class NflxElasticsearchCapacityModel(CapacityModel):
         # This model owns no instances -- it splits Elasticsearch into its data,
         # master and search node roles, which run on the shapes the caller was
         # describing. A memory reservation aimed at Elasticsearch is aimed at
-        # those roles, so it crosses. Each role still states its own default,
-        # which applies when the caller sets nothing.
+        # those roles, so an explicit caller value crosses this boundary. The
+        # data node model supplies its own default when the caller sets nothing.
         _ = child_model
         return ChildDesiresConfig(inherit_app_memory_reservation=True)
 
@@ -576,8 +573,6 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar
-                    reserved_instance_app_mem_gib=1,
                 ),
             )
         else:
@@ -638,8 +633,6 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar
-                    reserved_instance_app_mem_gib=1,
                 ),
             )
 

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -571,7 +571,9 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar
+                    # Elasticsearch has a 1 GiB sidecar. This model plans no
+                    # instances, so the figure stops here -- see
+                    # child_desires_config for what reaches the node roles.
                     reserved_instance_app_mem_gib=1,
                 ),
             )
@@ -633,7 +635,9 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
-                    # Elasticsearch has a 1 GiB sidecar
+                    # Elasticsearch has a 1 GiB sidecar. This model plans no
+                    # instances, so the figure stops here -- see
+                    # child_desires_config for what reaches the node roles.
                     reserved_instance_app_mem_gib=1,
                 ),
             )

--- a/service_capacity_modeling/models/org/netflix/elasticsearch.py
+++ b/service_capacity_modeling/models/org/netflix/elasticsearch.py
@@ -195,8 +195,6 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
     ) -> CapacityDesires:
         desires = CapacityModel.default_desires(user_desires, extra_model_arguments)
         desires.buffers = NflxElasticsearchDataCapacityModel.default_buffers()
-        # Elasticsearch data nodes run a 1 GiB sidecar.
-        desires.data_shape.reserved_instance_app_mem_gib = 1
         return desires
 
     @staticmethod
@@ -229,15 +227,15 @@ class NflxElasticsearchDataCapacityModel(CapacityModel):
         if instance.cpu < 2 or instance.ram_gib < 24:
             return None
 
-        # Sidecars/System takes away memory from Elasticsearch
-        # which uses half of available system max of 32 for compressed oops
+        # Sidecars and the OS take memory away from Elasticsearch. The JVM heap
+        # uses half of instance RAM, capped at 32 GiB for compressed pointers.
         base_mem = (
             desires.data_shape.reserved_instance_app_mem_gib
             + desires.data_shape.reserved_instance_system_mem_gib
         )
 
         def reserve_memory(instance_mem_gib: float) -> float:
-            return base_mem + max(32, instance_mem_gib / 2)
+            return base_mem + min(32, instance_mem_gib / 2)
 
         # The 24 GiB floor above ignores the workload's reserved memory. If the
         # reserves swallow the whole instance there is nothing left to hold
@@ -467,8 +465,8 @@ class NflxElasticsearchCapacityModel(CapacityModel):
         # This model owns no instances -- it splits Elasticsearch into its data,
         # master and search node roles, which run on the shapes the caller was
         # describing. A memory reservation aimed at Elasticsearch is aimed at
-        # those roles, so an explicit caller value crosses this boundary. The
-        # data node model supplies its own default when the caller sets nothing.
+        # those roles, so an explicit caller value crosses this boundary. When
+        # the caller sets nothing, each role uses the DataShape default.
         _ = child_model
         return ChildDesiresConfig(inherit_app_memory_reservation=True)
 
@@ -573,6 +571,8 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
+                    # Elasticsearch has a 1 GiB sidecar
+                    reserved_instance_app_mem_gib=1,
                 ),
             )
         else:
@@ -633,6 +633,8 @@ class NflxElasticsearchCapacityModel(CapacityModel):
                         high=4,
                         confidence=0.98,
                     ),
+                    # Elasticsearch has a 1 GiB sidecar
+                    reserved_instance_app_mem_gib=1,
                 ),
             )
 

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -297,10 +297,9 @@ def zonal_summary(zlr):
 def test_es_data_nodes_have_ram_left_after_reserves():
     """Data nodes must have RAM left once sidecars and the heap are carved out.
 
-    Elasticsearch reserves ``base_mem + max(32, ram / 2)`` per node, which
-    overruns shapes at or below ~34 GiB. Those used to yield a negative memory
-    node count that max() discarded, silently dropping the memory constraint
-    and letting an undersized shape win on cost.
+    Elasticsearch reserves the app and system memory plus half of instance RAM
+    for heap, capped at 32 GiB. A shape can only be chosen if something remains
+    for shards and the filesystem cache.
     """
     desires = CapacityDesires(
         service_tier=1,
@@ -337,7 +336,30 @@ def test_es_data_nodes_have_ram_left_after_reserves():
 
     for cluster in data_clusters:
         ram_gib = cluster.instance.ram_gib
-        reserved = base_mem + max(32, ram_gib / 2)
+        reserved = base_mem + min(32, ram_gib / 2)
         assert ram_gib > reserved, (
             f"{cluster.instance.name} reserves {reserved} GiB of {ram_gib} GiB"
         )
+
+
+def test_es_100_gib_plan_can_use_r5d_xlarge_data_nodes():
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(estimated_read_per_second=certain_int(1000)),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(100)),
+    )
+
+    plans = planner.plan_certain(
+        model_name="org.netflix.elasticsearch.node",
+        region="us-east-1",
+        desires=desires,
+        instance_families=["r5d"],
+        num_results=1,
+    )
+    data_clusters = plans[0].candidate_clusters.zonal
+
+    assert {cluster.instance.name for cluster in data_clusters} == {"r5d.xlarge"}
+    assert {
+        cluster.cluster_params["required_nodes_by_type"]["memory"]
+        for cluster in data_clusters
+    } == {1}

--- a/tests/netflix/test_elasticsearch.py
+++ b/tests/netflix/test_elasticsearch.py
@@ -294,47 +294,44 @@ def zonal_summary(zlr):
     )
 
 
-def test_es_data_nodes_have_ram_left_after_reserves():
-    """Data nodes must have RAM left once sidecars and the heap are carved out.
+def test_es_data_nodes_reject_shapes_with_no_ram_left_after_reserves():
+    """A big app reserve can swallow a shape that clears the 24 GiB floor.
 
-    Elasticsearch reserves the app and system memory plus half of instance RAM
-    for heap, capped at 32 GiB. A shape can only be chosen if something remains
-    for shards and the filesystem cache.
+    r5d.xlarge has 31.7 GiB, so a 16 GiB app reserve plus the 1 GiB system
+    reserve plus the 15.85 GiB heap leaves nothing for shards or filesystem
+    cache. The shape has to be dropped before sizing a cluster out of it, while
+    the larger r5d shapes still have room.
     """
+    app_mem_gib = 16
     desires = CapacityDesires(
         service_tier=1,
-        query_pattern=QueryPattern(
-            estimated_read_per_second=Interval(
-                low=1000, mid=10_000, high=100_000, confidence=0.98
-            ),
-        ),
+        query_pattern=QueryPattern(estimated_read_per_second=certain_int(1000)),
         data_shape=DataShape(
-            estimated_state_size_gib=Interval(
-                low=100, mid=1000, high=4000, confidence=0.98
-            ),
+            estimated_state_size_gib=certain_int(100),
+            reserved_instance_app_mem_gib=app_mem_gib,
         ),
+    )
+    base_mem = app_mem_gib + desires.data_shape.reserved_instance_system_mem_gib
+    usable = {
+        name: shapes.instance(name).ram_gib
+        - (base_mem + min(32, shapes.instance(name).ram_gib / 2))
+        for name in ("r5d.xlarge", "r5d.2xlarge")
+    }
+    assert usable["r5d.xlarge"] <= 0 < usable["r5d.2xlarge"], (
+        f"reserving {app_mem_gib} GiB must overrun only r5d.xlarge here: {usable}"
     )
 
     plans = planner.plan_certain(
-        model_name="org.netflix.elasticsearch",
+        model_name="org.netflix.elasticsearch.node",
         region="us-east-1",
         desires=desires,
+        instance_families=["r5d"],
     )
-    assert plans, "Expected plans on shapes large enough for the reserves"
+    assert plans, "Expected the larger r5d shapes to still have RAM left"
 
-    base_mem = (
-        desires.data_shape.reserved_instance_app_mem_gib
-        + desires.data_shape.reserved_instance_system_mem_gib
-    )
-    data_clusters = [
-        cluster
-        for plan in plans
-        for cluster in plan.candidate_clusters.zonal
-        if cluster.cluster_type == "elasticsearch-data"
-    ]
-    assert data_clusters
-
-    for cluster in data_clusters:
+    for cluster in (
+        cluster for plan in plans for cluster in plan.candidate_clusters.zonal
+    ):
         ram_gib = cluster.instance.ram_gib
         reserved = base_mem + min(32, ram_gib / 2)
         assert ram_gib > reserved, (

--- a/tests/test_composed_model_desires.py
+++ b/tests/test_composed_model_desires.py
@@ -113,9 +113,6 @@ def test_a_model_that_owns_no_instances_passes_the_reserve_down():
     the shapes the caller was describing. So a reservation aimed at
     Elasticsearch is aimed at those roles and has to cross, which is what
     ChildDesiresConfig(inherit_app_memory_reservation=True) says.
-
-    Nothing plans this model directly today, so raising the reserve is not
-    observable in production. It is the behaviour we want when someone does.
     """
     assert nflx_elasticsearch_capacity_model.child_desires_config(
         "org.netflix.elasticsearch.node"
@@ -125,6 +122,37 @@ def test_a_model_that_owns_no_instances_passes_the_reserve_down():
     heavy = _clusters_by_type("org.netflix.elasticsearch", 64)
 
     assert heavy["elasticsearch-data"] != lean["elasticsearch-data"]
+
+
+def test_es_aggregator_default_does_not_override_role_defaults():
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=BASE_QUERY_PATTERN.model_copy(deep=True),
+        data_shape=DataShape(estimated_state_size_gib=BASE_STATE_SIZE),
+    )
+    result = planner.plan(
+        model_name="org.netflix.elasticsearch",
+        region="us-east-1",
+        desires=desires,
+        simulations=2,
+    )
+    reserves = {
+        model: model_desires.data_shape.reserved_instance_app_mem_gib
+        for model, model_desires in result.explanation.desires_by_model.items()
+    }
+    default_reserve = DataShape.model_fields["reserved_instance_app_mem_gib"].default
+
+    assert (
+        nflx_elasticsearch_capacity_model.default_desires(
+            desires, {}
+        ).data_shape.reserved_instance_app_mem_gib
+        == 1
+    )
+    assert reserves == {
+        "org.netflix.elasticsearch.master": default_reserve,
+        "org.netflix.elasticsearch.node": default_reserve,
+        "org.netflix.elasticsearch.search": default_reserve,
+    }
 
 
 def test_a_composed_model_on_its_own_shapes_does_not_inherit():


### PR DESCRIPTION
## Summary

#311 restores valid Elasticsearch planning after #303 exposed the existing heap calculation bug. Before #303, smaller shapes could have negative usable RAM; the resulting negative memory count was discarded when the planner combined CPU, disk, and memory requirements. #311 retains #303's nonpositive-memory guard and changes the heap reservation from a 32 GiB floor to a 32 GiB cap.

```python
old_reserve = app_memory + system_memory + max(32, instance_ram / 2)
new_reserve = app_memory + system_memory + min(32, instance_ram / 2)
usable = instance_ram - new_reserve
```

## Before #303 / after #311

The following results replay the same four tier-1 `org.netflix.elasticsearch` requests in `us-east-1` against the commit before #303 and the head of #311. Each request uses a state interval of `(0.1x, 1x, 4x)`, a read-rate interval of `(0.1x, 1x, 10x)`, and confidence `0.98`. No instance-family filter is applied.

| Midpoint workload | Before #303 data nodes per zone | After #311 data nodes per zone | Composed annual cost before / after | Change |
| --- | --- | --- | ---: | ---: |
| 200 GiB, 10k reads/s | `i4i.xlarge` x1, -4.48 GiB usable | `i4i.xlarge` x1, 12.26 GiB usable | $8,336.97 / $8,336.97 | 0% |
| 1,000 GiB, 10k reads/s | `i7ie.xlarge` x1, -4.48 GiB usable | `i7ie.xlarge` x1, 12.26 GiB usable | $9,880.50 / $9,880.50 | 0% |
| 8,000 GiB, 50k reads/s | `i7ie.xlarge` x5, -4.48 GiB usable | `i3en.2xlarge` x3, 27.52 GiB usable | $30,578.58 / $31,696.98 | +3.7% |
| 32,000 GiB, 20k reads/s | `i3en.xlarge` x19, -4.48 GiB usable | `i3en.3xlarge` x7, 56.55 GiB usable | $90,187.17 / $99,178.05 | +10.0% |

Costs include data, master, and search tiers. Node counts are per zone. These are planner replays, not measurements of production clusters.

Every before-#303 result in this table is invalid: the selected data shape has negative usable RAM. Its memory requirement was reported as 0 or a negative number, then ignored in favor of CPU, disk, or minimum-count requirements. After #311, each selected shape has positive usable RAM and a positive memory count. Disk still determines the final count for the 32,000 GiB workload; memory, CPU, and disk jointly determine it for the 8,000 GiB workload.

## Focused regression case

For a 100 GiB, 1,000 reads/s request restricted to `r5d`, both revisions select one `r5d.xlarge` per zone at $8,538.03 annually for the composed plan. The calculation changes from:

```text
Before #303: 31.7 - 2 app - 1 system - 32 heap = -3.30 GiB usable
After #311:  31.7 - 2 app - 1 system - 15.85 heap = 12.85 GiB usable
```

The memory count changes from 0 to 1. On a 128 GiB `r5d.4xlarge`, modeled usable memory changes from 61 GiB before #303 to 93 GiB after #311 because the heap is capped at 32 GiB.

When the caller omits app memory, data, master, and search roles use the generic 2 GiB default both before #303 and after #311. An explicit caller reservation still reaches all three roles. With a 16 GiB app reservation, the guard rejects `r5d.xlarge` at -1.15 GiB usable; `r5d.2xlarge` remains eligible at 14.81 GiB.

## Scope and verification

The change is limited to the Elasticsearch model and regression tests. It does not include the broader `Excuse` conversion or unrelated stacked changes. There are no Elasticsearch entries in the generated baseline fixtures, so the comparisons above come from direct planner replays at the two revisions.

Planner tests cover selected shape, cost, effective role reservation, usable memory, memory count, explicit reservation propagation, and rejection of shapes with nonpositive usable memory. The GitHub test matrix passed on Python 3.10, 3.11, and 3.12. The four-workload experiment was run twice at each revision with identical output.
