### PR TITLE
feat(cassandra): attribute service cost per keyspace replication

### DIFF
--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -14,7 +14,6 @@ from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import field_validator
 from pydantic import model_validator
 
 from service_capacity_modeling.enum_utils import enum_docstrings
@@ -179,11 +178,6 @@ _CASSANDRA_SERIALIZATION_AMPLIFICATION = 1.42
 # Configurable via backup_retention_days in extra_model_arguments for clusters
 # with different compaction strategies (TWCS) or aggressive TTLs.
 _DEFAULT_BACKUP_RETENTION_DAYS = 14.0
-
-# Float slack allowed when checking that keyspace replication shares partition
-# a plan. Shares are computed by a caller dividing measured telemetry, so exact
-# equality to 1.0 is not achievable.
-_KEYSPACE_SHARE_TOLERANCE = 1e-6
 
 # Known Cassandra write size defaults (from default_desires() and interface.py).
 # Used to detect whether estimated_mean_write_size_bytes was user-supplied or
@@ -1282,6 +1276,11 @@ class KeyspaceReplication(BaseModel):
     with no cross-region replication. Since network cost scales with the regions
     a write must cross, pricing the whole cluster at one placement charges
     phantom cross-region replication to the single-region keyspaces.
+
+    Weights are relative, not fractions: pass measured magnitudes and the model
+    normalises them against each other. The plan's own totals stay the source of
+    truth, so a breakdown cannot contradict them no matter what scale the caller
+    works in, and there is no sum-to-one rule to get wrong.
     """
 
     keyspaces: List[str] = Field(
@@ -1298,17 +1297,17 @@ class KeyspaceReplication(BaseModel):
         description="How many regions these keyspaces replicate into. One means"
         " the data never leaves its region, so no cross-region replication.",
     )
-    state_size_share: float = Field(
+    state_size_weight: float = Field(
         ge=0,
-        le=1,
-        description="Fraction of the plan's estimated_state_size_gib that these"
-        " keyspaces hold.",
+        description="Relative amount of the plan's stored bytes these keyspaces"
+        " hold. Any non-negative scale works -- measured GiB is fine -- because"
+        " weights are normalised against the other entries rather than being"
+        " required to sum to anything.",
     )
-    write_share: float = Field(
+    write_weight: float = Field(
         ge=0,
-        le=1,
-        description="Fraction of the plan's estimated_write_per_second that these"
-        " keyspaces receive.",
+        description="Relative amount of the plan's write rate these keyspaces"
+        " receive, on the same footing as state_size_weight.",
     )
 
 
@@ -1328,10 +1327,10 @@ class NflxCassandraArguments(BaseModel):
         default=None,
         description="Replication placements of the keyspaces this plan holds, used"
         " to attribute network and backup cost. When supplied, each entry is priced"
-        " at its own replication factor and region count using its share of the"
-        " plan's state size and write rate, and the results are summed. An empty"
-        " list attributes no service cost. When unsupplied, the whole plan is"
-        " priced at one replication factor.",
+        " at its own replication factor and region count using its normalised"
+        " weight of the plan's state size and write rate, and the results are"
+        " summed. An empty list attributes no service cost. When unsupplied, the"
+        " whole plan is priced at one replication factor.",
     )
     require_local_disks: bool = Field(
         default=True,
@@ -1499,24 +1498,6 @@ class NflxCassandraArguments(BaseModel):
                 f"must be <= max_compute_buffer_ratio ({self.max_compute_buffer_ratio})"
             )
         return self
-
-    @field_validator("keyspace_replication")
-    @classmethod
-    def _check_replication_shares(
-        cls, value: Optional[List[KeyspaceReplication]]
-    ) -> Optional[List[KeyspaceReplication]]:
-        # The placements partition one plan, so their shares must account for all
-        # of it. Requiring that here makes a breakdown that contradicts the plan's
-        # own state size or write rate unrepresentable.
-        if not value:
-            return value
-        for field in ("state_size_share", "write_share"):
-            total = math.fsum(getattr(entry, field) for entry in value)
-            if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
-                raise ValueError(
-                    f"keyspace_replication {field} must sum to 1.0, got {total}"
-                )
-        return value
 
     @classmethod
     def from_extra_model_arguments(
@@ -1697,6 +1678,10 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             return []
         plan_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
         plan_write_per_second = desires.query_pattern.estimated_write_per_second.mid
+        # Normalising here is what makes the parts sum to the plan by
+        # construction. A zero total means nothing to attribute, not an error.
+        state_weight_total = math.fsum(entry.state_size_weight for entry in entries)
+        write_weight_total = math.fsum(entry.write_weight for entry in entries)
         charge_backup = _backup_charged(context, desires, args)
 
         services_by_type: Dict[str, ServiceCapacity] = {}
@@ -1706,10 +1691,14 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         for entry in entries:
             entry_desires = desires.model_copy(deep=True)
             entry_desires.data_shape.estimated_state_size_gib = certain_float(
-                plan_state_size_gib * entry.state_size_share
+                plan_state_size_gib * entry.state_size_weight / state_weight_total
+                if state_weight_total
+                else 0.0
             )
             entry_desires.query_pattern.estimated_write_per_second = certain_float(
-                plan_write_per_second * entry.write_share
+                plan_write_per_second * entry.write_weight / write_weight_total
+                if write_weight_total
+                else 0.0
             )
             entry_context = context.model_copy(
                 update={"num_regions": entry.num_regions}

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1282,6 +1282,10 @@ class KeyspaceReplication(BaseModel):
     with no cross-region replication. Since network cost scales with the regions
     a write must cross, pricing the whole cluster at one placement charges
     phantom cross-region replication to the single-region keyspaces.
+
+    Only the write rate is split. Stored bytes are not: the backup snapshot is a
+    function of what a region holds, not of how many regions hold it, so splitting
+    state size across placements changes nothing except rounding.
     """
 
     keyspaces: List[str] = Field(
@@ -1298,17 +1302,13 @@ class KeyspaceReplication(BaseModel):
         description="How many regions these keyspaces replicate into. One means"
         " the data never leaves its region, so no cross-region replication.",
     )
-    state_size_share: float = Field(
-        ge=0,
-        le=1,
-        description="Fraction of the plan's estimated_state_size_gib that these"
-        " keyspaces hold.",
-    )
     write_share: float = Field(
         ge=0,
         le=1,
         description="Fraction of the plan's estimated_write_per_second that these"
-        " keyspaces receive.",
+        " keyspaces receive. Write rate is the only placement-sensitive input:"
+        " cross-region transfer scales with it, while the backup snapshot depends"
+        " on stored bytes and not on how many regions hold them.",
     )
 
 
@@ -1329,9 +1329,9 @@ class NflxCassandraArguments(BaseModel):
         description="Replication placements of the keyspaces this plan holds, used"
         " to attribute network and backup cost. When supplied, each entry is priced"
         " at its own replication factor and region count using its share of the"
-        " plan's state size and write rate, and the results are summed. An empty"
-        " list attributes no service cost. When unsupplied, the whole plan is"
-        " priced at one replication factor.",
+        " plan's write rate, and the results are summed. An empty list attributes"
+        " no service cost. When unsupplied, the whole plan is priced at one"
+        " replication factor.",
     )
     require_local_disks: bool = Field(
         default=True,
@@ -1510,12 +1510,11 @@ class NflxCassandraArguments(BaseModel):
         # own state size or write rate unrepresentable.
         if not value:
             return value
-        for field in ("state_size_share", "write_share"):
-            total = math.fsum(getattr(entry, field) for entry in value)
-            if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
-                raise ValueError(
-                    f"keyspace_replication {field} must sum to 1.0, got {total}"
-                )
+        total = math.fsum(entry.write_share for entry in value)
+        if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
+            raise ValueError(
+                f"keyspace_replication write_share must sum to 1.0, got {total}"
+            )
         return value
 
     @classmethod
@@ -1673,27 +1672,26 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         """Price each keyspace replication placement separately and sum them.
 
         Every entry re-enters ``service_costs`` carrying its own share of the
-        plan's state size and write rate, its own replication factor, and its own
-        region count, so an entry with ``num_regions == 1`` is charged no
-        cross-region replication at all. Backup is charged once over the whole
-        plan because the snapshot floor and retention are per-plan.
+        plan's write rate, its own replication factor, and its own region count,
+        so an entry with ``num_regions == 1`` is charged no cross-region
+        replication at all.
+
+        Stored bytes are deliberately not split. The backup snapshot depends on
+        what a region holds, not on how many regions hold it, so it is computed
+        once from the plan's own state size; only the upload volume, which scales
+        with write fan-out, is summed per placement.
         """
         entries = args.keyspace_replication or []
         if not entries:
             return []
-        plan_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
         plan_write_per_second = desires.query_pattern.estimated_write_per_second.mid
         charge_backup = _backup_charged(context, desires, args)
 
         services_by_type: Dict[str, ServiceCapacity] = {}
-        snapshot_gib = 0
         daily_write_gib = 0.0
         backup_placements: List[Dict[str, Any]] = []
         for entry in entries:
             entry_desires = desires.model_copy(deep=True)
-            entry_desires.data_shape.estimated_state_size_gib = certain_float(
-                plan_state_size_gib * entry.state_size_share
-            )
             entry_desires.query_pattern.estimated_write_per_second = certain_float(
                 plan_write_per_second * entry.write_share
             )
@@ -1734,22 +1732,26 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                 )
 
             if charge_backup:
