### PR TITLE
fix(models): size GraphKV from fan-out and traversal depth

### DIFF
--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -39,9 +39,13 @@ from service_capacity_modeling.models import CapacityModel
 # intentionally excluded from this model.
 # ===========================================================================
 
-# Server-side ceiling on traversal depth, so a namespace cannot ask the model to
-# walk deeper than the engine will.
-MAX_TRAVERSAL_DEPTH = 3
+# Fleet-default traversal depth ceiling, from the shard config `max.traversal.depth`.
+# This is a default, NOT a ceiling we can validate against: GraphTraversalService
+# .getMaxDepth prefers a namespace's own TraversalConfig.maxDepth whenever that is
+# positive, and does not clamp it to the shard value. So a namespace may legitimately
+# walk deeper than this, and deeper inputs are accepted. What actually bounds the
+# amplification is MAX_EDGES_PER_TRAVERSAL below.
+DEFAULT_MAX_TRAVERSAL_DEPTH = 3
 
 
 class NflxGraphKVArguments(NflxJavaAppArguments):
@@ -67,13 +71,13 @@ class NflxGraphKVArguments(NflxJavaAppArguments):
     avg_traversal_depth: int = Field(
         default=1,
         ge=1,
-        le=MAX_TRAVERSAL_DEPTH,
         alias="graphkv.avg-traversal-depth",
         description=(
-            "Average number of hops a traversal actually walks, 1 to "
-            f"{MAX_TRAVERSAL_DEPTH}. This is the achieved depth, not the "
-            "configured ceiling, which is set to the maximum far more often "
-            "than it is reached."
+            "Average number of hops a traversal actually walks. This is the "
+            "achieved depth, not the configured ceiling, which is set to the "
+            "maximum far more often than it is reached. The fleet default "
+            f"ceiling is {DEFAULT_MAX_TRAVERSAL_DEPTH} hops, but a namespace can "
+            "raise its own, so deeper values are accepted."
         ),
     )
 
@@ -86,14 +90,23 @@ class NflxGraphKVArguments(NflxJavaAppArguments):
 # and scans one edge index, and a point read costs about one. Measured 1.17 to
 # 1.37 across both workloads at mean and peak.
 KV_READS_PER_LOGICAL_READ = 1.4
-# Backend write requests per logical write. A node write is one request; an edge
-# write is two, one per direction, plus one more when the edge carries
-# properties. Measured 1.2 on the node-heavy workload and 1.6 on the edge-heavy
-# one; held above the midpoint because under-provisioning writes costs more than
-# over-provisioning them.
+# Backend write REQUESTS per logical write. A node write is one request; an edge
+# write is two, one per direction, plus one more when the edge carries properties.
+# Held above the measured range because under-provisioning writes costs more than
+# over-provisioning them. This scales write RATE only -- stored size uses
+# KV_RECORDS_PER_LOGICAL_ITEM, which is a different quantity.
 KV_WRITES_PER_LOGICAL_WRITE = 1.5
-# Bytes one backend record occupies including key and metadata. Measured at 122 B
-# and 207 B on the two workloads; rounded up for the same reason.
+# Backend records STORED per logical node/edge. Not the same thing as the request
+# count above: a node write is one request but stores one metadata record plus one
+# per property, and an edge write stores one link record per direction plus its
+# property records. The two coincide numerically at the current fleet blend, which
+# is why they were a single constant before -- keeping them apart lets the
+# throughput knob move without silently resizing every namespace's disk.
+# TODO: carried over from the request multiplier rather than measured on its own.
+# Re-derive it from stored record counts per logical entity.
+KV_RECORDS_PER_LOGICAL_ITEM = 1.5
+# Bytes one backend record occupies including key and metadata, rounded up from the
+# measured range for the same reason.
 BYTES_PER_KV_RECORD = 256
 # Server-side cap on edges walked in one traversal, which bounds the geometric
 # frontier growth below.
