### PR TITLE
Calibrate Cassandra EBS IOPS estimates from observed ratios

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -395,6 +395,7 @@ def _derived_write_buffer_requirement_gib(
 
 class _CassandraRequirementEstimate(BaseModel):
     requirement: CapacityRequirement
+    disk_used_gib: float
     write_buffer_gib: float
     compaction_min_threshold: int
 
@@ -552,6 +553,7 @@ def _estimate_cassandra_requirement(
                 "read_per_second": reads_per_second,
             },
         ),
+        disk_used_gib=disk_used_gib,
         write_buffer_gib=write_buffer_gib,
         compaction_min_threshold=min_threshold,
     )
@@ -630,6 +632,7 @@ def _compute_penalties(
 
 
 # pylint: disable=too-many-locals
+# pylint: disable=too-many-branches
 # pylint: disable=too-many-return-statements
 # flake8: noqa: C901
 def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-arguments
@@ -656,6 +659,8 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     backup_retention_days: Optional[float] = None,
     max_disk_utilization: float = CASSANDRA_MAX_DISK_UTILIZATION,
     min_instance_ram_gib_exclusive: float = 16.0,
+    observed_ebs_read_io_per_read: Optional[float] = None,
+    observed_ebs_write_io_per_write: Optional[float] = None,
 ) -> Union[CapacityPlan, Excuse, None]:
     drive_name = drive.name
 
@@ -836,6 +841,41 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     )
 
     current_cluster_size = _get_current_cluster_size(desires)
+    read_io_calibration_factor = 1.0
+    read_io_calibrated = False
+    write_io_calibration_factor = 1.0
+    io_calibration: Dict[str, float] = {}
+    if is_ebs and current_cluster_size is not None and current_cluster_size > 0:
+        assert current_capacity is not None
+        current_count = math.ceil(current_cluster_size)
+        current_data_per_node_gib = max(1, current_capacity.disk_utilization_gib.mid)
+        if observed_ebs_read_io_per_read is not None and rps > 0:
+            modeled_read_io_per_read = _cass_io_per_read(current_data_per_node_gib) * (
+                math.ceil(read_io_per_sec / current_count) * current_count / rps
+            )
+            read_io_calibration_factor = (
+                observed_ebs_read_io_per_read / modeled_read_io_per_read
+            )
+            read_io_calibrated = True
+            io_calibration.update(
+                {
+                    "observed_read_io_per_read": observed_ebs_read_io_per_read,
+                    "modeled_read_io_per_read": modeled_read_io_per_read,
+                    "read_io_calibration_factor": read_io_calibration_factor,
+                }
+            )
+        if observed_ebs_write_io_per_write is not None and write_per_sec > 0:
+            modeled_write_io_per_write = write_io_per_sec / write_per_sec
+            write_io_calibration_factor = (
+                observed_ebs_write_io_per_write / modeled_write_io_per_write
+            )
+            io_calibration.update(
+                {
+                    "observed_write_io_per_write": observed_ebs_write_io_per_write,
+                    "modeled_write_io_per_write": modeled_write_io_per_write,
+                    "write_io_calibration_factor": write_io_calibration_factor,
+                }
+            )
     cluster_size_lambda = _get_cluster_size_lambda(
         cluster_size_mode,
         current_cluster_size=current_cluster_size,
@@ -872,9 +912,15 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         needed_network_mbps=requirement.network_mbps.mid,
         # Take into account the reads per read
         # from the per node dataset using leveled compaction
-        required_disk_ios=lambda size, count: (
-            _cass_io_per_read(size) * math.ceil(read_io_per_sec / count),
-            write_io_per_sec / count,
+        required_disk_ios=lambda _size, count: (
+            read_io_calibration_factor
+            * _cass_io_per_read(
+                max(1, requirement_estimate.disk_used_gib / count)
+                if read_io_calibrated
+                else _size
+            )
+            * math.ceil(read_io_per_sec / count),
+            write_io_calibration_factor * write_io_per_sec / count,
         ),
         # Critical C* clusters grow by doubling from the current cluster size.
         cluster_size=cluster_size_lambda,
@@ -906,6 +952,10 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             2,
         ),
     }