-                entry_snapshot_gib, entry_daily_write_gib = _backup_components(
+                # Only the upload volume is placement-sensitive: it divides by the
+                # regions a write fans out to. The snapshot is charged once below,
+                # on the plan's own state size.
+                _, entry_daily_write_gib = _backup_components(
                     entry_desires, entry_context, entry.copies_per_region
                 )
-                snapshot_gib += entry_snapshot_gib
                 daily_write_gib += entry_daily_write_gib
                 backup_placements.append(
                     {
                         "keyspaces": entry.keyspaces,
                         "copies_per_region": entry.copies_per_region,
                         "num_regions": entry.num_regions,
-                        "snapshot_gib": entry_snapshot_gib,
                         "daily_write_gib": round(entry_daily_write_gib, 1),
                     }
                 )
 
         if charge_backup:
+            snapshot_gib, _ = _backup_components(
+                desires, context, _target_rf(desires, args.copies_per_region)
+            )
             backup = _backup_service(
                 service_type,
                 context,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1282,10 +1282,6 @@ class KeyspaceReplication(BaseModel):
     with no cross-region replication. Since network cost scales with the regions
     a write must cross, pricing the whole cluster at one placement charges
     phantom cross-region replication to the single-region keyspaces.
-
-    Only the write rate is split. Stored bytes are not: the backup snapshot is a
-    function of what a region holds, not of how many regions hold it, so splitting
-    state size across placements changes nothing except rounding.
     """
 
     keyspaces: List[str] = Field(
@@ -1302,13 +1298,17 @@ class KeyspaceReplication(BaseModel):
         description="How many regions these keyspaces replicate into. One means"
         " the data never leaves its region, so no cross-region replication.",
     )
+    state_size_share: float = Field(
+        ge=0,
+        le=1,
+        description="Fraction of the plan's estimated_state_size_gib that these"
+        " keyspaces hold.",
+    )
     write_share: float = Field(
         ge=0,
         le=1,
         description="Fraction of the plan's estimated_write_per_second that these"
-        " keyspaces receive. Write rate is the only placement-sensitive input:"
-        " cross-region transfer scales with it, while the backup snapshot depends"
-        " on stored bytes and not on how many regions hold them.",
+        " keyspaces receive.",
     )
 
 
@@ -1329,9 +1329,9 @@ class NflxCassandraArguments(BaseModel):
         description="Replication placements of the keyspaces this plan holds, used"
         " to attribute network and backup cost. When supplied, each entry is priced"
         " at its own replication factor and region count using its share of the"
-        " plan's write rate, and the results are summed. An empty list attributes"
-        " no service cost. When unsupplied, the whole plan is priced at one"
-        " replication factor.",
+        " plan's state size and write rate, and the results are summed. An empty"
+        " list attributes no service cost. When unsupplied, the whole plan is"
+        " priced at one replication factor.",
     )
     require_local_disks: bool = Field(
         default=True,
@@ -1510,11 +1510,12 @@ class NflxCassandraArguments(BaseModel):
         # own state size or write rate unrepresentable.
         if not value:
             return value
-        total = math.fsum(entry.write_share for entry in value)
-        if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
-            raise ValueError(
-                f"keyspace_replication write_share must sum to 1.0, got {total}"
-            )
+        for field in ("state_size_share", "write_share"):
+            total = math.fsum(getattr(entry, field) for entry in value)
+            if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
+                raise ValueError(
+                    f"keyspace_replication {field} must sum to 1.0, got {total}"
+                )
         return value
 
     @classmethod
@@ -1672,9 +1673,9 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         """Price each keyspace replication placement separately and sum them.
 
         Every entry re-enters ``service_costs`` carrying its own share of the
-        plan's write rate, its own replication factor, and its own region count,
-        so an entry with ``num_regions == 1`` is charged no cross-region
-        replication at all.
+        plan's state size and write rate, its own replication factor, and its own
+        region count, so an entry with ``num_regions == 1`` is charged no
+        cross-region replication at all.
 
         **Entries are scoped to this region, and a single-region entry is priced
         as a whole.** Regional plans return an additive share so that summing all
@@ -1685,22 +1686,28 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         list such an entry in that one region's input only; repeating it in every
         region's input multiplies it by the region count.
 
-        Stored bytes are deliberately not split. The backup snapshot depends on
-        what a region holds, not on how many regions hold it, so it is computed
-        once from the plan's own state size; only the upload volume, which scales
-        with write fan-out, is summed per placement.
+        Backup is charged once over the whole plan because the snapshot floor and
+        retention are per-plan, but the snapshot is accumulated *per placement*:
+        it is state size times replication factor, and the factor differs between
+        placements, so one factor over the whole plan would misprice any cluster
+        whose keyspaces do not share an RF.
         """
         entries = args.keyspace_replication or []
         if not entries:
             return []
+        plan_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
         plan_write_per_second = desires.query_pattern.estimated_write_per_second.mid
         charge_backup = _backup_charged(context, desires, args)
 
         services_by_type: Dict[str, ServiceCapacity] = {}
+        snapshot_gib = 0
         daily_write_gib = 0.0
         backup_placements: List[Dict[str, Any]] = []
         for entry in entries:
             entry_desires = desires.model_copy(deep=True)
+            entry_desires.data_shape.estimated_state_size_gib = certain_float(
+                plan_state_size_gib * entry.state_size_share
+            )
             entry_desires.query_pattern.estimated_write_per_second = certain_float(
                 plan_write_per_second * entry.write_share
             )
@@ -1741,26 +1748,22 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                 )
 
             if charge_backup:
-                # Only the upload volume is placement-sensitive: it divides by the
-                # regions a write fans out to. The snapshot is charged once below,
-                # on the plan's own state size.
-                _, entry_daily_write_gib = _backup_components(
+                entry_snapshot_gib, entry_daily_write_gib = _backup_components(
                     entry_desires, entry_context, entry.copies_per_region
                 )
+                snapshot_gib += entry_snapshot_gib
                 daily_write_gib += entry_daily_write_gib
                 backup_placements.append(
                     {
                         "keyspaces": entry.keyspaces,
                         "copies_per_region": entry.copies_per_region,
                         "num_regions": entry.num_regions,
+                        "snapshot_gib": entry_snapshot_gib,
                         "daily_write_gib": round(entry_daily_write_gib, 1),
                     }
                 )
 
         if charge_backup:
-            snapshot_gib, _ = _backup_components(
-                desires, context, _target_rf(desires, args.copies_per_region)
-            )
             backup = _backup_service(
                 service_type,
                 context,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1676,6 +1676,15 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         so an entry with ``num_regions == 1`` is charged no cross-region
         replication at all.
 
+        **Entries are scoped to this region, and a single-region entry is priced
+        as a whole.** Regional plans return an additive share so that summing all
+        regions recovers the fleetwide cost, and that share is what
+        ``num_regions`` divides by. An entry with ``num_regions == 1`` therefore
+        comes back undivided -- correctly, because those keyspaces exist only
+        here and no other region's plan will contribute to them. Callers must
+        list such an entry in that one region's input only; repeating it in every
+        region's input multiplies it by the region count.
+
         Stored bytes are deliberately not split. The backup snapshot depends on
         what a region holds, not on how many regions hold it, so it is computed
         once from the plan's own state size; only the upload volume, which scales

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1387,10 +1387,11 @@ def keyspace_replication_by_region(
     fleetwide write rate. Normalising writes separately inside each regional list
     would inflate a global keyspace wherever it is the only local placement.
 
-    Returns a mapping keyed by region, ready to drop into that region's
-    ``extra_model_arguments["keyspace_replication"]``. Regions with no placements
-    are present with an empty list, which attributes no service cost -- rather
-    than being absent and silently falling back to single-replication pricing.
+    Returns a mapping whose keys are exactly the regions named by the placements,
+    ready to drop into each region's
+    ``extra_model_arguments["keyspace_replication"]``. Callers must validate that
+    those keys cover every deployed region; an omitted region could otherwise
+    silently fall back to single-replication pricing.
     """
     by_region: Dict[str, List[KeyspaceReplication]] = {
         region: [] for placement in placements for region in placement.regions

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1281,6 +1281,10 @@ class KeyspaceReplication(BaseModel):
     normalises them against each other. The plan's own totals stay the source of
     truth, so a breakdown cannot contradict them no matter what scale the caller
     works in, and there is no sum-to-one rule to get wrong.
+
+    Prefer :func:`keyspace_replication_by_region` over constructing these
+    directly; it derives correctly-scoped per-region inputs from the placements a
+    caller already has.
     """
 
     keyspaces: List[str] = Field(
@@ -1309,6 +1313,79 @@ class KeyspaceReplication(BaseModel):
         description="Relative amount of the plan's write rate these keyspaces"
         " receive, on the same footing as state_size_weight.",
     )
+
+
+class KeyspacePlacement(BaseModel):
+    """Where one set of keyspaces actually lives, as a caller measures it.
+
+    This is the shape a caller has: a keyspace, its replication factor, and the
+    regions it is deployed into. Hand these to
+    :func:`keyspace_replication_by_region` rather than assembling
+    :class:`KeyspaceReplication` lists directly -- the per-region scoping is easy
+    to get wrong by hand and wrong in a way that looks plausible.
+    """
+
+    keyspaces: List[str] = Field(
+        min_length=1,
+        description="Keyspaces sharing this placement.",
+    )
+    copies_per_region: int = Field(
+        gt=0,
+        description="Copies inside one region, e.g. RF=3.",
+    )
+    regions: List[str] = Field(
+        min_length=1,
+        description="Regions these keyspaces are deployed into. One region means"
+        " the data never leaves it, so no cross-region replication.",
+    )
+    state_size_weight: float = Field(
+        ge=0,
+        default=0.0,
+        description="Relative stored bytes, on any non-negative scale. Measured"
+        " GiB is the natural thing to pass.",
+    )
+    write_weight: float = Field(
+        ge=0,
+        default=0.0,
+        description="Relative write rate, on the same footing as"
+        " state_size_weight. Measured writes per second is the natural thing.",
+    )
+
+
+def keyspace_replication_by_region(
+    placements: List[KeyspacePlacement],
+) -> Dict[str, List[KeyspaceReplication]]:
+    """Per-region ``keyspace_replication`` inputs, scoped correctly by construction.
+
+    Each regional plan returns an additive share so that summing every region
+    recovers the fleetwide cost, and ``num_regions`` is the divisor. A placement
+    confined to one region therefore has to appear in *that region's* input only:
+    repeat it everywhere and it is counted once per region, which produces a
+    number that looks reasonable and is wrong by the region count.
+
+    Describing the placements once and deriving the per-region lists removes that
+    choice from the caller. ``num_regions`` is computed from the regions given
+    rather than passed separately, so it cannot disagree with them either.
+
+    Returns a mapping keyed by region, ready to drop into that region's
+    ``extra_model_arguments["keyspace_replication"]``. Regions with no placements
+    are present with an empty list, which attributes no service cost -- rather
+    than being absent and silently falling back to single-replication pricing.
+    """
+    by_region: Dict[str, List[KeyspaceReplication]] = {
+        region: [] for placement in placements for region in placement.regions
+    }
+    for placement in placements:
+        entry = KeyspaceReplication(
+            keyspaces=placement.keyspaces,
+            copies_per_region=placement.copies_per_region,
+            num_regions=len(set(placement.regions)),
+            state_size_weight=placement.state_size_weight,
+            write_weight=placement.write_weight,
+        )
+        for region in set(placement.regions):
+            by_region[region].append(entry)
+    return by_region
 
 
 class NflxCassandraArguments(BaseModel):
@@ -1663,9 +1740,12 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         regions recovers the fleetwide cost, and that share is what
         ``num_regions`` divides by. An entry with ``num_regions == 1`` therefore
         comes back undivided -- correctly, because those keyspaces exist only
-        here and no other region's plan will contribute to them. Callers must
-        list such an entry in that one region's input only; repeating it in every
-        region's input multiplies it by the region count.
+        here and no other region's plan will contribute to them.
+
+        Build these with :func:`keyspace_replication_by_region` rather than by
+        hand. It takes the placements a caller actually measures and derives the
+        per-region lists, so the scoping above is satisfied by construction
+        instead of being a rule to remember.
 
         Backup is charged once over the whole plan because the snapshot floor and
         retention are per-plan, but the snapshot is accumulated *per placement*:

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1196,6 +1196,24 @@ def _target_rf(desires: CapacityDesires, user_copies: Optional[int]) -> int:
     return 3
 
 
+def _capacity_rf(desires: CapacityDesires, args: "NflxCassandraArguments") -> int:
+    """Resolve the one replication factor used for regional capacity sizing."""
+    entries = args.keyspace_replication
+    if entries is None:
+        return _target_rf(desires, args.copies_per_region)
+    if not entries:
+        raise ValueError(
+            "keyspace_replication must contain at least one placement for "
+            "capacity planning"
+        )
+    factors = {entry.copies_per_region for entry in entries}
+    if len(factors) != 1:
+        raise ValueError(
+            "mixed keyspace replication factors are not supported for capacity planning"
+        )
+    return factors.pop()
+
+
 def _adaptive_storage_buffer_ratio(
     zonal_data_gib: float,
     max_ratio: float = 4.0,
@@ -1269,7 +1287,7 @@ def _adaptive_compute_buffer_ratio(
 
 
 class KeyspaceReplication(BaseModel):
-    """How one set of keyspaces is replicated, and its share of the load.
+    """Planner-ready regional share for one keyspace replication placement.
 
     A Cassandra cluster can host keyspaces with different replication placements
     at once: some replicated to every region, others confined to a single region
@@ -1277,14 +1295,10 @@ class KeyspaceReplication(BaseModel):
     a write must cross, pricing the whole cluster at one placement charges
     phantom cross-region replication to the single-region keyspaces.
 
-    Weights are relative, not fractions: pass measured magnitudes and the model
-    normalises them against each other. The plan's own totals stay the source of
-    truth, so a breakdown cannot contradict them no matter what scale the caller
-    works in, and there is no sum-to-one rule to get wrong.
-
-    Prefer :func:`keyspace_replication_by_region` over constructing these
-    directly; it derives correctly-scoped per-region inputs from the placements a
-    caller already has.
+    Prefer :func:`keyspace_replication_by_region` over constructing these directly.
+    It accepts raw measured weights and derives both the regional scoping and the
+    shares. State shares are relative to this regional plan, while write shares are
+    relative to the fleetwide write rate carried by every regional plan.
     """
 
     keyspaces: List[str] = Field(
@@ -1301,17 +1315,16 @@ class KeyspaceReplication(BaseModel):
         description="How many regions these keyspaces replicate into. One means"
         " the data never leaves its region, so no cross-region replication.",
     )
-    state_size_weight: float = Field(
+    state_size_share: float = Field(
         ge=0,
-        description="Relative amount of the plan's stored bytes these keyspaces"
-        " hold. Any non-negative scale works -- measured GiB is fine -- because"
-        " weights are normalised against the other entries rather than being"
-        " required to sum to anything.",
+        le=1,
+        description="Share of this regional plan's stored bytes held by these"
+        " keyspaces.",
     )
-    write_weight: float = Field(
+    write_share: float = Field(
         ge=0,
-        description="Relative amount of the plan's write rate these keyspaces"
-        " receive, on the same footing as state_size_weight.",
+        le=1,
+        description="Share of the fleetwide write rate received by these keyspaces.",
     )
 
 
@@ -1341,14 +1354,15 @@ class KeyspacePlacement(BaseModel):
     state_size_weight: float = Field(
         ge=0,
         default=0.0,
-        description="Relative stored bytes, on any non-negative scale. Measured"
-        " GiB is the natural thing to pass.",
+        description="Relative stored bytes held in each participating region, on"
+        " any non-negative scale. The helper normalises these within each regional"
+        " plan.",
     )
     write_weight: float = Field(
         ge=0,
         default=0.0,
-        description="Relative write rate, on the same footing as"
-        " state_size_weight. Measured writes per second is the natural thing.",
+        description="Relative fleetwide write rate, on any non-negative scale."
+        " Measured writes per second is the natural thing to pass.",
     )
 
 
@@ -1367,6 +1381,12 @@ def keyspace_replication_by_region(
     choice from the caller. ``num_regions`` is computed from the regions given
     rather than passed separately, so it cannot disagree with them either.
 
+    State weights are normalised among the placements present in each region,
+    because every plan carries that region's state size. Write weights are
+    normalised once across all placements, because every plan carries the same
+    fleetwide write rate. Normalising writes separately inside each regional list
+    would inflate a global keyspace wherever it is the only local placement.
+
     Returns a mapping keyed by region, ready to drop into that region's
     ``extra_model_arguments["keyspace_replication"]``. Regions with no placements
     are present with an empty list, which attributes no service cost -- rather
@@ -1375,16 +1395,32 @@ def keyspace_replication_by_region(
     by_region: Dict[str, List[KeyspaceReplication]] = {
         region: [] for placement in placements for region in placement.regions
     }
-    for placement in placements:
-        entry = KeyspaceReplication(
-            keyspaces=placement.keyspaces,
-            copies_per_region=placement.copies_per_region,
-            num_regions=len(set(placement.regions)),
-            state_size_weight=placement.state_size_weight,
-            write_weight=placement.write_weight,
+    write_weight_total = math.fsum(placement.write_weight for placement in placements)
+    for region in by_region:
+        regional_placements = [
+            placement for placement in placements if region in placement.regions
+        ]
+        state_weight_total = math.fsum(
+            placement.state_size_weight for placement in regional_placements
         )
-        for region in set(placement.regions):
-            by_region[region].append(entry)
+        for placement in regional_placements:
+            by_region[region].append(
+                KeyspaceReplication(
+                    keyspaces=placement.keyspaces,
+                    copies_per_region=placement.copies_per_region,
+                    num_regions=len(set(placement.regions)),
+                    state_size_share=(
+                        placement.state_size_weight / state_weight_total
+                        if state_weight_total
+                        else 0.0
+                    ),
+                    write_share=(
+                        placement.write_weight / write_weight_total
+                        if write_weight_total
+                        else 0.0
+                    ),
+                )
+            )
     return by_region
 
 
@@ -1398,16 +1434,20 @@ class NflxCassandraArguments(BaseModel):
     copies_per_region: Optional[int] = Field(
         default=None,
         description="How many copies of the data will exist e.g. RF=3. If unsupplied"
-        " this will be deduced from durability and consistency desires",
+        " this will be deduced from durability and consistency desires. This is"
+        " the simple replication input and cannot be combined with"
+        " keyspace_replication.",
     )
     keyspace_replication: Optional[List[KeyspaceReplication]] = Field(
         default=None,
         description="Replication placements of the keyspaces this plan holds, used"
         " to attribute network and backup cost. When supplied, each entry is priced"
-        " at its own replication factor and region count using its normalised"
-        " weight of the plan's state size and write rate, and the results are"
-        " summed. An empty list attributes no service cost. When unsupplied, the"
-        " whole plan is priced at one replication factor.",
+        " at its own replication factor and region count using its share of the"
+        " plan's state size and write rate, and the results are summed. Placements"
+        " are authoritative when supplied, so copies_per_region must be omitted."
+        " Capacity planning currently requires every placement to use the same"
+        " replication factor. When unsupplied, the whole plan is priced at one"
+        " replication factor.",
     )
     require_local_disks: bool = Field(
         default=True,
@@ -1559,6 +1599,14 @@ class NflxCassandraArguments(BaseModel):
     )
 
     @model_validator(mode="after")
+    def _check_replication_source(self) -> "NflxCassandraArguments":
+        if self.copies_per_region is not None and self.keyspace_replication is not None:
+            raise ValueError(
+                "copies_per_region and keyspace_replication are mutually exclusive"
+            )
+        return self
+
+    @model_validator(mode="after")
     def _check_storage_buffer_bounds(self) -> "NflxCassandraArguments":
         if self.min_storage_buffer_ratio > self.max_storage_buffer_ratio:
             raise ValueError(
@@ -1666,9 +1714,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                 service_type, context, desires, extra_model_arguments, args
             )
 
-        copies_per_region: int = _target_rf(
-            desires, extra_model_arguments.get("copies_per_region")
-        )
+        copies_per_region = _target_rf(desires, args.copies_per_region)
 
         # Compute overhead-adjusted wire write size for CRR network cost.
         # Cassandra mutations carry ~900B fixed overhead plus 1.42x proportional
@@ -1758,10 +1804,6 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             return []
         plan_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
         plan_write_per_second = desires.query_pattern.estimated_write_per_second.mid
-        # Normalising here is what makes the parts sum to the plan by
-        # construction. A zero total means nothing to attribute, not an error.
-        state_weight_total = math.fsum(entry.state_size_weight for entry in entries)
-        write_weight_total = math.fsum(entry.write_weight for entry in entries)
         charge_backup = _backup_charged(context, desires, args)
 
         services_by_type: Dict[str, ServiceCapacity] = {}
@@ -1771,14 +1813,10 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         for entry in entries:
             entry_desires = desires.model_copy(deep=True)
             entry_desires.data_shape.estimated_state_size_gib = certain_float(
-                plan_state_size_gib * entry.state_size_weight / state_weight_total
-                if state_weight_total
-                else 0.0
+                plan_state_size_gib * entry.state_size_share
             )
             entry_desires.query_pattern.estimated_write_per_second = certain_float(
-                plan_write_per_second * entry.write_weight / write_weight_total
-                if write_weight_total
-                else 0.0
+                plan_write_per_second * entry.write_share
             )
             entry_context = context.model_copy(
                 update={"num_regions": entry.num_regions}
@@ -1857,7 +1895,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         args = NflxCassandraArguments.from_extra_model_arguments(extra_model_arguments)
 
         # Use durability and consistency to compute RF if not explicitly set
-        copies_per_region = _target_rf(desires, args.copies_per_region)
+        copies_per_region = _capacity_rf(desires, args)
 
         # Validate required_cluster_size for critical tiers
         required_cluster_size: Optional[int] = (
@@ -1986,17 +2024,16 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                     f"User asked for {key}={value}"
                 )
 
+        args = NflxCassandraArguments.from_extra_model_arguments(extra_model_arguments)
+
         # Lower RF = less write compute
-        rf = _target_rf(
-            user_desires, extra_model_arguments.get("copies_per_region", None)
-        )
+        rf = _capacity_rf(user_desires, args)
         if rf < 3:
             rf_write_latency = Interval(low=0.2, mid=0.6, high=2, confidence=0.98)
         else:
             rf_write_latency = Interval(low=0.4, mid=1, high=2, confidence=0.98)
 
         # Compute adaptive storage buffer ratio based on data size
-        args = NflxCassandraArguments.from_extra_model_arguments(extra_model_arguments)
         storage_ratio = args.max_storage_buffer_ratio
         if args.adaptive_storage_buffer:
             storage_ratio = _adaptive_storage_buffer_ratio(

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -257,12 +257,14 @@ def _get_cores_from_desires(desires: CapacityDesires, instance: Instance) -> int
     return needed_cores
 
 
-def _get_disk_from_desires(desires: CapacityDesires, copies_per_region: int) -> int:
+def _get_raw_disk_from_desires(
+    desires: CapacityDesires, copies_per_region: int
+) -> float:
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
     # Do not add disk buffers now as memory calculation is done on the disk usage
-    return math.ceil(
+    return (
         (1.0 / desires.data_shape.estimated_compression_ratio.mid)
         * desires.data_shape.estimated_state_size_gib.mid
         * copies_per_region
@@ -270,21 +272,23 @@ def _get_disk_from_desires(desires: CapacityDesires, copies_per_region: int) -> 
     )
 
 
+def _get_disk_from_desires(desires: CapacityDesires, copies_per_region: int) -> int:
+    return math.ceil(_get_raw_disk_from_desires(desires, copies_per_region))
+
+
 def _backup_components(
     desires: CapacityDesires,
     context: RegionContext,
     copies_per_region: int,
-) -> Tuple[int, float]:
-    """Snapshot GiB per zone and daily backup upload GiB for one replication.
+) -> Tuple[float, float]:
+    """Raw replicated disk GiB and daily upload GiB for one replication.
 
     Backup storage is dominated by continuous SSTable uploads, not just the
     data-at-rest snapshot. The upload volume uses the overhead-adjusted wire
     size because SSTables include full serialized mutations (cell metadata,
     timestamps, bloom filter contributions), not just the raw app payload.
     """
-    snapshot_gib = (
-        _get_disk_from_desires(desires, copies_per_region) // context.zones_in_region
-    )
+    snapshot_disk_gib = _get_raw_disk_from_desires(desires, copies_per_region)
     wire_write_size = _cassandra_wire_write_size(
         desires.query_pattern.estimated_mean_write_size_bytes.mid
     )
@@ -292,7 +296,7 @@ def _backup_components(
     daily_write_gib = (wps * wire_write_size * 86400) / (
         (1024**3) * max(context.num_regions, 1)
     )
-    return snapshot_gib, daily_write_gib
+    return snapshot_disk_gib, daily_write_gib
 
 
 def _backup_charged(
@@ -1748,7 +1752,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         services.extend(net_services)
 
         if _backup_charged(context, desires, args):
-            snapshot_gib, daily_write_gib = _backup_components(
+            snapshot_disk_gib, daily_write_gib = _backup_components(
                 desires, context, copies_per_region
             )
             services.append(
@@ -1757,7 +1761,9 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                     context,
                     desires,
                     args,
-                    snapshot_gib=snapshot_gib,
+                    snapshot_gib=(
+                        math.ceil(snapshot_disk_gib) // context.zones_in_region
+                    ),
                     daily_write_gib=daily_write_gib,
                 )
             )
@@ -1805,7 +1811,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         charge_backup = _backup_charged(context, desires, args)
 
         services_by_type: Dict[str, ServiceCapacity] = {}
-        snapshot_gib = 0
+        placement_snapshot_disk_gib: List[float] = []
         daily_write_gib = 0.0
         backup_placements: List[Dict[str, Any]] = []
         for entry in entries:
@@ -1853,22 +1859,28 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
                 )
 
             if charge_backup:
-                entry_snapshot_gib, entry_daily_write_gib = _backup_components(
+                entry_snapshot_disk_gib, entry_daily_write_gib = _backup_components(
                     entry_desires, entry_context, entry.copies_per_region
                 )
-                snapshot_gib += entry_snapshot_gib
+                placement_snapshot_disk_gib.append(entry_snapshot_disk_gib)
                 daily_write_gib += entry_daily_write_gib
                 backup_placements.append(
                     {
                         "keyspaces": entry.keyspaces,
                         "copies_per_region": entry.copies_per_region,
                         "num_regions": entry.num_regions,
-                        "snapshot_gib": entry_snapshot_gib,
+                        "snapshot_gib": (
+                            entry_snapshot_disk_gib / context.zones_in_region
+                        ),
                         "daily_write_gib": round(entry_daily_write_gib, 1),
                     }
                 )
 
         if charge_backup:
+            snapshot_gib = (
+                math.ceil(math.fsum(placement_snapshot_disk_gib))
+                // context.zones_in_region
+            )
             backup = _backup_service(
                 service_type,
                 context,

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -14,6 +14,7 @@ from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 from pydantic import model_validator
 
 from service_capacity_modeling.enum_utils import enum_docstrings
@@ -179,6 +180,11 @@ _CASSANDRA_SERIALIZATION_AMPLIFICATION = 1.42
 # with different compaction strategies (TWCS) or aggressive TTLs.
 _DEFAULT_BACKUP_RETENTION_DAYS = 14.0
 
+# Float slack allowed when checking that keyspace replication shares partition
+# a plan. Shares are computed by a caller dividing measured telemetry, so exact
+# equality to 1.0 is not achievable.
+_KEYSPACE_SHARE_TOLERANCE = 1e-6
+
 # Known Cassandra write size defaults (from default_desires() and interface.py).
 # Used to detect whether estimated_mean_write_size_bytes was user-supplied or
 # model-defaulted. Interval has frozen=True (hashable), so set membership works.
@@ -267,6 +273,84 @@ def _get_disk_from_desires(desires: CapacityDesires, copies_per_region: int) -> 
         * desires.data_shape.estimated_state_size_gib.mid
         * copies_per_region
         * disk_buffer.ratio
+    )
+
+
+def _backup_components(
+    desires: CapacityDesires,
+    context: RegionContext,
+    copies_per_region: int,
+) -> Tuple[int, float]:
+    """Snapshot GiB per zone and daily backup upload GiB for one replication.
+
+    Backup storage is dominated by continuous SSTable uploads, not just the
+    data-at-rest snapshot. The upload volume uses the overhead-adjusted wire
+    size because SSTables include full serialized mutations (cell metadata,
+    timestamps, bloom filter contributions), not just the raw app payload.
+    """
+    snapshot_gib = (
+        _get_disk_from_desires(desires, copies_per_region) // context.zones_in_region
+    )
+    wire_write_size = _cassandra_wire_write_size(
+        desires.query_pattern.estimated_mean_write_size_bytes.mid
+    )
+    wps = desires.query_pattern.estimated_write_per_second.mid
+    daily_write_gib = (wps * wire_write_size * 86400) / (
+        (1024**3) * max(context.num_regions, 1)
+    )
+    return snapshot_gib, daily_write_gib
+
+
+def _backup_charged(
+    context: RegionContext,
+    desires: CapacityDesires,
+    args: "NflxCassandraArguments",
+) -> bool:
+    """Whether this plan is charged for backups at all.
+
+    Callers check this before computing backup components, so a plan with backup
+    switched off does no backup arithmetic -- and so cannot fail on a region
+    shape it never divides by.
+    """
+    if (
+        args.backup_retention_days == 0
+        or desires.data_shape.durability_slo_order.mid < 1000
+    ):
+        return False
+    return bool(context.services.get("blob.standard", None))
+
+
+def _backup_service(
+    service_type: str,
+    context: RegionContext,
+    desires: CapacityDesires,
+    args: "NflxCassandraArguments",
+    *,
+    snapshot_gib: int,
+    daily_write_gib: float,
+    extra_service_params: Optional[Dict[str, Any]] = None,
+) -> ServiceCapacity:
+    """Blob cost of retaining one plan's backups. Requires `_backup_charged`."""
+    blob = context.services["blob.standard"]
+    retention_days = (
+        _DEFAULT_BACKUP_RETENTION_DAYS
+        if args.backup_retention_days is None
+        else args.backup_retention_days
+    )
+    # The snapshot floor is a per-plan minimum, so callers summing several
+    # replication placements pass the already-summed snapshot and get one floor.
+    backup_disk_gib = max(1, snapshot_gib)
+    backup_total_gib = backup_disk_gib + daily_write_gib * retention_days
+    return ServiceCapacity(
+        service_type=f"{service_type}.backup.{blob.name}",
+        annual_cost=blob.annual_cost_gib(backup_total_gib),
+        service_params={
+            "snapshot_gib": backup_disk_gib,
+            "daily_write_gib": round(daily_write_gib, 1),
+            "retention_days": retention_days,
+            "write_size_defaulted": _is_write_size_defaulted(desires),
+            **(extra_service_params or {}),
+        },
     )
 
 
@@ -1100,7 +1184,10 @@ def _cass_io_per_read(node_size_gib: float, sstable_size_mb: int = 160) -> int:
 
 def _target_rf(desires: CapacityDesires, user_copies: Optional[int]) -> int:
     if user_copies is not None:
-        assert user_copies > 1
+        # An explicitly supplied factor is taken as measured fact, including
+        # RF=1: a single-replica keyspace is unwise but real, and costing it
+        # correctly matters more than refusing to model it.
+        assert user_copies > 0
         return user_copies
 
     # Due to the relaxed durability and consistency requirements we can
@@ -1187,6 +1274,44 @@ def _adaptive_compute_buffer_ratio(
     return max_ratio - t * (max_ratio - min_ratio)
 
 
+class KeyspaceReplication(BaseModel):
+    """How one set of keyspaces is replicated, and its share of the load.
+
+    A Cassandra cluster can host keyspaces with different replication placements
+    at once: some replicated to every region, others confined to a single region
+    with no cross-region replication. Since network cost scales with the regions
+    a write must cross, pricing the whole cluster at one placement charges
+    phantom cross-region replication to the single-region keyspaces.
+    """
+
+    keyspaces: List[str] = Field(
+        min_length=1,
+        description="Keyspaces sharing this replication placement.",
+    )
+    copies_per_region: int = Field(
+        gt=0,
+        description="How many copies of these keyspaces exist inside one region,"
+        " e.g. RF=3.",
+    )
+    num_regions: int = Field(
+        gt=0,
+        description="How many regions these keyspaces replicate into. One means"
+        " the data never leaves its region, so no cross-region replication.",
+    )
+    state_size_share: float = Field(
+        ge=0,
+        le=1,
+        description="Fraction of the plan's estimated_state_size_gib that these"
+        " keyspaces hold.",
+    )
+    write_share: float = Field(
+        ge=0,
+        le=1,
+        description="Fraction of the plan's estimated_write_per_second that these"
+        " keyspaces receive.",
+    )
+
+
 class NflxCassandraArguments(BaseModel):
     """Configuration arguments for the Netflix Cassandra capacity model.
 
@@ -1198,6 +1323,15 @@ class NflxCassandraArguments(BaseModel):
         default=None,
         description="How many copies of the data will exist e.g. RF=3. If unsupplied"
         " this will be deduced from durability and consistency desires",
+    )
+    keyspace_replication: Optional[List[KeyspaceReplication]] = Field(
+        default=None,
+        description="Replication placements of the keyspaces this plan holds, used"
+        " to attribute network and backup cost. When supplied, each entry is priced"
+        " at its own replication factor and region count using its share of the"
+        " plan's state size and write rate, and the results are summed. An empty"
+        " list attributes no service cost. When unsupplied, the whole plan is"
+        " priced at one replication factor.",
     )
     require_local_disks: bool = Field(
         default=True,
@@ -1366,6 +1500,24 @@ class NflxCassandraArguments(BaseModel):
             )
         return self
 
+    @field_validator("keyspace_replication")
+    @classmethod
+    def _check_replication_shares(
+        cls, value: Optional[List[KeyspaceReplication]]
+    ) -> Optional[List[KeyspaceReplication]]:
+        # The placements partition one plan, so their shares must account for all
+        # of it. Requiring that here makes a breakdown that contradicts the plan's
+        # own state size or write rate unrepresentable.
+        if not value:
+            return value
+        for field in ("state_size_share", "write_share"):
+            total = math.fsum(getattr(entry, field) for entry in value)
+            if abs(total - 1.0) > _KEYSPACE_SHARE_TOLERANCE:
+                raise ValueError(
+                    f"keyspace_replication {field} must sum to 1.0, got {total}"
+                )
+        return value
+
     @classmethod
     def from_extra_model_arguments(
         cls, extra_model_arguments: Dict[str, Any]
@@ -1445,8 +1597,17 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
         and backup write-throughput costs so summing all regions recovers the
         fleetwide cost. The schema-backed ``backup_retention_days`` argument owns
         backup inclusion and retention; it does not affect network costs.
+
+        When ``keyspace_replication`` is supplied, the plan is instead priced once
+        per replication placement and summed, so keyspaces that never leave their
+        region are not charged cross-region replication.
         """
         args = NflxCassandraArguments.from_extra_model_arguments(extra_model_arguments)
+        if args.keyspace_replication is not None:
+            return NflxCassandraCapacityModel._replicated_service_costs(
+                service_type, context, desires, extra_model_arguments, args
+            )
+
         copies_per_region: int = _target_rf(
             desires, extra_model_arguments.get("copies_per_region")
         )
@@ -1484,52 +1645,122 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             svc.service_params["write_size_defaulted"] = write_size_defaulted
         services.extend(net_services)
 
-        if (
-            args.backup_retention_days != 0
-            and desires.data_shape.durability_slo_order.mid >= 1000
-        ):
-            blob = context.services.get("blob.standard", None)
-            if blob:
-                # Snapshot component: data-at-rest per zone
-                backup_disk_gib = max(
-                    1,
-                    _get_disk_from_desires(desires, copies_per_region)
-                    // context.zones_in_region,
+        if _backup_charged(context, desires, args):
+            snapshot_gib, daily_write_gib = _backup_components(
+                desires, context, copies_per_region
+            )
+            services.append(
+                _backup_service(
+                    service_type,
+                    context,
+                    desires,
+                    args,
+                    snapshot_gib=snapshot_gib,
+                    daily_write_gib=daily_write_gib,
                 )
-
-                # Write-throughput component: backup storage is dominated by
-                # continuous SSTable uploads, not just the data-at-rest snapshot.
-                # Uses overhead-adjusted wire size because SSTables include
-                # full serialized mutations (cell metadata, timestamps, bloom
-                # filter contributions), not just raw app payload.
-                wps = desires.query_pattern.estimated_write_per_second.mid
-                write_region_count = max(context.num_regions, 1)
-                daily_write_gib = (wps * wire_write_size * 86400) / (
-                    (1024**3) * write_region_count
-                )
-                retention_days = (
-                    _DEFAULT_BACKUP_RETENTION_DAYS
-                    if args.backup_retention_days is None
-                    else args.backup_retention_days
-                )
-
-                # Total = state snapshot + retained write volume
-                backup_total_gib = backup_disk_gib + daily_write_gib * retention_days
-
-                services.append(
-                    ServiceCapacity(
-                        service_type=f"{service_type}.backup.{blob.name}",
-                        annual_cost=blob.annual_cost_gib(backup_total_gib),
-                        service_params={
-                            "snapshot_gib": backup_disk_gib,
-                            "daily_write_gib": round(daily_write_gib, 1),
-                            "retention_days": retention_days,
-                            "write_size_defaulted": write_size_defaulted,
-                        },
-                    )
-                )
+            )
 
         return services
+
+    @staticmethod
+    def _replicated_service_costs(
+        service_type: str,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+        args: NflxCassandraArguments,
+    ) -> List[ServiceCapacity]:
+        """Price each keyspace replication placement separately and sum them.
+
+        Every entry re-enters ``service_costs`` carrying its own share of the
+        plan's state size and write rate, its own replication factor, and its own
+        region count, so an entry with ``num_regions == 1`` is charged no
+        cross-region replication at all. Backup is charged once over the whole
+        plan because the snapshot floor and retention are per-plan.
+        """
+        entries = args.keyspace_replication or []
+        if not entries:
+            return []
+        plan_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
+        plan_write_per_second = desires.query_pattern.estimated_write_per_second.mid
+        charge_backup = _backup_charged(context, desires, args)
+
+        services_by_type: Dict[str, ServiceCapacity] = {}
+        snapshot_gib = 0
+        daily_write_gib = 0.0
+        backup_placements: List[Dict[str, Any]] = []
+        for entry in entries:
+            entry_desires = desires.model_copy(deep=True)
+            entry_desires.data_shape.estimated_state_size_gib = certain_float(
+                plan_state_size_gib * entry.state_size_share
+            )
+            entry_desires.query_pattern.estimated_write_per_second = certain_float(
+                plan_write_per_second * entry.write_share
+            )
+            entry_context = context.model_copy(
+                update={"num_regions": entry.num_regions}
+            )
+            entry_arguments = dict(extra_model_arguments)
+            # Dropping the placements is what ends the recursion: the inner call
+            # takes the single-replication path for this entry alone. Backup is
+            # disabled there so it is charged once, on the summed snapshot.
+            entry_arguments.pop("keyspace_replication", None)
+            entry_arguments["copies_per_region"] = entry.copies_per_region
+            entry_arguments["backup_retention_days"] = 0
+            for service in NflxCassandraCapacityModel.service_costs(
+                service_type, entry_context, entry_desires, entry_arguments
+            ):
+                aggregate = services_by_type.setdefault(
+                    service.service_type,
+                    ServiceCapacity(
+                        service_type=service.service_type,
+                        annual_cost=0,
+                        service_params={
+                            "write_size_defaulted": service.service_params.get(
+                                "write_size_defaulted", False
+                            ),
+                            "placements": [],
+                        },
+                    ),
+                )
+                aggregate.annual_cost += service.annual_cost
+                aggregate.service_params["placements"].append(
+                    {
+                        "keyspaces": entry.keyspaces,
+                        "copies_per_region": entry.copies_per_region,
+                        "num_regions": entry.num_regions,
+                        "annual_cost": service.annual_cost,
+                    }
+                )
+
+            if charge_backup:
+                entry_snapshot_gib, entry_daily_write_gib = _backup_components(
+                    entry_desires, entry_context, entry.copies_per_region
+                )
+                snapshot_gib += entry_snapshot_gib
+                daily_write_gib += entry_daily_write_gib
+                backup_placements.append(
+                    {
+                        "keyspaces": entry.keyspaces,
+                        "copies_per_region": entry.copies_per_region,
+                        "num_regions": entry.num_regions,
+                        "snapshot_gib": entry_snapshot_gib,
+                        "daily_write_gib": round(entry_daily_write_gib, 1),
+                    }
+                )
+
+        if charge_backup:
+            backup = _backup_service(
+                service_type,
+                context,
+                desires,
+                args,
+                snapshot_gib=snapshot_gib,
+                daily_write_gib=daily_write_gib,
+                extra_service_params={"placements": backup_placements},
+            )
+            services_by_type[backup.service_type] = backup
+        return list(services_by_type.values())
 
     @staticmethod
     def capacity_plan(

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -1601,11 +1601,33 @@ class NflxCassandraArguments(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_replication_source(self) -> "NflxCassandraArguments":
+    def _check_replication_source(  # pylint: disable=not-an-iterable
+        self,
+    ) -> "NflxCassandraArguments":
         if self.copies_per_region is not None and self.keyspace_replication is not None:
             raise ValueError(
                 "copies_per_region and keyspace_replication are mutually exclusive"
             )
+        entries = self.keyspace_replication or []
+        if entries:
+            state_size_share_total = math.fsum(
+                entry.state_size_share for entry in entries
+            )
+            if not (
+                math.isclose(state_size_share_total, 0.0, abs_tol=1e-6)
+                or math.isclose(state_size_share_total, 1.0, abs_tol=1e-6)
+            ):
+                raise ValueError(
+                    "keyspace_replication state_size_share total must be "
+                    "approximately 0 or 1"
+                )
+            write_share_total = math.fsum(entry.write_share for entry in entries)
+            if write_share_total > 1 and not math.isclose(
+                write_share_total, 1.0, abs_tol=1e-6
+            ):
+                raise ValueError(
+                    "keyspace_replication write_share total must be at most 1"
+                )
         return self
 
     @model_validator(mode="after")

--- a/service_capacity_modeling/models/org/netflix/cassandra.py
+++ b/service_capacity_modeling/models/org/netflix/cassandra.py
@@ -718,6 +718,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     drive: Drive,
     context: RegionContext,
     desires: CapacityDesires,
+    extra_model_arguments: Dict[str, Any],
     zones_per_region: int = 3,
     copies_per_region: int = 3,
     require_local_disks: bool = False,
@@ -734,7 +735,6 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
     large_instance_regret: float = 0.2,
     different_family_regret: float = 0.10,
     max_page_cache_gib: float = DEFAULT_MAX_PAGE_CACHE_GIB,
-    backup_retention_days: Optional[float] = None,
     max_disk_utilization: float = CASSANDRA_MAX_DISK_UTILIZATION,
     min_instance_ram_gib_exclusive: float = 16.0,
     observed_ebs_read_io_per_read: Optional[float] = None,
@@ -1123,10 +1123,7 @@ def _estimate_cassandra_cluster_zonal(  # pylint: disable=too-many-positional-ar
         service_type=NflxCassandraCapacityModel.service_name,
         context=context,
         desires=desires,
-        extra_model_arguments={
-            "copies_per_region": copies_per_region,
-            "backup_retention_days": backup_retention_days,
-        },
+        extra_model_arguments=extra_model_arguments,
     )
 
     cluster.cluster_type = NflxCassandraCapacityModel.cluster_type
@@ -1922,6 +1919,7 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             drive=drive,
             context=context,
             desires=desires,
+            extra_model_arguments=extra_model_arguments,
             zones_per_region=context.zones_in_region,
             copies_per_region=copies_per_region,
             require_local_disks=args.require_local_disks,
@@ -1939,7 +1937,6 @@ class NflxCassandraCapacityModel(CapacityModel, CostAwareModel):
             large_instance_regret=args.large_instance_regret,
             different_family_regret=args.different_family_regret,
             max_page_cache_gib=args.max_page_cache_gib,
-            backup_retention_days=args.backup_retention_days,
             max_disk_utilization=args.max_disk_utilization,
             min_instance_ram_gib_exclusive=args.min_instance_ram_gib_exclusive,
             observed_ebs_read_io_per_read=args.observed_ebs_read_io_per_read,

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -31,7 +31,6 @@ from service_capacity_modeling.models.org.netflix.cassandra import (
     _get_min_count,
     CassandraClusterSizeMode,
     KeyspaceReplication,
-    NflxCassandraArguments,
     NflxCassandraCapacityModel,
 )
 from tests.util import assert_minimum_storage_gib
@@ -1350,7 +1349,7 @@ class TestCassandraServiceCosts:
         ] == [["rf2"], ["rf3"]]
 
     def test_keyspace_replication_empty_disables_service_costs(self):
-        assert self._services(keyspace_replication=[]) == []
+        assert not self._services(keyspace_replication=[])
 
     def test_keyspace_replication_prices_a_single_replica_keyspace(self):
         # RF=1 is unwise but real, and a measured factor is taken as fact. There
@@ -1434,6 +1433,10 @@ class TestCassandraServiceCosts:
             },
         ]
         entries[1][field] = share
+
+        from service_capacity_modeling.models.org.netflix.cassandra import (
+            NflxCassandraArguments,
+        )
 
         with pytest.raises(ValueError, match=f"{field} must sum to 1.0"):
             NflxCassandraArguments.from_extra_model_arguments(

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1362,6 +1362,38 @@ class TestCassandraServiceCosts:
             ]
         ] == [["rf2"], ["rf3"]]
 
+    def test_single_region_entry_is_priced_whole_not_as_a_regional_share(self):
+        # Regional plans return a share that sums to the fleet cost across
+        # regions, and `num_regions` is the divisor. A single-region entry has no
+        # other region contributing to it, so it must come back undivided -- and
+        # a caller must therefore list it in one region's input only. Getting
+        # this wrong multiplies that entry by the region count, which looks like
+        # a plausible number rather than an error.
+        confined = KeyspaceReplication(
+            keyspaces=["local_only"],
+            copies_per_region=3,
+            num_regions=1,
+            write_share=1.0,
+        )
+        spread = confined.model_copy(update={"num_regions": 4})
+
+        one_region = {
+            s.service_type: s.annual_cost
+            for s in self._services(num_regions=4, keyspace_replication=[confined])
+        }
+        four_regions = {
+            s.service_type: s.annual_cost
+            for s in self._services(num_regions=4, keyspace_replication=[spread])
+        }
+
+        assert one_region["cassandra.net.inter.region"] == 0
+        assert four_regions["cassandra.net.inter.region"] > 0
+        # Same writes, same RF: the confined entry is the whole cost, the spread
+        # entry is this region's quarter of it.
+        assert one_region["cassandra.net.intra.region"] == pytest.approx(
+            four_regions["cassandra.net.intra.region"] * 4
+        )
+
     def test_keyspace_replication_empty_disables_service_costs(self):
         assert not self._services(keyspace_replication=[])
 

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -868,13 +868,13 @@ class TestCassandraCurrentCapacity:
 
 class TestCassandraReplicationArguments:
     @staticmethod
-    def _replication_entry(copies_per_region=3, keyspace="events"):
+    def _replication_entry(copies_per_region=3, keyspace="events", share=1.0):
         return {
             "keyspaces": [keyspace],
             "copies_per_region": copies_per_region,
             "num_regions": 2,
-            "state_size_share": 1.0,
-            "write_share": 1.0,
+            "state_size_share": share,
+            "write_share": share,
         }
 
     def test_replication_inputs_are_mutually_exclusive(self):
@@ -884,6 +884,55 @@ class TestCassandraReplicationArguments:
                     "copies_per_region": 3,
                     "keyspace_replication": [self._replication_entry()],
                 }
+            )
+
+    @pytest.mark.parametrize(
+        "state_size_share, write_share",
+        [
+            (0.0, 0.0),
+            (0.00000025, 0.0),
+            (0.50000025, 0.50000025),
+            (0.5, 0.25),
+        ],
+    )
+    def test_replication_share_totals_accept_valid_rounding_and_partial_writes(
+        self, state_size_share, write_share
+    ):
+        NflxCassandraArguments.from_extra_model_arguments(
+            {
+                "keyspace_replication": [
+                    {
+                        **self._replication_entry(keyspace=f"keyspace-{index}"),
+                        "state_size_share": state_size_share,
+                        "write_share": write_share,
+                    }
+                    for index in range(2)
+                ]
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "state_size_share, write_share, invalid_total",
+        [
+            (0.45, 0.5, "state_size_share"),
+            (0.5, 0.6, "write_share"),
+        ],
+    )
+    def test_replication_share_totals_reject_invalid_aggregates(
+        self, state_size_share, write_share, invalid_total
+    ):
+        entries = [
+            {
+                **self._replication_entry(keyspace=f"keyspace-{index}"),
+                "state_size_share": state_size_share,
+                "write_share": write_share,
+            }
+            for index in range(2)
+        ]
+
+        with pytest.raises(ValueError, match=f"{invalid_total} total"):
+            NflxCassandraArguments.from_extra_model_arguments(
+                {"keyspace_replication": entries}
             )
 
     def test_capacity_plan_derives_rf_from_keyspace_replication(self):
@@ -943,8 +992,8 @@ class TestCassandraReplicationArguments:
     def test_capacity_plan_requires_one_replication_factor(self, keyspace_replication):
         if keyspace_replication == "mixed":
             keyspace_replication = [
-                self._replication_entry(2),
-                self._replication_entry(3, "sessions"),
+                self._replication_entry(2, share=0.5),
+                self._replication_entry(3, "sessions", share=0.5),
             ]
         hardware = shapes.region("us-east-1")
 

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1511,40 +1511,6 @@ class TestCassandraServiceCosts:
             four_regions["cassandra.net.intra.region"] * 4
         )
 
-    def test_backup_snapshot_follows_each_placement_replication_factor(self):
-        # The snapshot is state size times replication factor, so when placements
-        # do not share an RF the snapshot has to accumulate per placement. Using
-        # one factor over the whole plan overcharges the lower-RF share -- for
-        # 30% at RF2 and 70% at RF3 it bills 450 GiB against a true 405.
-        entries = [
-            KeyspaceReplication(
-                keyspaces=["rf2"],
-                copies_per_region=2,
-                num_regions=2,
-                state_size_share=0.3,
-                write_share=0.5,
-            ),
-            KeyspaceReplication(
-                keyspaces=["rf3"],
-                copies_per_region=3,
-                num_regions=2,
-                state_size_share=0.7,
-                write_share=0.5,
-            ),
-        ]
-
-        services = {
-            service.service_type: service
-            for service in self._services(num_regions=2, keyspace_replication=entries)
-        }
-        backup = services["cassandra.backup.s3-standard"]
-
-        assert [
-            placement["snapshot_gib"]
-            for placement in backup.service_params["placements"]
-        ] == [90, 315]
-        assert backup.service_params["snapshot_gib"] == 405
-
     def test_backup_snapshot_rounds_after_summing_placements(self):
         entries = [
             KeyspaceReplication(

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -909,6 +909,36 @@ class TestCassandraReplicationArguments:
             == 2
         )
 
+    def test_capacity_plan_prices_confined_keyspace_without_inter_region_cost(self):
+        hardware = shapes.region("us-east-1")
+        result = NflxCassandraCapacityModel.capacity_plan(
+            instance=hardware.instances["m6id.2xlarge"],
+            drive=hardware.drives["gp3"],
+            context=RegionContext(
+                zones_in_region=hardware.zones_in_region,
+                num_regions=4,
+                services=hardware.services,
+            ),
+            desires=small_but_high_qps,
+            extra_model_arguments={
+                "require_local_disks": False,
+                "keyspace_replication": [
+                    {
+                        **self._replication_entry(),
+                        "num_regions": 1,
+                    }
+                ],
+            },
+        )
+
+        assert result is not None
+        assert not isinstance(result, Excuse)
+        services = {
+            service.service_type: service
+            for service in result.candidate_clusters.services
+        }
+        assert services["cassandra.net.inter.region"].annual_cost == 0
+
     @pytest.mark.parametrize("keyspace_replication", [[], "mixed"])
     def test_capacity_plan_requires_one_replication_factor(self, keyspace_replication):
         if keyspace_replication == "mixed":

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -30,6 +30,8 @@ from service_capacity_modeling.models.org.netflix.cassandra import (
     _get_cluster_size_lambda,
     _get_min_count,
     CassandraClusterSizeMode,
+    keyspace_replication_by_region,
+    KeyspacePlacement,
     KeyspaceReplication,
     NflxCassandraCapacityModel,
 )
@@ -1417,6 +1419,66 @@ class TestCassandraServiceCosts:
         # The single-RF whole-plan figure, which is what a collapsed snapshot
         # would have produced.
         assert backup.service_params["snapshot_gib"] != 450
+
+    def test_placements_derive_per_region_inputs_scoped_to_where_they_live(self):
+        # The shape a caller actually has: a keyspace, its RF, and the regions it
+        # is deployed into. Deriving the per-region inputs means the caller never
+        # chooses whether a confined placement appears in one region or all four
+        # -- the choice that is easy to get wrong and wrong by the region count.
+        regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1"]
+        by_region = keyspace_replication_by_region(
+            [
+                KeyspacePlacement(
+                    keyspaces=["events"],
+                    copies_per_region=3,
+                    regions=regions,
+                    state_size_weight=1200.0,
+                    write_weight=40.0,
+                ),
+                KeyspacePlacement(
+                    keyspaces=["events_useast1"],
+                    copies_per_region=3,
+                    regions=["us-east-1"],
+                    state_size_weight=600.0,
+                    write_weight=90.0,
+                ),
+            ]
+        )
+
+        assert set(by_region) == set(regions)
+        # The confined placement lands only where it lives.
+        assert [entry.keyspaces for entry in by_region["us-east-1"]] == [
+            ["events"],
+            ["events_useast1"],
+        ]
+        assert [entry.keyspaces for entry in by_region["eu-west-1"]] == [["events"]]
+        # num_regions is derived from the regions, so it cannot disagree with them.
+        assert [entry.num_regions for entry in by_region["us-east-1"]] == [4, 1]
+
+    def test_derived_inputs_charge_no_cross_region_transfer_for_a_confined_keyspace(
+        self,
+    ):
+        # End to end through the helper: the region hosting a confined keyspace
+        # pays cross-region transfer only for the globally replicated one.
+        by_region = keyspace_replication_by_region(
+            [
+                KeyspacePlacement(
+                    keyspaces=["events_useast1"],
+                    copies_per_region=3,
+                    regions=["us-east-1"],
+                    write_weight=100.0,
+                ),
+            ]
+        )
+
+        costs = {
+            service.service_type: service.annual_cost
+            for service in self._services(
+                num_regions=4, keyspace_replication=by_region["us-east-1"]
+            )
+        }
+
+        assert costs["cassandra.net.inter.region"] == 0
 
     def test_keyspace_replication_empty_disables_service_costs(self):
         assert not self._services(keyspace_replication=[])

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1495,9 +1495,34 @@ class TestCassandraServiceCosts:
             for placement in backup.service_params["placements"]
         ] == [90, 315]
         assert backup.service_params["snapshot_gib"] == 405
-        # The single-RF whole-plan figure, which is what a collapsed snapshot
-        # would have produced.
-        assert backup.service_params["snapshot_gib"] != 450
+
+    def test_backup_snapshot_rounds_after_summing_placements(self):
+        entries = [
+            KeyspaceReplication(
+                keyspaces=[f"keyspace-{index}"],
+                copies_per_region=3,
+                num_regions=1,
+                state_size_share=0.01,
+                write_share=0.01,
+            )
+            for index in range(100)
+        ]
+
+        services = {
+            service.service_type: service
+            for service in self._services(
+                num_regions=1,
+                state_size_gib=20,
+                keyspace_replication=entries,
+            )
+        }
+        backup = services["cassandra.backup.s3-standard"]
+
+        assert backup.service_params["snapshot_gib"] == 30
+        assert sum(
+            placement["snapshot_gib"]
+            for placement in backup.service_params["placements"]
+        ) == pytest.approx(30)
 
     def test_placements_derive_per_region_inputs_scoped_to_where_they_live(self):
         # The shape a caller actually has: a keyspace, its RF, and the regions it

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1264,7 +1264,6 @@ class TestCassandraServiceCosts:
                         keyspaces=["one"],
                         copies_per_region=3,
                         num_regions=1,
-                        state_size_share=1.0,
                         write_share=1.0,
                     )
                 ],
@@ -1295,14 +1294,12 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
-                state_size_share=0.3,
                 write_share=0.4,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
-                state_size_share=0.7,
                 write_share=0.6,
             ),
         ]
@@ -1317,7 +1314,6 @@ class TestCassandraServiceCosts:
                     service.service_type: service
                     for service in self._services(
                         num_regions=entry.num_regions,
-                        state_size_gib=300 * entry.state_size_share,
                         writes_per_second=100 * entry.write_share,
                         copies_per_region=entry.copies_per_region,
                         **overrides,
@@ -1326,21 +1322,39 @@ class TestCassandraServiceCosts:
                 for entry in entries
             ]
 
+        # Network cost is what placement changes, and it does not depend on stored
+        # bytes, so the parts must add up to independently modelling each entry.
         for service_type in (
             "cassandra.net.inter.region",
             "cassandra.net.intra.region",
-            "cassandra.backup.s3-standard",
         ):
             assert combined[service_type].annual_cost == pytest.approx(
                 sum(services[service_type].annual_cost for services in independently())
             ), service_type
 
+        # Backup splits differently on purpose: the snapshot is what the plan
+        # stores, charged once, while the upload volume follows write fan-out and
+        # so is summed per placement. Summing snapshots instead would count the
+        # same bytes once per placement.
+        whole_plan = {
+            service.service_type: service
+            for service in self._services(num_regions=2, writes_per_second=0)
+        }
         backup = combined["cassandra.backup.s3-standard"]
-        assert backup.service_params["snapshot_gib"] == 405
-        assert [
-            placement["snapshot_gib"]
-            for placement in backup.service_params["placements"]
-        ] == [90, 315]
+        assert (
+            backup.service_params["snapshot_gib"]
+            == whole_plan["cassandra.backup.s3-standard"].service_params["snapshot_gib"]
+        )
+        assert backup.service_params["daily_write_gib"] == pytest.approx(
+            sum(
+                services["cassandra.backup.s3-standard"].service_params[
+                    "daily_write_gib"
+                ]
+                for services in independently()
+            ),
+            abs=0.2,
+        )
+        assert "snapshot_gib" not in backup.service_params["placements"][0]
         assert [
             placement["keyspaces"]
             for placement in combined["cassandra.net.inter.region"].service_params[
@@ -1362,7 +1376,6 @@ class TestCassandraServiceCosts:
                         keyspaces=["unreplicated"],
                         copies_per_region=1,
                         num_regions=1,
-                        state_size_share=1.0,
                         write_share=1.0,
                     )
                 ]
@@ -1378,7 +1391,6 @@ class TestCassandraServiceCosts:
             keyspaces=["events_useast1"],
             copies_per_region=3,
             num_regions=1,
-            state_size_share=0.5,
             write_share=0.5,
         )
         global_keyspace = island.model_copy(
@@ -1413,32 +1425,29 @@ class TestCassandraServiceCosts:
         ] == [0, pytest.approx(mixed["cassandra.net.inter.region"].annual_cost)]
         assert mixed["cassandra.net.inter.region"].annual_cost > 0
 
-    @pytest.mark.parametrize("field", ["state_size_share", "write_share"])
     @pytest.mark.parametrize("share", [0.4, 0.6])
-    def test_keyspace_replication_shares_must_partition_the_plan(self, field, share):
+    def test_keyspace_replication_shares_must_partition_the_plan(self, share):
         entries = [
             {
                 "keyspaces": ["one"],
                 "copies_per_region": 3,
                 "num_regions": 1,
-                "state_size_share": 0.5,
                 "write_share": 0.5,
             },
             {
                 "keyspaces": ["two"],
                 "copies_per_region": 3,
                 "num_regions": 1,
-                "state_size_share": 0.5,
                 "write_share": 0.5,
             },
         ]
-        entries[1][field] = share
+        entries[1]["write_share"] = share
 
         from service_capacity_modeling.models.org.netflix.cassandra import (
             NflxCassandraArguments,
         )
 
-        with pytest.raises(ValueError, match=f"{field} must sum to 1.0"):
+        with pytest.raises(ValueError, match="write_share must sum to 1.0"):
             NflxCassandraArguments.from_extra_model_arguments(
                 {"keyspace_replication": entries}
             )
@@ -1449,7 +1458,6 @@ class TestCassandraServiceCosts:
                 keyspaces=[keyspace],
                 copies_per_region=2,
                 num_regions=1,
-                state_size_share=0.5,
                 write_share=0.5,
             )
             for keyspace in ("one", "two")
@@ -1470,6 +1478,6 @@ class TestCassandraServiceCosts:
         backup = services["cassandra.backup.s3-standard"]
         assert backup.service_params["snapshot_gib"] == 1
         assert [
-            placement["snapshot_gib"]
+            placement["daily_write_gib"]
             for placement in backup.service_params["placements"]
-        ] == [0, 0]
+        ] == [0.0, 0.0]

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -30,6 +30,8 @@ from service_capacity_modeling.models.org.netflix.cassandra import (
     _get_cluster_size_lambda,
     _get_min_count,
     CassandraClusterSizeMode,
+    KeyspaceReplication,
+    NflxCassandraArguments,
     NflxCassandraCapacityModel,
 )
 from tests.util import assert_minimum_storage_gib
@@ -1180,14 +1182,20 @@ class TestCassandraServiceCosts:
         *,
         num_regions=4,
         backup_retention_days=None,
+        keyspace_replication=None,
+        state_size_gib=300,
+        writes_per_second=100,
+        copies_per_region=None,
     ):
         hardware = shapes.region("us-east-1")
         desires = CapacityDesires(
             query_pattern=QueryPattern(
-                estimated_write_per_second=certain_float(100),
+                estimated_write_per_second=certain_float(writes_per_second),
                 estimated_mean_write_size_bytes=certain_int(512),
             ),
-            data_shape=DataShape(estimated_state_size_gib=certain_float(300)),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_float(state_size_gib)
+            ),
         )
         return NflxCassandraCapacityModel.service_costs(
             "cassandra",
@@ -1199,6 +1207,8 @@ class TestCassandraServiceCosts:
             desires,
             {
                 "backup_retention_days": backup_retention_days,
+                "keyspace_replication": keyspace_replication,
+                "copies_per_region": copies_per_region,
             },
         )
 