@@ -182,11 +195,16 @@ class NflxGraphKVCapacityModel(CapacityModel):
             # An item count is logical nodes plus edges, so it has to be expanded
             # into backend KV records to become a stored size. A state size in GiB
             # is already a backend size -- re-deriving an item count from it and
-            # expanding that would charge the fan-out twice.
+            # expanding that would charge the fan-out twice. So when the caller
+            # supplied both, the GiB figure is the authoritative one and the count
+            # is left for the KeyValue model to interpret.
+            caller_set_state_size = (
+                "estimated_state_size_gib" in user_desires.data_shape.model_fields_set
+            )
             item_count = relaxed.data_shape.estimated_state_item_count
-            if item_count is not None:
+            if item_count is not None and not caller_set_state_size:
                 relaxed.data_shape.estimated_state_size_gib = item_count.scale(
-                    KV_WRITES_PER_LOGICAL_WRITE * BYTES_PER_KV_RECORD / 1024**3
+                    KV_RECORDS_PER_LOGICAL_ITEM * BYTES_PER_KV_RECORD / 1024**3
                 )
             return relaxed
 

--- a/service_capacity_modeling/models/org/netflix/graphkv.py
+++ b/service_capacity_modeling/models/org/netflix/graphkv.py
@@ -39,6 +39,10 @@ from service_capacity_modeling.models import CapacityModel
 # intentionally excluded from this model.
 # ===========================================================================
 
+# Server-side ceiling on traversal depth, so a namespace cannot ask the model to
+# walk deeper than the engine will.
+MAX_TRAVERSAL_DEPTH = 3
+
 
 class NflxGraphKVArguments(NflxJavaAppArguments):
     """Per-namespace inputs describing the graph shape.
@@ -48,115 +52,76 @@ class NflxGraphKVArguments(NflxJavaAppArguments):
     constants below).
     """
 