+    if io_calibration:
+        params["cassandra.ebs_io_calibration"] = {
+            key: round(value, 4) for key, value in io_calibration.items()
+        }
     upsert_params(cluster, params)
 
     # All penalties inflate plan.rank = cost * (1 + sum(penalties)),
@@ -940,6 +990,16 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             if node_counts is not None and node_counts.resource_bottleneck is not None
             else "unknown"
         )
+        excuse_context: Dict[str, Any] = {
+            "computed_count": cluster.count,
+            "required_cluster_size": required_cluster_size,
+            "required_nodes_by_type": required_nodes_by_type,
+            "resource_bottleneck": resource_bottleneck,
+        }
+        if io_calibration:
+            excuse_context["ebs_io_calibration"] = {
+                key: round(value, 4) for key, value in io_calibration.items()
+            }
         return Excuse(
             instance=instance.name,
             drive=drive_name,
@@ -948,12 +1008,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
                 f"(resource bottleneck: {resource_bottleneck}) "
                 f"!= required {required_cluster_size}"
             ),
-            context={
-                "computed_count": cluster.count,
-                "required_cluster_size": required_cluster_size,
-                "required_nodes_by_type": required_nodes_by_type,
-                "resource_bottleneck": resource_bottleneck,
-            },
+            context=excuse_context,
             bottleneck=Bottleneck.cluster_size,
         )
 
@@ -1273,6 +1328,22 @@ class NflxCassandraArguments(BaseModel):
         "Lower values are more conservative; higher values allow denser current "
         "shape planning.",
     )
+    observed_ebs_read_io_per_read: Optional[float] = Field(
+        default=None,
+        gt=0,
+        allow_inf_nan=False,
+        description="Observed EBS read operations per logical Cassandra read. "
+        "For existing EBS clusters, calibrates the theoretical LCS read-I/O "
+        "estimate while retaining candidate data-per-node sensitivity.",
+    )
+    observed_ebs_write_io_per_write: Optional[float] = Field(
+        default=None,
+        gt=0,
+        allow_inf_nan=False,
+        description="Observed EBS write operations per logical Cassandra write. "
+        "For existing EBS clusters, calibrates the theoretical commitlog and "
+        "compaction write-I/O estimate.",
+    )
 
     @model_validator(mode="after")
     def _check_storage_buffer_bounds(self) -> "NflxCassandraArguments":
@@ -1515,6 +1586,8 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             backup_retention_days=args.backup_retention_days,
             max_disk_utilization=args.max_disk_utilization,
             min_instance_ram_gib_exclusive=args.min_instance_ram_gib_exclusive,
+            observed_ebs_read_io_per_read=args.observed_ebs_read_io_per_read,
+            observed_ebs_write_io_per_write=args.observed_ebs_write_io_per_write,
         )
 
         return result

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -844,12 +844,16 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     read_io_calibration_factor = 1.0
     read_io_calibrated = False
     write_io_calibration_factor = 1.0
-    io_calibration: Dict[str, float] = {}
-    if is_ebs and current_cluster_size is not None and current_cluster_size > 0:
+    reported_io_calibration: Dict[str, float] = {}
+    if is_ebs and current_cluster_size > 0:
         assert current_capacity is not None
         current_count = math.ceil(current_cluster_size)
-        current_data_per_node_gib = max(1, current_capacity.disk_utilization_gib.mid)
-        if observed_ebs_read_io_per_read is not None and rps > 0:
+        current_data_per_node_gib = current_capacity.disk_utilization_gib.mid
+        if (
+            observed_ebs_read_io_per_read is not None
+            and rps > 0
+            and current_data_per_node_gib > 0
+        ):
             modeled_read_io_per_read = _cass_io_per_read(current_data_per_node_gib) * (
                 math.ceil(read_io_per_sec / current_count) * current_count / rps
             )
@@ -857,7 +861,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
                 observed_ebs_read_io_per_read / modeled_read_io_per_read
             )
             read_io_calibrated = True