@@ -1244,3 +1254,219 @@ class TestCassandraServiceCosts:
         assert "cassandra.backup.s3-standard" not in disabled
         assert "cassandra.net.inter.region" in disabled
         assert "cassandra.net.intra.region" in disabled
+
+    @pytest.mark.parametrize(
+        "keyspace_replication",
+        [
+            pytest.param(None, id="single-replication"),
+            pytest.param(
+                [
+                    KeyspaceReplication(
+                        keyspaces=["one"],
+                        copies_per_region=3,
+                        num_regions=1,
+                        state_size_share=1.0,
+                        write_share=1.0,
+                    )
+                ],
+                id="per-placement",
+            ),
+        ],
+    )
+    def test_backup_disabled_does_no_backup_arithmetic(self, keyspace_replication):
+        # zones_in_region is an unconstrained int, so a caller can hand us zero.
+        # Backup eligibility must be settled before anything divides by it.
+        services = NflxCassandraCapacityModel.service_costs(
+            "cassandra",
+            RegionContext(services={}, zones_in_region=0, num_regions=1),
+            CapacityDesires(),
+            {
+                "backup_retention_days": 0,
+                "keyspace_replication": keyspace_replication,
+            },
+        )
+
+        assert [service.service_type for service in services] == []
+
+    def test_keyspace_replication_equals_independently_modeled_service_costs(self):
+        # The two entries partition a 300 GiB / 100 wps plan, so pricing them
+        # together must cost the same as pricing each one as its own plan.
+        entries = [
+            KeyspaceReplication(
+                keyspaces=["rf2"],
+                copies_per_region=2,
+                num_regions=2,
+                state_size_share=0.3,
+                write_share=0.4,
+            ),
+            KeyspaceReplication(
+                keyspaces=["rf3"],
+                copies_per_region=3,
+                num_regions=2,
+                state_size_share=0.7,
+                write_share=0.6,
+            ),
+        ]
+        combined = {
+            service.service_type: service
+            for service in self._services(num_regions=2, keyspace_replication=entries)
+        }
+
+        def independently(**overrides):
+            return [
+                {
+                    service.service_type: service
+                    for service in self._services(
+                        num_regions=entry.num_regions,
+                        state_size_gib=300 * entry.state_size_share,
+                        writes_per_second=100 * entry.write_share,
+                        copies_per_region=entry.copies_per_region,
+                        **overrides,
+                    )
+                }
+                for entry in entries
+            ]
+
+        for service_type in (
+            "cassandra.net.inter.region",
+            "cassandra.net.intra.region",
+            "cassandra.backup.s3-standard",
+        ):
+            assert combined[service_type].annual_cost == pytest.approx(
+                sum(services[service_type].annual_cost for services in independently())
+            ), service_type
+
+        backup = combined["cassandra.backup.s3-standard"]
+        assert backup.service_params["snapshot_gib"] == 405
+        assert [
+            placement["snapshot_gib"]
+            for placement in backup.service_params["placements"]
+        ] == [90, 315]
+        assert [
+            placement["keyspaces"]
+            for placement in combined["cassandra.net.inter.region"].service_params[
+                "placements"
+            ]
+        ] == [["rf2"], ["rf3"]]
+
+    def test_keyspace_replication_empty_disables_service_costs(self):
+        assert self._services(keyspace_replication=[]) == []
+
+    def test_keyspace_replication_prices_a_single_replica_keyspace(self):
+        # RF=1 is unwise but real, and a measured factor is taken as fact. There
+        # are no remote copies to ship a write to, in this region or any other.
+        services = {
+            service.service_type: service
+            for service in self._services(
+                keyspace_replication=[
+                    KeyspaceReplication(
+                        keyspaces=["unreplicated"],
+                        copies_per_region=1,
+                        num_regions=1,
+                        state_size_share=1.0,
+                        write_share=1.0,
+                    )
+                ]
+            )
+        }
+
+        assert services["cassandra.net.inter.region"].annual_cost == 0
+        assert services["cassandra.net.intra.region"].annual_cost == 0
+        assert services["cassandra.backup.s3-standard"].annual_cost > 0
+
+    def test_island_keyspace_replication_pays_no_inter_region_cost(self):
+        island = KeyspaceReplication(
+            keyspaces=["events_useast1"],
+            copies_per_region=3,
+            num_regions=1,
+            state_size_share=0.5,
+            write_share=0.5,
+        )
+        global_keyspace = island.model_copy(
+            update={"keyspaces": ["events"], "num_regions": 4}
+        )
+
+        islands_only = {
+            service.service_type: service
+            for service in self._services(
+                num_regions=4,
+                keyspace_replication=[
+                    island,
+                    island.model_copy(update={"keyspaces": ["events_uswest2"]}),
+                ],
+            )
+        }
+        mixed = {
+            service.service_type: service
+            for service in self._services(
+                num_regions=4, keyspace_replication=[island, global_keyspace]
+            )
+        }
+
+        # An island never ships a write across a region boundary, so all of the
+        # cross-region charge a single-replication plan would pay is phantom.
+        assert islands_only["cassandra.net.inter.region"].annual_cost == 0
+        assert [
+            placement["annual_cost"]
+            for placement in mixed["cassandra.net.inter.region"].service_params[
+                "placements"
+            ]
+        ] == [0, pytest.approx(mixed["cassandra.net.inter.region"].annual_cost)]
+        assert mixed["cassandra.net.inter.region"].annual_cost > 0
+
+    @pytest.mark.parametrize("field", ["state_size_share", "write_share"])
+    @pytest.mark.parametrize("share", [0.4, 0.6])
+    def test_keyspace_replication_shares_must_partition_the_plan(self, field, share):
+        entries = [
+            {
+                "keyspaces": ["one"],
+                "copies_per_region": 3,
+                "num_regions": 1,
+                "state_size_share": 0.5,
+                "write_share": 0.5,
+            },
+            {
+                "keyspaces": ["two"],
+                "copies_per_region": 3,
+                "num_regions": 1,
+                "state_size_share": 0.5,
+                "write_share": 0.5,
+            },
+        ]
+        entries[1][field] = share
+
+        with pytest.raises(ValueError, match=f"{field} must sum to 1.0"):
+            NflxCassandraArguments.from_extra_model_arguments(
+                {"keyspace_replication": entries}
+            )
+
+    def test_keyspace_replication_backup_floor_applies_once(self):
+        entries = [
+            KeyspaceReplication(
+                keyspaces=[keyspace],
+                copies_per_region=2,
+                num_regions=1,
+                state_size_share=0.5,
+                write_share=0.5,
+            )
+            for keyspace in ("one", "two")
+        ]
+
+        # An empty plan leaves nothing for either placement to snapshot, so the
+        # one-GiB floor must apply to the plan and not once per placement.
+        services = {
+            service.service_type: service
+            for service in self._services(
+                num_regions=1,
+                state_size_gib=0,
+                writes_per_second=0,
+                keyspace_replication=entries,
+            )
+        }
+
+        backup = services["cassandra.backup.s3-standard"]
+        assert backup.service_params["snapshot_gib"] == 1
+        assert [
+            placement["snapshot_gib"]
+            for placement in backup.service_params["placements"]
+        ] == [0, 0]

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1264,8 +1264,8 @@ class TestCassandraServiceCosts:
                         keyspaces=["one"],
                         copies_per_region=3,
                         num_regions=1,