-    edge_mapping_count: int = Field(
-        default=5,
-        alias="graphkv.edge-mapping-count",
+    avg_fanout_per_hop: float = Field(
+        default=10.0,
+        ge=0.0,
+        alias="graphkv.avg-fanout-per-hop",
         description=(
-            "Number of registered edge-mappings (distinct "
-            "(from_type, edge_type, to_type) triples) in the namespace. Drives "
-            "READ amplification: a traversal issues one KV scan per edge-mapping "
-            "per hop. Does not change per-write cost."
+            "Average number of edges a traversal follows out of one frontier "
+            "node in one hop, i.e. the branching factor. Grows the frontier the "
+            "next hop has to scan, so it only costs backend reads when the "
+            "traversal is deeper than one hop; at depth 1 it costs response "
+            "bytes, not requests."
         ),
     )
-    edge_mapping_property_count: int = Field(
+    avg_traversal_depth: int = Field(
         default=1,
-        alias="graphkv.edge-mapping-property-count",
+        ge=1,
+        le=MAX_TRAVERSAL_DEPTH,
+        alias="graphkv.avg-traversal-depth",
         description=(
-            "Average number of properties stored on an edge. Drives WRITE "
-            "amplification: each property is a separate KV item, so an edge "
-            "write fans out to (2 link items + this many property items)."
-        ),
-    )
-    node_mapping_count: int = Field(
-        default=5,
-        alias="graphkv.node-mapping-count",
-        description=(
-            "Number of registered node-mappings (distinct node types) in the "
-            "namespace. Used only to estimate the node-vs-edge WRITE mix; it "
-            "does not change per-operation amplification on its own."
-        ),
-    )
-    node_mapping_property_count: int = Field(
-        default=2,
-        alias="graphkv.node-mapping-property-count",
-        description=(
-            "Average number of properties stored on a node. Drives WRITE "
-            "amplification: each property is a separate KV item, so a node "
-            "write fans out to (1 metadata item + this many property items)."
+            "Average number of hops a traversal actually walks, 1 to "
+            f"{MAX_TRAVERSAL_DEPTH}. This is the achieved depth, not the "
+            "configured ceiling, which is set to the maximum far more often "
+            "than it is reached."
         ),
     )
 
 
 # --- Model assumptions (NOT namespace config) -----------------------------
-# Every edge is persisted twice: the forward link plus its inverse/reverse
-# link (bidirectional symmetry / inverse index). Edge properties are written
-# once, on the aligned direction only.
-EDGE_DIRECTION_COPIES = 2
-# A node write always stores one metadata item in addition to its properties.
-NODE_BASE_ITEMS = 1
-# Average out-degree a single edge-mapping contributes at a node, i.e. how many
-# neighbors of one edge-type a node has (formerly "average_node_fanout").
-AVG_FANOUT_PER_EDGE_MAPPING = 10
-# Directions scanned per hop: 1 for unidirectional, 2 if a namespace must scan
-# both OUT and IN. Held at 1 as the fleet default.
-DIRECTION_SCAN_FACTOR = 1
-# Property reads charged per visited neighbor. Properties are co-located under
-# the entity id, so one scan returns all of them (filter OR hydrate => 1).
-PROPERTY_READS_PER_NEIGHBOR = 1
-# Representative traversal depth in hops. Kept at 1 so the default estimate
-# stays bounded; the geometric fan-out below scales correctly if this is
-# raised to model multi-hop traversals.
-TRAVERSAL_DEPTH = 1
-
-
-def _write_amplification(args: NflxGraphKVArguments) -> float:
-    """Backend KV item-writes per logical write.
-
-      edge write -> EDGE_DIRECTION_COPIES link items + 1 item per edge property
-      node write -> NODE_BASE_ITEMS metadata item + 1 item per node property
-
-    Blended by the node-vs-edge write mix. We don't know the real mix, so we
-    proxy it with the registered mapping counts (more edge-mappings than
-    node-mappings => more edge-heavy writes).
-    """
-    edge_write_amp = EDGE_DIRECTION_COPIES + args.edge_mapping_property_count
-    node_write_amp = NODE_BASE_ITEMS + args.node_mapping_property_count
-
-    total_mappings = args.edge_mapping_count + args.node_mapping_count
-    edge_write_fraction = (
-        args.edge_mapping_count / total_mappings if total_mappings > 0 else 0.5
-    )
-    return (
-        edge_write_fraction * edge_write_amp
-        + (1 - edge_write_fraction) * node_write_amp
-    )
+# Empirically derived from two production workloads (Jul 2026), one node-heavy
+# and one edge-heavy, each compared against the backend load it actually caused.
+#
+# Backend reads per logical read at depth 1: a traversal reads its source entity
+# and scans one edge index, and a point read costs about one. Measured 1.17 to
+# 1.37 across both workloads at mean and peak.
+KV_READS_PER_LOGICAL_READ = 1.4
+# Backend write requests per logical write. A node write is one request; an edge
+# write is two, one per direction, plus one more when the edge carries
+# properties. Measured 1.2 on the node-heavy workload and 1.6 on the edge-heavy
+# one; held above the midpoint because under-provisioning writes costs more than
+# over-provisioning them.
+KV_WRITES_PER_LOGICAL_WRITE = 1.5
+# Bytes one backend record occupies including key and metadata. Measured at 122 B
+# and 207 B on the two workloads; rounded up for the same reason.
+BYTES_PER_KV_RECORD = 256
+# Server-side cap on edges walked in one traversal, which bounds the geometric
+# frontier growth below.
+MAX_EDGES_PER_TRAVERSAL = 100_000
 
 
 def _read_amplification(args: NflxGraphKVArguments) -> float:
-    """Backend KV reads per logical traversal.
+    """Backend KV reads per logical GraphKV read.
 
-    Per hop, per frontier node:
-      enumeration = edge_mappings_traversed * DIRECTION_SCAN_FACTOR
-                    (one scan per edge-mapping; each returns ~fanout neighbors --
-                    note this is ADDITIVE in edge-mappings, not multiplicative)
-      hydration   = neighbors * PROPERTY_READS_PER_NEIGHBOR
+    Each frontier node is expanded by its own KV request -- GraphKV does not
+    batch a hop's frontier into one call -- so request count is driven by how
+    many nodes get expanded, which is geometric in fan-out over hops:
 
-    Summed geometrically over TRAVERSAL_DEPTH hops, since the frontier grows by
-    the per-node neighbor count each hop.
+        frontier(1) = 1, frontier(h + 1) = frontier(h) * fanout
+        reads = KV_READS_PER_LOGICAL_READ * sum(frontier(1..depth))
+
+    Fan-out therefore costs nothing at depth 1 (the one scan returns all the
+    neighbors at once, as response bytes); it only multiplies request count once
+    there is a second hop to expand into.
     """
-    edge_mappings_traversed = args.edge_mapping_count
-    neighbors_per_hop = AVG_FANOUT_PER_EDGE_MAPPING * edge_mappings_traversed
-    enumeration_reads = edge_mappings_traversed * DIRECTION_SCAN_FACTOR
-    hydration_reads = neighbors_per_hop * PROPERTY_READS_PER_NEIGHBOR
-    read_amp_per_hop = enumeration_reads + hydration_reads
-
-    branch = neighbors_per_hop
-    if branch <= 1 or TRAVERSAL_DEPTH <= 1:
-        return read_amp_per_hop * TRAVERSAL_DEPTH
-    # Frontier at hop h is branch**h, so total reads =
-    # read_amp_per_hop * sum_{h=0}^{D-1} branch**h.
-    hop_multiplier = (float(branch) ** TRAVERSAL_DEPTH - 1) / (branch - 1)
-    return read_amp_per_hop * hop_multiplier
+    frontier, scans, edges = 1.0, 0.0, 0.0
+    for _ in range(args.avg_traversal_depth):
+        scans += frontier
+        edges += frontier * args.avg_fanout_per_hop
+        if edges >= MAX_EDGES_PER_TRAVERSAL:
+            break
+        frontier *= args.avg_fanout_per_hop
+    return KV_READS_PER_LOGICAL_READ * scans
 
 
 class NflxGraphKVCapacityModel(CapacityModel):
@@ -200,8 +165,8 @@ class NflxGraphKVCapacityModel(CapacityModel):
             relaxed = user_desires.model_copy(deep=True)
 
             # Per-namespace graph shape drives how each logical read/write fans
-            # out into backend KV operations. See _read_amplification /
-            # _write_amplification and the model constants above.
+            # out into backend KV operations. See _read_amplification and the
+            # model constants above.
             args = NflxGraphKVArguments.model_validate(extra_model_arguments)
             relaxed.query_pattern.estimated_read_per_second = (
                 user_desires.query_pattern.estimated_read_per_second.scale(
@@ -210,34 +175,19 @@ class NflxGraphKVCapacityModel(CapacityModel):
             )
             relaxed.query_pattern.estimated_write_per_second = (
                 user_desires.query_pattern.estimated_write_per_second.scale(
-                    _write_amplification(args)
+                    KV_WRITES_PER_LOGICAL_WRITE
                 )
             )
 
+            # An item count is logical nodes plus edges, so it has to be expanded
+            # into backend KV records to become a stored size. A state size in GiB
+            # is already a backend size -- re-deriving an item count from it and
+            # expanding that would charge the fan-out twice.
             item_count = relaxed.data_shape.estimated_state_item_count
-            if item_count is None:
-                # assume 1 KB items
-                if (
-                    user_desires.query_pattern.estimated_mean_write_size_bytes
-                    is not None
-                ):
-                    item_size_gib = (
-                        user_desires.query_pattern.estimated_mean_write_size_bytes.mid
-                        / 1024**3
-                    )
-                else:
-                    item_size_gib = 1 / 1024**2  # type: ignore[unreachable]
-                item_count = user_desires.data_shape.estimated_state_size_gib.scale(
-                    1 / item_size_gib
+            if item_count is not None:
+                relaxed.data_shape.estimated_state_size_gib = item_count.scale(
+                    KV_WRITES_PER_LOGICAL_WRITE * BYTES_PER_KV_RECORD / 1024**3
                 )
-            # item_count is the number of *logical* nodes/edges. Each one fans
-            # out into _write_amplification() backend KV items (2 links + one
-            # item per edge property; 1 metadata item + one per node property),
-            # and every item written is an item stored. Size each KV item at the
-            # ~512 B needed to track its id and metadata write_ts.
-            relaxed.data_shape.estimated_state_size_gib = item_count.scale(
-                _write_amplification(args) * 512 / 1024**3
-            )
             return relaxed
 
         return (("org.netflix.key-value", _modify_kv_desires),)

--- a/tests/netflix/test_graphkv.py
+++ b/tests/netflix/test_graphkv.py
@@ -2,10 +2,145 @@
 Tests for Netflix GraphKV model.
 """
 
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.models.org.netflix.graphkv import (
+    _read_amplification,
+    KV_READS_PER_LOGICAL_READ,
+    MAX_EDGES_PER_TRAVERSAL,
+    NflxGraphKVArguments,
+)
+
 # Property test configuration for GraphKV model.
 # See tests/netflix/PROPERTY_TESTING.md for configuration options and examples.
 PROPERTY_TEST_CONFIG = {
-    # "org.netflix.graphkv": {
-    #     "extra_model_arguments": {},
-    # },
+    "org.netflix.graphkv": {
+        "extra_model_arguments": {
+            "graphkv.avg-fanout-per-hop": 10,
+            "graphkv.avg-traversal-depth": 1,
+        },
+    },
 }
+
+
+def _args(fanout: float, depth: int) -> NflxGraphKVArguments:
+    return NflxGraphKVArguments.model_validate(
+        {
+            "graphkv.avg-fanout-per-hop": fanout,
+            "graphkv.avg-traversal-depth": depth,
+        }
+    )
+
+
+def test_fanout_costs_nothing_at_one_hop():
+    # A single hop is one edge-index scan whatever it returns, so fan-out shows up
+    # as response bytes rather than as extra backend requests.
+    for fanout in (0.1, 1.0, 10.0, 1000.0):
+        assert _read_amplification(_args(fanout, 1)) == KV_READS_PER_LOGICAL_READ
+
+
+def test_depth_multiplies_by_the_frontier():
+    # frontier(h) = fanout ** (h - 1), so depth 3 at fan-out 10 scans 1 + 10 + 100.
+    assert _read_amplification(_args(10, 3)) == KV_READS_PER_LOGICAL_READ * 111
+    # Fan-out below 1 shrinks the frontier instead of growing it.
+    assert _read_amplification(_args(0.16, 3)) == KV_READS_PER_LOGICAL_READ * (
+        1 + 0.16 + 0.16**2
+    )
+
+
+def test_frontier_growth_stops_at_the_traversal_edge_limit():
+    huge = _read_amplification(_args(MAX_EDGES_PER_TRAVERSAL * 10, 3))
+    # The first hop already blows past the edge limit, so hops 2 and 3 never run.
+    assert huge == KV_READS_PER_LOGICAL_READ
+
+
+# Two measured workload shapes and the backend KV load each produced.
+# Rates are entities per second, not RPCs.
+WORKLOADS = (
+    {
+        "shape": "node-heavy, shallow",
+        "logical_read_per_second": 8_895,
+        "logical_write_per_second": 268,
+        # Below 1: most traversals return nothing.
+        "fanout_per_hop": 0.16,
+        "traversal_depth": 1,
+        "kv_read_per_second": 11_338,
+        "kv_write_per_second": 345,
+        "state_gib": 53,
+    },
+    {
+        "shape": "edge-heavy, shallow",
+        "logical_read_per_second": 30_494,
+        "logical_write_per_second": 13_785,
+        "fanout_per_hop": 8.35,
+        "traversal_depth": 1,
+        "kv_read_per_second": 35_738,
+        "kv_write_per_second": 18_003,
+        "state_gib": 58,
+    },
+)
+
+
+def _plan(model, read_per_second, write_per_second, state_gib, extra_args=None):
+    plans = planner.plan_certain(
+        model_name=model,
+        region="us-east-1",
+        desires=CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                estimated_read_per_second=certain_int(read_per_second),
+                estimated_write_per_second=certain_int(write_per_second),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(state_gib)),
+        ),
+        num_results=1,
+        extra_model_arguments=extra_args or {},
+    )
+    assert plans, f"no plan for {model}"
+    return plans[0].candidate_clusters
+
+
+def test_production_shapes_land_near_their_key_value_counterparts():
+    # Planning from logical traffic should land near the KeyValue plan built from
+    # the backend load that traffic actually produced.
+    for workload in WORKLOADS:
+        graph_candidate = _plan(
+            "org.netflix.graphkv",
+            workload["logical_read_per_second"],
+            workload["logical_write_per_second"],
+            workload["state_gib"],
+            {
+                "graphkv.avg-fanout-per-hop": workload["fanout_per_hop"],
+                "graphkv.avg-traversal-depth": workload["traversal_depth"],
+            },
+        )
+        kv_candidate = _plan(
+            "org.netflix.key-value",
+            workload["kv_read_per_second"],
+            workload["kv_write_per_second"],
+            workload["state_gib"],
+        )
+
+        # The GraphKV plan carries its own app tier on top of everything the KV
+        # plan has, so compare the shared clusters and allow that one extra tier.
+        graph_clusters = {
+            cluster.cluster_type: cluster for cluster in graph_candidate.regional
+        }
+        kv_clusters = {
+            cluster.cluster_type: cluster for cluster in kv_candidate.regional
+        }
+        assert "dgwgraphkv" in graph_clusters
+        for cluster_type, kv_cluster in kv_clusters.items():
+            assert graph_clusters[cluster_type].count <= 2 * kv_cluster.count, (
+                f"{workload['shape']} over-provisions {cluster_type}"
+            )
+
+        graph_cost = float(graph_candidate.total_annual_cost)
+        kv_cost = float(kv_candidate.total_annual_cost)
+        assert graph_cost < 1.5 * kv_cost, (
+            f"{workload['shape']} costs {graph_cost:,.0f} against {kv_cost:,.0f} "
+            f"for the KeyValue shard behind it"
+        )