-            io_calibration.update(
+            reported_io_calibration.update(
                 {
                     "observed_read_io_per_read": observed_ebs_read_io_per_read,
                     "modeled_read_io_per_read": modeled_read_io_per_read,
@@ -869,7 +873,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             write_io_calibration_factor = (
                 observed_ebs_write_io_per_write / modeled_write_io_per_write
             )
-            io_calibration.update(
+            reported_io_calibration.update(
                 {
                     "observed_write_io_per_write": observed_ebs_write_io_per_write,
                     "modeled_write_io_per_write": modeled_write_io_per_write,
@@ -952,10 +956,8 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             2,
         ),
     }
-    if io_calibration:
-        params["cassandra.ebs_io_calibration"] = {
-            key: round(value, 4) for key, value in io_calibration.items()
-        }
+    if reported_io_calibration:
+        params["cassandra.ebs_io_calibration"] = reported_io_calibration
     upsert_params(cluster, params)
 
     # All penalties inflate plan.rank = cost * (1 + sum(penalties)),
@@ -996,10 +998,8 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
             "required_nodes_by_type": required_nodes_by_type,
             "resource_bottleneck": resource_bottleneck,
         }
-        if io_calibration:
-            excuse_context["ebs_io_calibration"] = {
-                key: round(value, 4) for key, value in io_calibration.items()
-            }
+        if reported_io_calibration:
+            excuse_context["ebs_io_calibration"] = reported_io_calibration
         return Excuse(
             instance=instance.name,
             drive=drive_name,
@@ -1022,18 +1022,21 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     #       duration of this can increase a lot with > 500 node clusters.
     max_zonal = max_regional_size // zones_per_region
     if cluster.count > max_zonal:
+        excuse_context = {
+            "zonal_count": cluster.count,
+            "max_zonal": max_zonal,
+            "needed_disk_gib": needed_disk_gib,
+            "disk_per_node_gib": effective_disk_per_node_gib,
+        }
+        if reported_io_calibration:
+            excuse_context["ebs_io_calibration"] = reported_io_calibration
         return Excuse(
             instance=instance.name,
             drive=drive_name,
             reason=(
                 f"Cluster too large: {cluster.count} nodes > max {max_zonal} per zone"
             ),
-            context={
-                "zonal_count": cluster.count,
-                "max_zonal": max_zonal,
-                "needed_disk_gib": needed_disk_gib,
-                "disk_per_node_gib": effective_disk_per_node_gib,
-            },
+            context=excuse_context,
             bottleneck=Bottleneck.disk_capacity,
         )
 

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -194,13 +194,15 @@ class TestCassandraStorage:
     """Test storage-related scenarios."""
 
     @staticmethod
-    def _existing_ebs_desires() -> CapacityDesires:
+    def _existing_ebs_desires(
+        disk_utilization_gib: float = 900,
+    ) -> CapacityDesires:
         current = CurrentZoneClusterCapacity(
             cluster_instance_name="r7a.4xlarge",
             cluster_instance_count=certain_int(64),
-            cluster_drive=simple_drive(size_gib=1200),
+            cluster_drive=simple_drive(size_gib=max(1200, disk_utilization_gib)),
             cpu_utilization=certain_float(20),
-            disk_utilization_gib=certain_float(900),
+            disk_utilization_gib=certain_float(disk_utilization_gib),
             network_utilization_mbps=certain_float(100),
         )
         return CapacityDesires(
@@ -213,36 +215,32 @@ class TestCassandraStorage:
             current_clusters=CurrentClusters(zonal=[current] * 3),
         )
 
+    @staticmethod
+    def _ebs_plan(desires: CapacityDesires, **extra_model_arguments):
+        plan = planner.plan_certain(
+            model_name="org.netflix.cassandra",
+            region="us-east-1",
+            desires=desires,
+            extra_model_arguments={
+                "require_attached_disks": True,
+                "require_local_disks": False,
+                "cluster_size_mode": "unrestricted",
+                "max_regional_size": 600,
+                **extra_model_arguments,
+            },
+            instance_families=["r7a"],
+            num_results=1,
+        )[0]
+        return plan.candidate_clusters.zonal[0]
+
     def test_ebs_io_per_request_calibrates_candidate_iops(self):
         desires = self._existing_ebs_desires()
-        baseline = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desires,
-            extra_model_arguments={
-                "require_attached_disks": True,
-                "require_local_disks": False,
-                "cluster_size_mode": "unrestricted",
-                "max_regional_size": 600,
-            },
-            instance_families=["r7a"],
-            num_results=1,
-        )[0].candidate_clusters.zonal[0]
-        calibrated = planner.plan_certain(
-            model_name="org.netflix.cassandra",
-            region="us-east-1",
-            desires=desires,
-            extra_model_arguments={
-                "require_attached_disks": True,
-                "require_local_disks": False,
-                "cluster_size_mode": "unrestricted",
-                "max_regional_size": 600,
-                "observed_ebs_read_io_per_read": 2.0,
-                "observed_ebs_write_io_per_write": 1.0,
-            },
-            instance_families=["r7a"],
-            num_results=1,
-        )[0].candidate_clusters.zonal[0]
+        baseline = self._ebs_plan(desires)
+        calibrated = self._ebs_plan(
+            desires,
+            observed_ebs_read_io_per_read=0.0002,
+            observed_ebs_write_io_per_write=1.0,
+        )
 
         calibration = calibrated.cluster_params["cassandra.ebs_io_calibration"]
         assert "cassandra.ebs_io_calibration" not in baseline.cluster_params
@@ -250,19 +248,15 @@ class TestCassandraStorage:
             baseline.attached_drives[0].read_io_per_s,
             baseline.attached_drives[0].write_io_per_s,
         ) == (11_400, 200)
-        assert calibration["observed_read_io_per_read"] == 2.0
+        assert calibration["observed_read_io_per_read"] == 0.0002
         modeled_read_io_per_read = _cass_io_per_read(900) * 1_563 * 64 / 100_000
-        assert calibration["modeled_read_io_per_read"] == round(
-            modeled_read_io_per_read, 4
+        assert calibration["modeled_read_io_per_read"] == pytest.approx(
+            modeled_read_io_per_read
         )
         assert calibration["read_io_calibration_factor"] == pytest.approx(
-            2.0 / modeled_read_io_per_read, abs=0.0001
+            0.0002 / modeled_read_io_per_read
         )
-        assert calibration["modeled_read_io_per_read"] * calibration[
-            "read_io_calibration_factor"
-        ] == pytest.approx(calibration["observed_read_io_per_read"], abs=0.001)
         assert calibration["observed_write_io_per_write"] == 1.0
-        assert calibration["write_io_calibration_factor"] > 1
         assert (
             calibrated.attached_drives[0].read_io_per_s
             < baseline.attached_drives[0].read_io_per_s
@@ -279,17 +273,31 @@ class TestCassandraStorage:
     @pytest.mark.parametrize("value", [0, float("nan"), float("inf")])
     def test_ebs_io_per_request_must_be_positive_and_finite(self, field, value):
         with pytest.raises(ValueError):
-            planner.plan_certain(
-                model_name="org.netflix.cassandra",
-                region="us-east-1",
-                desires=self._existing_ebs_desires(),
-                extra_model_arguments={field: value},
-                num_results=1,
-            )
+            self._ebs_plan(self._existing_ebs_desires(), **{field: value})
+
+    def test_ebs_read_calibration_requires_current_disk_utilization(self):
+        desires = self._existing_ebs_desires(disk_utilization_gib=0)
+        baseline = self._ebs_plan(desires)
+        calibrated = self._ebs_plan(
+            desires,
+            observed_ebs_read_io_per_read=2.0,
+            observed_ebs_write_io_per_write=1.0,
+        )
+
+        calibration = calibrated.cluster_params["cassandra.ebs_io_calibration"]
+        assert set(calibration) == {
+            "observed_write_io_per_write",
+            "modeled_write_io_per_write",
+            "write_io_calibration_factor",
+        }
+        baseline_drive = baseline.attached_drives[0]
+        calibrated_drive = calibrated.attached_drives[0]
+        assert calibrated_drive.read_io_per_s == baseline_drive.read_io_per_s
+        assert calibrated_drive.write_io_per_s > baseline_drive.write_io_per_s
 
     def test_ebs_read_calibration_uses_current_data_not_future_storage_scale(self):
-        def calibration(storage_scale: float) -> dict:
-            desires = self._existing_ebs_desires()
+        def candidate(storage_scale: float):
+            desires = self._existing_ebs_desires(disk_utilization_gib=1500)
             desires.buffers = Buffers(
                 derived={
                     BufferIntent.scale: Buffer(
@@ -299,41 +307,40 @@ class TestCassandraStorage:
                     )
                 }
             )
-            plan = planner.plan_certain(
-                model_name="org.netflix.cassandra",
-                region="us-east-1",
-                desires=desires,
-                extra_model_arguments={
-                    "require_attached_disks": True,
-                    "require_local_disks": False,
-                    "cluster_size_mode": "unrestricted",
-                    "max_regional_size": 600,
-                    "observed_ebs_read_io_per_read": 2.0,
-                },
-                instance_families=["r7a"],
-                num_results=1,
-            )[0]
-            return plan.candidate_clusters.zonal[0].cluster_params[
-                "cassandra.ebs_io_calibration"
-            ]
+            return self._ebs_plan(
+                desires,
+                max_disk_utilization=1.0,
+                max_regional_size=3000,
+                observed_ebs_read_io_per_read=2.0,
+            )
 
-        current_load = calibration(1.0)
-        future_growth = calibration(2.0)
+        current_load = candidate(1.0)
+        future_growth = candidate(2.0)
+        current_calibration = current_load.cluster_params[
+            "cassandra.ebs_io_calibration"
+        ]
+        future_calibration = future_growth.cluster_params[
+            "cassandra.ebs_io_calibration"
+        ]
 
         assert (
-            current_load["modeled_read_io_per_read"]
-            == future_growth["modeled_read_io_per_read"]
+            current_calibration["read_io_calibration_factor"]
+            == future_calibration["read_io_calibration_factor"]
         )
-        assert (
-            current_load["read_io_calibration_factor"]
-            == future_growth["read_io_calibration_factor"]
-        )
+        assert [
+            (
+                candidate.count,
+                candidate.attached_drives[0].read_io_per_s,
+                _cass_io_per_read(1500 * 64 * scale / candidate.count),
+            )
+            for candidate, scale in ((current_load, 1), (future_growth, 2))
+        ] == [(89, 2400, 10), (122, 2000, 12)]
 
-    def test_cass_io_per_read_changes_at_lcs_level_boundary(self):
-        assert _cass_io_per_read(100 * 160 / 1024) == 6
-        assert _cass_io_per_read(101 * 160 / 1024) == 8
-
-    def test_ebs_calibration_is_in_no_plan_excuse_context(self):
+    @pytest.mark.parametrize(
+        "constraint",
+        [{"required_cluster_size": 64}, {"max_regional_size": 3}],
+    )
+    def test_ebs_calibration_is_in_no_plan_excuse_context(self, constraint):
         explained = planner.plan_certain_explained(
             model_name="org.netflix.cassandra",
             region="us-east-1",
@@ -343,8 +350,8 @@ class TestCassandraStorage:
                 "require_local_disks": False,
                 "cluster_size_mode": "unrestricted",
                 "max_regional_size": 600,
-                "required_cluster_size": 64,
                 "observed_ebs_read_io_per_read": 20.0,
+                **constraint,
             },
             instance_families=["r7a"],
             num_results=1,
@@ -360,9 +367,7 @@ class TestCassandraStorage:
         assert calibrated_excuses
         calibration = calibrated_excuses[0].context["ebs_io_calibration"]
         assert calibration["observed_read_io_per_read"] == 20.0
-        assert calibration["modeled_read_io_per_read"] * calibration[
-            "read_io_calibration_factor"
-        ] == pytest.approx(20.0, abs=0.01)
+        assert calibration["read_io_calibration_factor"] > 1
 
     def test_ebs_high_reads(self):
         cap_plan = planner.plan_certain(

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -25,6 +25,7 @@ from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models.org.netflix.cassandra import (
+    _cass_io_per_read,
     _default_cluster_size_mode,
     _get_cluster_size_lambda,
     _get_min_count,
@@ -191,6 +192,177 @@ class TestCassandraCapacityPlanning:
 
 class TestCassandraStorage:
     """Test storage-related scenarios."""
+
+    @staticmethod
+    def _existing_ebs_desires() -> CapacityDesires:
+        current = CurrentZoneClusterCapacity(
+            cluster_instance_name="r7a.4xlarge",
+            cluster_instance_count=certain_int(64),
+            cluster_drive=simple_drive(size_gib=1200),
+            cpu_utilization=certain_float(20),
+            disk_utilization_gib=certain_float(900),
+            network_utilization_mbps=certain_float(100),
+        )
+        return CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=certain_int(300_000),
+                estimated_write_per_second=certain_int(300_000),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(70_000)),
+            current_clusters=CurrentClusters(zonal=[current] * 3),
+        )
+
+    def test_ebs_io_per_request_calibrates_candidate_iops(self):
+        desires = self._existing_ebs_desires()
+        baseline = planner.plan_certain(
+            model_name="org.netflix.cassandra",
+            region="us-east-1",
+            desires=desires,
+            extra_model_arguments={
+                "require_attached_disks": True,
+                "require_local_disks": False,
+                "cluster_size_mode": "unrestricted",
+                "max_regional_size": 600,
+            },
+            instance_families=["r7a"],
+            num_results=1,
+        )[0].candidate_clusters.zonal[0]
+        calibrated = planner.plan_certain(
+            model_name="org.netflix.cassandra",
+            region="us-east-1",
+            desires=desires,
+            extra_model_arguments={
+                "require_attached_disks": True,
+                "require_local_disks": False,
+                "cluster_size_mode": "unrestricted",
+                "max_regional_size": 600,
+                "observed_ebs_read_io_per_read": 2.0,
+                "observed_ebs_write_io_per_write": 1.0,
+            },
+            instance_families=["r7a"],
+            num_results=1,
+        )[0].candidate_clusters.zonal[0]
+
+        calibration = calibrated.cluster_params["cassandra.ebs_io_calibration"]
+        assert "cassandra.ebs_io_calibration" not in baseline.cluster_params
+        assert (
+            baseline.attached_drives[0].read_io_per_s,
+            baseline.attached_drives[0].write_io_per_s,
+        ) == (11_400, 200)
+        assert calibration["observed_read_io_per_read"] == 2.0
+        modeled_read_io_per_read = _cass_io_per_read(900) * 1_563 * 64 / 100_000
+        assert calibration["modeled_read_io_per_read"] == round(
+            modeled_read_io_per_read, 4
+        )
+        assert calibration["read_io_calibration_factor"] == pytest.approx(
+            2.0 / modeled_read_io_per_read, abs=0.0001
+        )
+        assert calibration["modeled_read_io_per_read"] * calibration[
+            "read_io_calibration_factor"
+        ] == pytest.approx(calibration["observed_read_io_per_read"], abs=0.001)
+        assert calibration["observed_write_io_per_write"] == 1.0
+        assert calibration["write_io_calibration_factor"] > 1
+        assert (
+            calibrated.attached_drives[0].read_io_per_s
+            < baseline.attached_drives[0].read_io_per_s
+        )
+        assert (
+            calibrated.attached_drives[0].write_io_per_s
+            > baseline.attached_drives[0].write_io_per_s
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        ["observed_ebs_read_io_per_read", "observed_ebs_write_io_per_write"],
+    )
+    @pytest.mark.parametrize("value", [0, float("nan"), float("inf")])
+    def test_ebs_io_per_request_must_be_positive_and_finite(self, field, value):
+        with pytest.raises(ValueError):
+            planner.plan_certain(
+                model_name="org.netflix.cassandra",
+                region="us-east-1",
+                desires=self._existing_ebs_desires(),
+                extra_model_arguments={field: value},
+                num_results=1,
+            )
+
+    def test_ebs_read_calibration_uses_current_data_not_future_storage_scale(self):
+        def calibration(storage_scale: float) -> dict:
+            desires = self._existing_ebs_desires()
+            desires.buffers = Buffers(
+                derived={
+                    BufferIntent.scale: Buffer(
+                        ratio=storage_scale,
+                        intent=BufferIntent.scale,
+                        components=[BufferComponent.storage],
+                    )
+                }
+            )
+            plan = planner.plan_certain(
+                model_name="org.netflix.cassandra",
+                region="us-east-1",
+                desires=desires,
+                extra_model_arguments={
+                    "require_attached_disks": True,
+                    "require_local_disks": False,
+                    "cluster_size_mode": "unrestricted",
+                    "max_regional_size": 600,
+                    "observed_ebs_read_io_per_read": 2.0,
+                },
+                instance_families=["r7a"],
+                num_results=1,
+            )[0]
+            return plan.candidate_clusters.zonal[0].cluster_params[
+                "cassandra.ebs_io_calibration"
+            ]
+
+        current_load = calibration(1.0)
+        future_growth = calibration(2.0)
+
+        assert (
+            current_load["modeled_read_io_per_read"]
+            == future_growth["modeled_read_io_per_read"]
+        )
+        assert (
+            current_load["read_io_calibration_factor"]
+            == future_growth["read_io_calibration_factor"]
+        )
+
+    def test_cass_io_per_read_changes_at_lcs_level_boundary(self):
+        assert _cass_io_per_read(100 * 160 / 1024) == 6
+        assert _cass_io_per_read(101 * 160 / 1024) == 8
+
+    def test_ebs_calibration_is_in_no_plan_excuse_context(self):
+        explained = planner.plan_certain_explained(
+            model_name="org.netflix.cassandra",
+            region="us-east-1",
+            desires=self._existing_ebs_desires(),
+            extra_model_arguments={
+                "require_attached_disks": True,
+                "require_local_disks": False,
+                "cluster_size_mode": "unrestricted",
+                "max_regional_size": 600,
+                "required_cluster_size": 64,
+                "observed_ebs_read_io_per_read": 20.0,
+            },
+            instance_families=["r7a"],
+            num_results=1,
+        )
+        calibrated_excuses = [
+            excuse
+            for excuses in explained.excuses_by_model.values()
+            for excuse in excuses
+            if "ebs_io_calibration" in excuse.context
+        ]
+
+        assert not explained.plans
+        assert calibrated_excuses
+        calibration = calibrated_excuses[0].context["ebs_io_calibration"]
+        assert calibration["observed_read_io_per_read"] == 20.0
+        assert calibration["modeled_read_io_per_read"] * calibration[
+            "read_io_calibration_factor"
+        ] == pytest.approx(20.0, abs=0.01)
 
     def test_ebs_high_reads(self):
         cap_plan = planner.plan_certain(


### PR DESCRIPTION
## What am I trying to do?

Calibrate Cassandra EBS IOPS estimates from observed physical EBS operations per logical read or write. This lets capacity-planning callers correct workload-specific model bias without losing SCM's ability to scale a future candidate according to its data density and LCS levels.

## Why did I do it this way?

### Calibrate the model instead of replacing it

For each supplied observation, SCM compares the existing cluster's observation with its modeled value:

```text
calibration factor = current observed I/O per operation / current modeled I/O per operation
candidate IOPS = candidate modeled IOPS * calibration factor
```

The factor captures workload-specific bias while the candidate model still responds to node count, data per node, and LCS read amplification. Using the current observed ratio directly for every candidate would flatten that scaling and under-size denser candidates.

### Keep read and write observations independent

Read calibration requires positive current per-node disk utilization because LCS read amplification depends on data density. If that utilization is absent or zero, SCM skips only read calibration rather than inventing a density; write calibration can still apply when its observation and write rate are available.

### Keep the interface optional and explainable

Existing plans are unchanged when neither argument is supplied. When calibration applies, the plan and relevant no-candidate excuses report the observed value, SCM's modeled value, and the applied factor under `cassandra.ebs_io_calibration`. Values retain full precision so small positive factors are not reported as zero.

## Are there any tests?

Yes. Focused tests verify input validation, unchanged uncalibrated plans, independent zero-disk handling, read/write IOPS changes, candidate-density behavior across an LCS level boundary, and calibration metadata in both cluster-size excuse paths. All 64 Cassandra tests, pre-commit checks, and mypy pass; an independent Kimi K3 review found no actionable defects.

## How would I use the new code?

Pass either or both observations as Cassandra extra model arguments:

```json
{
  "observed_ebs_read_io_per_read": 2.0,
  "observed_ebs_write_io_per_write": 1.0
}
```

Both values are optional, finite positive floats measured as physical EBS operations per logical Cassandra operation. Callers provide only the observations; SCM derives and applies the modeled values and factors.