-                        state_size_share=1.0,
-                        write_share=1.0,
+                        state_size_weight=1.0,
+                        write_weight=1.0,
                     )
                 ],
                 id="per-placement",
@@ -1295,15 +1295,15 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
-                state_size_share=0.3,
-                write_share=0.4,
+                state_size_weight=0.3,
+                write_weight=0.4,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
-                state_size_share=0.7,
-                write_share=0.6,
+                state_size_weight=0.7,
+                write_weight=0.6,
             ),
         ]
         combined = {
@@ -1317,8 +1317,8 @@ class TestCassandraServiceCosts:
                     service.service_type: service
                     for service in self._services(
                         num_regions=entry.num_regions,
-                        state_size_gib=300 * entry.state_size_share,
-                        writes_per_second=100 * entry.write_share,
+                        state_size_gib=300 * entry.state_size_weight,
+                        writes_per_second=100 * entry.write_weight,
                         copies_per_region=entry.copies_per_region,
                         **overrides,
                     )
@@ -1359,8 +1359,8 @@ class TestCassandraServiceCosts:
             keyspaces=["local_only"],
             copies_per_region=3,
             num_regions=1,
-            state_size_share=1.0,
-            write_share=1.0,
+            state_size_weight=1.0,
+            write_weight=1.0,
         )
         spread = confined.model_copy(update={"num_regions": 4})
 