--- a/tests/netflix/test_graphkv.py
+++ b/tests/netflix/test_graphkv.py
@@ -2,6 +2,8 @@
 Tests for Netflix GraphKV model.
 """
 
+import pytest
+
 from service_capacity_modeling.capacity_planner import planner
 from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import certain_int
@@ -9,9 +11,14 @@ from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.models.org.netflix.graphkv import (
     _read_amplification,
+    BYTES_PER_KV_RECORD,
+    DEFAULT_MAX_TRAVERSAL_DEPTH,
     KV_READS_PER_LOGICAL_READ,
+    KV_RECORDS_PER_LOGICAL_ITEM,
+    KV_WRITES_PER_LOGICAL_WRITE,
     MAX_EDGES_PER_TRAVERSAL,
     NflxGraphKVArguments,
+    NflxGraphKVCapacityModel,
 )
 
 # Property test configuration for GraphKV model.
@@ -55,6 +62,80 @@ def test_frontier_growth_stops_at_the_traversal_edge_limit():
     huge = _read_amplification(_args(MAX_EDGES_PER_TRAVERSAL * 10, 3))
     # The first hop already blows past the edge limit, so hops 2 and 3 never run.
     assert huge == KV_READS_PER_LOGICAL_READ
+
+
+def test_depth_beyond_the_fleet_default_is_accepted():
+    # GraphTraversalService.getMaxDepth prefers a namespace's own
+    # TraversalConfig.maxDepth whenever it is positive and never clamps it to the
+    # shard default, so a namespace can be configured deeper than
+    # DEFAULT_MAX_TRAVERSAL_DEPTH and the model has to plan it, not reject it.
+    deeper = _read_amplification(_args(2.0, DEFAULT_MAX_TRAVERSAL_DEPTH + 2))
+    assert deeper > _read_amplification(_args(2.0, DEFAULT_MAX_TRAVERSAL_DEPTH))
+    # The edge limit, not the depth field, is what stops a typo from exploding: at
+    # fan-out 1000 the second hop already exceeds it, so hops 3..50 never run.
+    assert _read_amplification(_args(1_000.0, 50)) == KV_READS_PER_LOGICAL_READ * 1_001
+
+
+def _composed_kv_data_shape(data_shape: DataShape) -> DataShape:
+    """Run the key-value composition transform alone, without the planner."""
+    desires = CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            estimated_read_per_second=certain_int(1_000),
+            estimated_write_per_second=certain_int(100),
+        ),
+        data_shape=data_shape,
+    )
+    ((_, transform),) = NflxGraphKVCapacityModel.compose_with(desires, {})
+    return transform(desires).data_shape
+
+
+def test_state_size_alone_passes_through():
+    # A size in GiB is already a backend size, so it reaches KeyValue untouched.
+    size_only = _composed_kv_data_shape(
+        DataShape(estimated_state_size_gib=certain_int(100))
+    )
+    assert size_only.estimated_state_size_gib.mid == 100
+
+
+def test_explicit_state_size_wins_over_an_item_count():
+    # Expanding the item count on top of a size the caller gave us would charge the
+    # fan-out twice and silently discard what they asked for.
+    both = _composed_kv_data_shape(
+        DataShape(
+            estimated_state_size_gib=certain_int(100),
+            estimated_state_item_count=certain_int(1_000_000_000),
+        )
+    )
+    assert both.estimated_state_size_gib.mid == 100
+
+
+def test_item_count_alone_expands_by_the_stored_record_multiplier():
+    # Only an item count has to be expanded, and it expands by records STORED per
+    # logical entity -- not by the write-REQUEST multiplier, which is a different
+    # quantity that happens to share its value today.
+    count_only = _composed_kv_data_shape(
+        DataShape(estimated_state_item_count=certain_int(1_000_000_000))
+    )
+    expected_gib = (
+        1_000_000_000 * KV_RECORDS_PER_LOGICAL_ITEM * BYTES_PER_KV_RECORD / 1024**3
+    )
+    assert count_only.estimated_state_size_gib.mid == pytest.approx(expected_gib)
+
+
+def test_stored_size_ignores_the_write_request_multiplier(monkeypatch):
+    # The record count and the request count share a value today, so the test above
+    # cannot tell which one sizes the disk. Pull them apart and check that moving the
+    # throughput knob does not resize storage.
+    module = "service_capacity_modeling.models.org.netflix.graphkv"
+    monkeypatch.setattr(f"{module}.KV_RECORDS_PER_LOGICAL_ITEM", 4.0)
+    monkeypatch.setattr(f"{module}.KV_WRITES_PER_LOGICAL_WRITE", 99.0)
+
+    count_only = _composed_kv_data_shape(
+        DataShape(estimated_state_item_count=certain_int(1_000_000_000))
+    )
+    expected_gib = 1_000_000_000 * 4.0 * BYTES_PER_KV_RECORD / 1024**3
+    assert count_only.estimated_state_size_gib.mid == pytest.approx(expected_gib)
 
 
 # Two measured workload shapes and the backend KV load each produced.
@@ -103,9 +184,39 @@ def _plan(model, read_per_second, write_per_second, state_gib, extra_args=None):
     return plans[0].candidate_clusters
 
 
+def test_amplification_matches_measured_backend_load():
+    # The direct guard on the constants: what the model multiplies logical traffic
+    # by, against what each workload's backend load actually was. Two-sided on
+    # purpose -- an upper bound alone passes an arbitrarily under-estimated model,
+    # and under-estimating is the direction that under-provisions.
+    for workload in WORKLOADS:
+        modeled_read = _read_amplification(
+            _args(workload["fanout_per_hop"], workload["traversal_depth"])
+        )
+        operations = (
+            (
+                "read",
+                modeled_read,
+                workload["kv_read_per_second"] / workload["logical_read_per_second"],
+            ),
+            (
+                "write",
+                KV_WRITES_PER_LOGICAL_WRITE,
+                workload["kv_write_per_second"] / workload["logical_write_per_second"],
+            ),
+        )
+        for operation, modeled, measured in operations:
+            headroom = modeled / measured
+            assert 1.0 <= headroom <= 1.25, (
+                f"{workload['shape']} {operation} amplification is {headroom:.2f}x "
+                f"the backend load this workload actually produced. The band is "
+                f"deliberately tight; re-check the measurements before widening it."
+            )
+
+
 def test_production_shapes_land_near_their_key_value_counterparts():
     # Planning from logical traffic should land near the KeyValue plan built from
-    # the backend load that traffic actually produced.
+    # the backend load that traffic actually produced -- near from both sides.
     for workload in WORKLOADS:
         graph_candidate = _plan(
             "org.netflix.graphkv",
@@ -134,13 +245,21 @@ def test_production_shapes_land_near_their_key_value_counterparts():
         }
         assert "dgwgraphkv" in graph_clusters
         for cluster_type, kv_cluster in kv_clusters.items():
-            assert graph_clusters[cluster_type].count <= 2 * kv_cluster.count, (
-                f"{workload['shape']} over-provisions {cluster_type}"
+            assert cluster_type in graph_clusters, (
+                f"{workload['shape']} is missing the {cluster_type} tier that the "
+                f"KeyValue plan provisions"
+            )
+            count_ratio = graph_clusters[cluster_type].count / kv_cluster.count
+            assert 0.75 <= count_ratio <= 2.0, (
+                f"{workload['shape']} sizes {cluster_type} at {count_ratio:.2f}x the "
+                f"KeyValue shard behind it"
             )
 
-        graph_cost = float(graph_candidate.total_annual_cost)
-        kv_cost = float(kv_candidate.total_annual_cost)
-        assert graph_cost < 1.5 * kv_cost, (
-            f"{workload['shape']} costs {graph_cost:,.0f} against {kv_cost:,.0f} "
-            f"for the KeyValue shard behind it"
+        # Compared as a ratio: the graph plan adds its own tier on top of everything
+        # the KV plan plans, so it has to cost more, but not by a multiple.
+        cost_ratio = float(graph_candidate.total_annual_cost) / float(
+            kv_candidate.total_annual_cost
+        )
+        assert 1.0 < cost_ratio < 1.5, (
+            f"{workload['shape']} costs {cost_ratio:.2f}x the KeyValue shard behind it"
         )


### PR DESCRIPTION
## What

Replaces the GraphKV amplification model. Four schema-derived inputs become two behavioural ones:

| removed | added |
|---|---|
| `graphkv.edge-mapping-count` | `graphkv.avg-fanout-per-hop` |
| `graphkv.edge-mapping-property-count` | `graphkv.avg-traversal-depth` |
| `graphkv.node-mapping-count` | |
| `graphkv.node-mapping-property-count` | |

## Why

Registered mapping counts do not predict backend load. A traversal issues one edge-index scan per hop whatever the schema size, and one scan returns all of a node's neighbours — so fan-out costs response bytes at a single hop, not requests. Depth is what multiplies request count, and it was a module constant rather than an input.

Read amplification is now `sum(fanout ** (h - 1))` for `h` in `1..depth`, bounded by the server-side edge-traversal cap.

Stored size no longer round-trips through an item count: a size given in GiB passes through, and only an item count is expanded.

## Validation

`tests/netflix/test_graphkv.py` plans two workload shapes twice — from logical traffic through this model, and from the resulting backend load through `org.netflix.key-value` — and asserts the two agree on cluster shape and stay within a bounded cost factor.

## Scope

Only `org.netflix.graphkv` output changes. `tox -e capture-baseline` produces no diff.