@@ -1391,15 +1391,15 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
-                state_size_share=0.3,
-                write_share=0.5,
+                state_size_weight=0.3,
+                write_weight=0.5,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
-                state_size_share=0.7,
-                write_share=0.5,
+                state_size_weight=0.7,
+                write_weight=0.5,
             ),
         ]
 
@@ -1432,8 +1432,8 @@ class TestCassandraServiceCosts:
                         keyspaces=["unreplicated"],
                         copies_per_region=1,
                         num_regions=1,
-                        state_size_share=1.0,
-                        write_share=1.0,
+                        state_size_weight=1.0,
+                        write_weight=1.0,
                     )
                 ]
             )
@@ -1448,8 +1448,8 @@ class TestCassandraServiceCosts:
             keyspaces=["events_useast1"],
             copies_per_region=3,
             num_regions=1,
-            state_size_share=0.5,
-            write_share=0.5,
+            state_size_weight=0.5,
+            write_weight=0.5,
         )
         global_keyspace = island.model_copy(
             update={"keyspaces": ["events"], "num_regions": 4}
@@ -1483,35 +1483,79 @@ class TestCassandraServiceCosts:
         ] == [0, pytest.approx(mixed["cassandra.net.inter.region"].annual_cost)]
         assert mixed["cassandra.net.inter.region"].annual_cost > 0
 
-    @pytest.mark.parametrize("field", ["state_size_share", "write_share"])
-    @pytest.mark.parametrize("share", [0.4, 0.6])
-    def test_keyspace_replication_shares_must_partition_the_plan(self, field, share):
-        entries = [
-            {
-                "keyspaces": ["one"],
-                "copies_per_region": 3,
-                "num_regions": 1,
-                "state_size_share": 0.5,
-                "write_share": 0.5,
-            },
-            {
-                "keyspaces": ["two"],
-                "copies_per_region": 3,
-                "num_regions": 1,
-                "state_size_share": 0.5,
-                "write_share": 0.5,
-            },
-        ]
-        entries[1][field] = share
+    def test_weights_are_relative_so_any_scale_gives_the_same_cost(self):
+        # Weights are normalised against each other, so a caller can pass raw
+        # measured magnitudes without dividing anything. That removes the whole
+        # class of "my shares did not add up" caller error: there is no total to
+        # get wrong, and the plan's own figures stay the source of truth.
+        def costs_at(scale):
+            entries = [
+                KeyspaceReplication(
+                    keyspaces=["confined"],
+                    copies_per_region=3,
+                    num_regions=1,
+                    state_size_weight=0.25 * scale,
+                    write_weight=0.25 * scale,
+                ),
+                KeyspaceReplication(
+                    keyspaces=["global"],
+                    copies_per_region=3,
+                    num_regions=4,
+                    state_size_weight=0.75 * scale,
+                    write_weight=0.75 * scale,
+                ),
+            ]
+            return {
+                service.service_type: service.annual_cost
+                for service in self._services(
+                    num_regions=4, keyspace_replication=entries
+                )
+            }
 
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
+        fractions = costs_at(1.0)
+        # Percentages, and raw measured GiB -- the same split at wildly different
+        # magnitudes must price identically.
+        for scale in (100.0, 4_812_935.0):
+            other = costs_at(scale)
+            assert set(other) == set(fractions)
+            for service_type, cost in fractions.items():
+                assert other[service_type] == pytest.approx(cost), service_type
+
+        # And the split is doing something: the confined entry pays no
+        # cross-region transfer, so the charge is strictly below a plan where
+        # everything is globally replicated.
+        assert fractions["cassandra.net.inter.region"] > 0
+        assert (
+            fractions["cassandra.net.inter.region"]
+            < self._service_cost_without_placements()
         )
 
-        with pytest.raises(ValueError, match=f"{field} must sum to 1.0"):
-            NflxCassandraArguments.from_extra_model_arguments(
-                {"keyspace_replication": entries}
+    def _service_cost_without_placements(self):
+        return next(
+            service.annual_cost
+            for service in self._services(num_regions=4)
+            if service.service_type == "cassandra.net.inter.region"
+        )
+
+    def test_zero_weights_attribute_nothing_rather_than_dividing_by_zero(self):
+        entries = [
+            KeyspaceReplication(
+                keyspaces=[name],
+                copies_per_region=3,
+                num_regions=1,
+                state_size_weight=0.0,
+                write_weight=0.0,
             )
+            for name in ("a", "b")
+        ]
+
+        costs = {
+            service.service_type: service.annual_cost
+            for service in self._services(num_regions=4, keyspace_replication=entries)
+        }
+
+        assert costs["cassandra.net.inter.region"] == 0
+        assert costs["cassandra.net.intra.region"] == 0
 
     def test_keyspace_replication_backup_floor_applies_once(self):
         entries = [
@@ -1519,8 +1563,8 @@ class TestCassandraServiceCosts:
                 keyspaces=[keyspace],
                 copies_per_region=2,
                 num_regions=1,
-                state_size_share=0.5,
-                write_share=0.5,
+                state_size_weight=0.5,
+                write_weight=0.5,
             )
             for keyspace in ("one", "two")
         ]

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -33,6 +33,7 @@ from service_capacity_modeling.models.org.netflix.cassandra import (
     keyspace_replication_by_region,
     KeyspacePlacement,
     KeyspaceReplication,
+    NflxCassandraArguments,
     NflxCassandraCapacityModel,
 )
 from tests.util import assert_minimum_storage_gib
@@ -865,6 +866,74 @@ class TestCassandraCurrentCapacity:
         assert result.count == 24
 
 
+class TestCassandraReplicationArguments:
+    @staticmethod
+    def _replication_entry(copies_per_region=3, keyspace="events"):
+        return {
+            "keyspaces": [keyspace],
+            "copies_per_region": copies_per_region,
+            "num_regions": 2,
+            "state_size_share": 1.0,
+            "write_share": 1.0,
+        }
+
+    def test_replication_inputs_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            NflxCassandraArguments.from_extra_model_arguments(
+                {
+                    "copies_per_region": 3,
+                    "keyspace_replication": [self._replication_entry()],
+                }
+            )
+
+    def test_capacity_plan_derives_rf_from_keyspace_replication(self):
+        hardware = shapes.region("us-east-1")
+        result = NflxCassandraCapacityModel.capacity_plan(
+            instance=hardware.instances["m6id.2xlarge"],
+            drive=hardware.drives["gp3"],
+            context=RegionContext(
+                zones_in_region=hardware.zones_in_region,
+                services=hardware.services,
+            ),
+            desires=small_but_high_qps,
+            extra_model_arguments={
+                "require_local_disks": False,
+                "keyspace_replication": [self._replication_entry(2)],
+            },
+        )
+
+        assert result is not None
+        assert not isinstance(result, Excuse)
+        assert (
+            result.candidate_clusters.zonal[0].cluster_params["cassandra.keyspace.rf"]
+            == 2
+        )
+
+    @pytest.mark.parametrize("keyspace_replication", [[], "mixed"])
+    def test_capacity_plan_requires_one_replication_factor(self, keyspace_replication):
+        if keyspace_replication == "mixed":
+            keyspace_replication = [
+                self._replication_entry(2),
+                self._replication_entry(3, "sessions"),
+            ]
+        hardware = shapes.region("us-east-1")
+
+        with pytest.raises(ValueError, match="capacity planning"):
+            NflxCassandraCapacityModel.capacity_plan(
+                instance=hardware.instances["m6id.2xlarge"],
+                drive=hardware.drives["gp3"],
+                context=RegionContext(
+                    zones_in_region=hardware.zones_in_region,
+                    services=hardware.services,
+                ),
+                desires=small_but_high_qps,
+                extra_model_arguments={
+                    "require_local_disks": False,
+                    "keyspace_replication": keyspace_replication,
+                },
+            )
+
+
 class TestCassandraExtraModelArguments:
     """Test model argument validation."""
 
@@ -1065,18 +1134,10 @@ class TestCassandraExtraModelArguments:
         )
 
     def test_page_cache_cap_default(self):
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
-        )
-
         args = NflxCassandraArguments.from_extra_model_arguments({})
         assert args.max_page_cache_gib == 28.0
 
     def test_min_instance_ram_gib_exclusive_default(self):
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
-        )
-
         args = NflxCassandraArguments.from_extra_model_arguments({})
         assert args.min_instance_ram_gib_exclusive == 16.0
 
@@ -1116,10 +1177,6 @@ class TestCassandraExtraModelArguments:
         assert result.candidate_clusters.zonal[0].instance.name == "m6id.xlarge"
 
     def test_cluster_size_mode_extra_argument(self):
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
-        )
-
         assert (
             NflxCassandraArguments.from_extra_model_arguments({}).cluster_size_mode
             is None
@@ -1138,10 +1195,6 @@ class TestCassandraExtraModelArguments:
         )
 
     def test_allow_ebs_volume_shrink_extra_argument(self):
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
-        )
-
         assert (
             NflxCassandraArguments.from_extra_model_arguments(
                 {}
@@ -1156,10 +1209,6 @@ class TestCassandraExtraModelArguments:
         )
 
     def test_cluster_size_mode_schema_exposes_enum_docstrings(self):
-        from service_capacity_modeling.models.org.netflix.cassandra import (
-            NflxCassandraArguments,
-        )
-
         schema = NflxCassandraArguments.model_json_schema()
         cluster_size_mode = schema["$defs"]["CassandraClusterSizeMode"]
 
@@ -1266,8 +1315,8 @@ class TestCassandraServiceCosts:
                         keyspaces=["one"],
                         copies_per_region=3,
                         num_regions=1,
-                        state_size_weight=1.0,
-                        write_weight=1.0,
+                        state_size_share=1.0,
+                        write_share=1.0,
                     )
                 ],
                 id="per-placement",
@@ -1297,15 +1346,15 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
-                state_size_weight=0.3,
-                write_weight=0.4,
+                state_size_share=0.3,
+                write_share=0.4,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
-                state_size_weight=0.7,
-                write_weight=0.6,
+                state_size_share=0.7,
+                write_share=0.6,
             ),
         ]
         combined = {
@@ -1319,8 +1368,8 @@ class TestCassandraServiceCosts:
                     service.service_type: service
                     for service in self._services(
                         num_regions=entry.num_regions,
-                        state_size_gib=300 * entry.state_size_weight,
-                        writes_per_second=100 * entry.write_weight,
+                        state_size_gib=300 * entry.state_size_share,
+                        writes_per_second=100 * entry.write_share,
                         copies_per_region=entry.copies_per_region,
                         **overrides,
                     )
@@ -1361,8 +1410,8 @@ class TestCassandraServiceCosts:
             keyspaces=["local_only"],
             copies_per_region=3,
             num_regions=1,
-            state_size_weight=1.0,
-            write_weight=1.0,
+            state_size_share=1.0,
+            write_share=1.0,
         )
         spread = confined.model_copy(update={"num_regions": 4})
 
@@ -1393,15 +1442,15 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
-                state_size_weight=0.3,
-                write_weight=0.5,
+                state_size_share=0.3,
+                write_share=0.5,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
-                state_size_weight=0.7,
-                write_weight=0.5,
+                state_size_share=0.7,
+                write_share=0.5,
             ),
         ]
 
@@ -1454,6 +1503,71 @@ class TestCassandraServiceCosts:
         assert [entry.keyspaces for entry in by_region["eu-west-1"]] == [["events"]]
         # num_regions is derived from the regions, so it cannot disagree with them.
         assert [entry.num_regions for entry in by_region["us-east-1"]] == [4, 1]
+        assert [
+            entry.state_size_share for entry in by_region["us-east-1"]
+        ] == pytest.approx([2 / 3, 1 / 3])
+        assert [entry.write_share for entry in by_region["us-east-1"]] == pytest.approx(
+            [40 / 130, 90 / 130]
+        )
+        assert by_region["eu-west-1"][0].state_size_share == 1
+        assert by_region["eu-west-1"][0].write_share == pytest.approx(40 / 130)
+
+    def test_derived_inputs_preserve_fleetwide_weights_across_regions(self):
+        regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1"]
+        by_region = keyspace_replication_by_region(
+            [
+                KeyspacePlacement(
+                    keyspaces=["events"],
+                    copies_per_region=3,
+                    regions=regions,
+                    write_weight=40.0,
+                ),
+                KeyspacePlacement(
+                    keyspaces=["events_useast1"],
+                    copies_per_region=3,
+                    regions=["us-east-1"],
+                    write_weight=60.0,
+                ),
+            ]
+        )
+
+        actual = {}
+        for region in regions:
+            for service in self._services(
+                num_regions=len(regions),
+                backup_retention_days=0,
+                keyspace_replication=by_region[region],
+            ):
+                actual[service.service_type] = (
+                    actual.get(service.service_type, 0) + service.annual_cost
+                )
+
+        global_share = {
+            service.service_type: service.annual_cost
+            for service in self._services(
+                num_regions=len(regions),
+                backup_retention_days=0,
+                writes_per_second=40,
+                copies_per_region=3,
+            )
+        }
+        confined = {
+            service.service_type: service.annual_cost
+            for service in self._services(
+                num_regions=1,
+                backup_retention_days=0,
+                writes_per_second=60,
+                copies_per_region=3,
+            )
+        }
+
+        assert actual["cassandra.net.inter.region"] == pytest.approx(
+            global_share["cassandra.net.inter.region"] * len(regions)
+        )
+        assert actual["cassandra.net.intra.region"] == pytest.approx(
+            global_share["cassandra.net.intra.region"] * len(regions)
+            + confined["cassandra.net.intra.region"]
+        )
 
     def test_derived_inputs_charge_no_cross_region_transfer_for_a_confined_keyspace(
         self,
@@ -1494,8 +1608,8 @@ class TestCassandraServiceCosts:
                         keyspaces=["unreplicated"],
                         copies_per_region=1,
                         num_regions=1,
-                        state_size_weight=1.0,
-                        write_weight=1.0,
+                        state_size_share=1.0,
+                        write_share=1.0,
                     )
                 ]
             )
@@ -1510,8 +1624,8 @@ class TestCassandraServiceCosts:
             keyspaces=["events_useast1"],
             copies_per_region=3,
             num_regions=1,
-            state_size_weight=0.5,
-            write_weight=0.5,
+            state_size_share=0.5,
+            write_share=0.5,
         )
         global_keyspace = island.model_copy(
             update={"keyspaces": ["events"], "num_regions": 4}
@@ -1551,26 +1665,34 @@ class TestCassandraServiceCosts:
         # class of "my shares did not add up" caller error: there is no total to
         # get wrong, and the plan's own figures stay the source of truth.
         def costs_at(scale):
-            entries = [
-                KeyspaceReplication(
-                    keyspaces=["confined"],
-                    copies_per_region=3,
-                    num_regions=1,
-                    state_size_weight=0.25 * scale,
-                    write_weight=0.25 * scale,
-                ),
-                KeyspaceReplication(
-                    keyspaces=["global"],
-                    copies_per_region=3,
-                    num_regions=4,
-                    state_size_weight=0.75 * scale,
-                    write_weight=0.75 * scale,
-                ),
-            ]
+            by_region = keyspace_replication_by_region(
+                [
+                    KeyspacePlacement(
+                        keyspaces=["confined"],
+                        copies_per_region=3,
+                        regions=["us-east-1"],
+                        state_size_weight=0.25 * scale,
+                        write_weight=0.25 * scale,
+                    ),
+                    KeyspacePlacement(
+                        keyspaces=["global"],
+                        copies_per_region=3,
+                        regions=[
+                            "us-east-1",
+                            "us-east-2",
+                            "us-west-2",
+                            "eu-west-1",
+                        ],
+                        state_size_weight=0.75 * scale,
+                        write_weight=0.75 * scale,
+                    ),
+                ]
+            )
             return {
                 service.service_type: service.annual_cost
                 for service in self._services(
-                    num_regions=4, keyspace_replication=entries
+                    num_regions=4,
+                    keyspace_replication=by_region["us-east-1"],
                 )
             }
 
@@ -1599,14 +1721,14 @@ class TestCassandraServiceCosts:
             if service.service_type == "cassandra.net.inter.region"
         )
 
-    def test_zero_weights_attribute_nothing_rather_than_dividing_by_zero(self):
+    def test_zero_shares_attribute_nothing(self):
         entries = [
             KeyspaceReplication(
                 keyspaces=[name],
                 copies_per_region=3,
                 num_regions=1,
-                state_size_weight=0.0,
-                write_weight=0.0,
+                state_size_share=0.0,
+                write_share=0.0,
             )
             for name in ("a", "b")
         ]
@@ -1625,8 +1747,8 @@ class TestCassandraServiceCosts:
                 keyspaces=[keyspace],
                 copies_per_region=2,
                 num_regions=1,
-                state_size_weight=0.5,
-                write_weight=0.5,
+                state_size_share=0.5,
+                write_share=0.5,
             )
             for keyspace in ("one", "two")
         ]

--- a/tests/netflix/test_cassandra.py
+++ b/tests/netflix/test_cassandra.py
@@ -1264,6 +1264,7 @@ class TestCassandraServiceCosts:
                         keyspaces=["one"],
                         copies_per_region=3,
                         num_regions=1,
+                        state_size_share=1.0,
                         write_share=1.0,
                     )
                 ],
@@ -1294,12 +1295,14 @@ class TestCassandraServiceCosts:
                 keyspaces=["rf2"],
                 copies_per_region=2,
                 num_regions=2,
+                state_size_share=0.3,
                 write_share=0.4,
             ),
             KeyspaceReplication(
                 keyspaces=["rf3"],
                 copies_per_region=3,
                 num_regions=2,
+                state_size_share=0.7,
                 write_share=0.6,
             ),
         ]
@@ -1314,6 +1317,7 @@ class TestCassandraServiceCosts:
                     service.service_type: service
                     for service in self._services(
                         num_regions=entry.num_regions,
+                        state_size_gib=300 * entry.state_size_share,
                         writes_per_second=100 * entry.write_share,
                         copies_per_region=entry.copies_per_region,
                         **overrides,
@@ -1322,39 +1326,21 @@ class TestCassandraServiceCosts:
                 for entry in entries
             ]
 
-        # Network cost is what placement changes, and it does not depend on stored
-        # bytes, so the parts must add up to independently modelling each entry.
         for service_type in (
             "cassandra.net.inter.region",
             "cassandra.net.intra.region",
+            "cassandra.backup.s3-standard",
         ):
             assert combined[service_type].annual_cost == pytest.approx(
                 sum(services[service_type].annual_cost for services in independently())
             ), service_type
 
-        # Backup splits differently on purpose: the snapshot is what the plan
-        # stores, charged once, while the upload volume follows write fan-out and
-        # so is summed per placement. Summing snapshots instead would count the
-        # same bytes once per placement.
-        whole_plan = {
-            service.service_type: service
-            for service in self._services(num_regions=2, writes_per_second=0)
-        }
         backup = combined["cassandra.backup.s3-standard"]
-        assert (
-            backup.service_params["snapshot_gib"]
-            == whole_plan["cassandra.backup.s3-standard"].service_params["snapshot_gib"]
-        )
-        assert backup.service_params["daily_write_gib"] == pytest.approx(
-            sum(
-                services["cassandra.backup.s3-standard"].service_params[
-                    "daily_write_gib"
-                ]
-                for services in independently()
-            ),
-            abs=0.2,
-        )
-        assert "snapshot_gib" not in backup.service_params["placements"][0]
+        assert backup.service_params["snapshot_gib"] == 405
+        assert [
+            placement["snapshot_gib"]
+            for placement in backup.service_params["placements"]
+        ] == [90, 315]
         assert [
             placement["keyspaces"]
             for placement in combined["cassandra.net.inter.region"].service_params[
@@ -1373,6 +1359,7 @@ class TestCassandraServiceCosts:
             keyspaces=["local_only"],
             copies_per_region=3,
             num_regions=1,
+            state_size_share=1.0,
             write_share=1.0,
         )
         spread = confined.model_copy(update={"num_regions": 4})
@@ -1394,6 +1381,43 @@ class TestCassandraServiceCosts:
             four_regions["cassandra.net.intra.region"] * 4
         )
 
+    def test_backup_snapshot_follows_each_placement_replication_factor(self):
+        # The snapshot is state size times replication factor, so when placements
+        # do not share an RF the snapshot has to accumulate per placement. Using
+        # one factor over the whole plan overcharges the lower-RF share -- for
+        # 30% at RF2 and 70% at RF3 it bills 450 GiB against a true 405.
+        entries = [
+            KeyspaceReplication(
+                keyspaces=["rf2"],
+                copies_per_region=2,
+                num_regions=2,
+                state_size_share=0.3,
+                write_share=0.5,
+            ),
+            KeyspaceReplication(
+                keyspaces=["rf3"],
+                copies_per_region=3,
+                num_regions=2,
+                state_size_share=0.7,
+                write_share=0.5,
+            ),
+        ]
+
+        services = {
+            service.service_type: service
+            for service in self._services(num_regions=2, keyspace_replication=entries)
+        }
+        backup = services["cassandra.backup.s3-standard"]
+
+        assert [
+            placement["snapshot_gib"]
+            for placement in backup.service_params["placements"]
+        ] == [90, 315]
+        assert backup.service_params["snapshot_gib"] == 405
+        # The single-RF whole-plan figure, which is what a collapsed snapshot
+        # would have produced.
+        assert backup.service_params["snapshot_gib"] != 450
+
     def test_keyspace_replication_empty_disables_service_costs(self):
         assert not self._services(keyspace_replication=[])
 
@@ -1408,6 +1432,7 @@ class TestCassandraServiceCosts:
                         keyspaces=["unreplicated"],
                         copies_per_region=1,
                         num_regions=1,
+                        state_size_share=1.0,
                         write_share=1.0,
                     )
                 ]
@@ -1423,6 +1448,7 @@ class TestCassandraServiceCosts:
             keyspaces=["events_useast1"],
             copies_per_region=3,
             num_regions=1,
+            state_size_share=0.5,
             write_share=0.5,
         )
         global_keyspace = island.model_copy(
@@ -1457,29 +1483,32 @@ class TestCassandraServiceCosts:
         ] == [0, pytest.approx(mixed["cassandra.net.inter.region"].annual_cost)]
         assert mixed["cassandra.net.inter.region"].annual_cost > 0
 
+    @pytest.mark.parametrize("field", ["state_size_share", "write_share"])
     @pytest.mark.parametrize("share", [0.4, 0.6])
-    def test_keyspace_replication_shares_must_partition_the_plan(self, share):
+    def test_keyspace_replication_shares_must_partition_the_plan(self, field, share):
         entries = [
             {
                 "keyspaces": ["one"],
                 "copies_per_region": 3,
                 "num_regions": 1,
+                "state_size_share": 0.5,
                 "write_share": 0.5,
             },
             {
                 "keyspaces": ["two"],
                 "copies_per_region": 3,
                 "num_regions": 1,
+                "state_size_share": 0.5,
                 "write_share": 0.5,
             },
         ]
-        entries[1]["write_share"] = share
+        entries[1][field] = share
 
         from service_capacity_modeling.models.org.netflix.cassandra import (
             NflxCassandraArguments,
         )
 
-        with pytest.raises(ValueError, match="write_share must sum to 1.0"):
+        with pytest.raises(ValueError, match=f"{field} must sum to 1.0"):
             NflxCassandraArguments.from_extra_model_arguments(
                 {"keyspace_replication": entries}
             )
@@ -1490,6 +1519,7 @@ class TestCassandraServiceCosts:
                 keyspaces=[keyspace],
                 copies_per_region=2,
                 num_regions=1,
+                state_size_share=0.5,
                 write_share=0.5,
             )
             for keyspace in ("one", "two")
@@ -1510,6 +1540,6 @@ class TestCassandraServiceCosts:
         backup = services["cassandra.backup.s3-standard"]
         assert backup.service_params["snapshot_gib"] == 1
         assert [
-            placement["daily_write_gib"]
+            placement["snapshot_gib"]
             for placement in backup.service_params["placements"]
-        ] == [0.0, 0.0]
+        ] == [0, 0]


### PR DESCRIPTION
## What am I trying to do?

Attribute Cassandra network and backup service costs to the keyspaces that actually incur them. A cluster can mix globally replicated keyspaces with region-confined keyspaces; pricing the entire plan as one placement charges confined data for cross-region traffic it never sends.

Existing callers remain source-compatible. When `keyspace_replication` is omitted, the established single-replication path is unchanged.

## Why did I do it this way?

### Accept placements once, derive regional planner inputs

`KeyspacePlacement` is the caller-facing shape: keyspaces, copies per region, deployed regions, and relative state/write weights. `keyspace_replication_by_region()` converts those facts into `KeyspaceReplication` entries for each regional plan, deriving `num_regions` and regional scoping instead of asking every caller to reproduce that logic.

State weights are normalized among placements present in each region. Write weights are normalized once across the fleet because each regional plan carries the fleetwide write rate. The generated inputs therefore preserve additive fleet costs and do not repeat a single-region placement in regions where it does not live.

Direct `KeyspaceReplication` inputs remain validated: state shares must total approximately 0 or 1, write shares may total at most 1 within `1e-6`, and `copies_per_region` cannot be supplied alongside placements.

### Price each placement, then aggregate

For service costs, each placement is priced with its own state share, write share, replication factor, and region count. Network services are summed by type and retain a `placements` breakdown, so a region-confined keyspace contributes zero inter-region replication cost.

Backup snapshot bytes are computed per placement because replication factors may differ, then summed with `math.fsum` and rounded once for the plan. Daily upload volume is also summed per placement, while the retention/floor policy is applied once. This avoids both mixed-RF mispricing and per-placement rounding or minimum-charge inflation.

Candidate plans pass the original placement arguments through to service costing, so the costs used to rank a recommendation match the costs returned on that recommendation. Capacity sizing currently requires all supplied placements to share one replication factor; mixed factors are supported for cost attribution but deliberately rejected for sizing.

### Preserve the simple path

The existing `copies_per_region` API remains the simple whole-plan input. Explicit RF=1 is accepted as measured reality, producing no intra- or inter-region replication traffic. Backup eligibility is checked before backup arithmetic, preserving disabled-backup behavior even for otherwise unusable region shapes.

## Are there any tests?

Yes. The focused Cassandra suite passes with **89 tests**, covering placement derivation, partial write attribution, aggregate share validation, confined-keyspace traffic, candidate-plan propagation, RF constraints, mixed-RF backup snapshots, aggregate-before-rounding behavior, and compatibility of the single-replication path.

The full pre-commit pipeline passes: Ruff, formatting, Flake8, mypy, Pylint **10.00/10**, repository guards, and cost-baseline capture. The downstream ag-cass integration suite passes **107 tests** with this SCM branch installed editable. The final diff also received multi-model independent review with no blocking findings.

## How would I use the new code?

```python
placements = [
    KeyspacePlacement(
        keyspaces=["events"],
        copies_per_region=3,
        regions=["us-east-1", "us-west-2"],
        state_size_weight=1200,
        write_weight=40,
    ),
    KeyspacePlacement(
        keyspaces=["events_us_east_1"],
        copies_per_region=3,
        regions=["us-east-1"],
        state_size_weight=600,
        write_weight=90,
    ),
]

replication_by_region = keyspace_replication_by_region(placements)
extra_model_arguments = {
    "keyspace_replication": replication_by_region["us-east-1"],
}
```

Use the corresponding derived list for each regional plan. Callers must still verify that the returned region keys cover every deployed region; an omitted region would otherwise fall back to simple whole-plan pricing.