### PR TITLE
Add with_effective_cpu() helper to resize instances without corrupting HT signal

### DIFF
--- a/service_capacity_modeling/models/common.py
+++ b/service_capacity_modeling/models/common.py
@@ -285,6 +285,21 @@ def _reserved_headroom(
     return strategy.calculate_reserved_headroom(effective_cpu)
 
 
+def with_effective_cpu(instance: Instance, effective_cpu: int) -> Instance:
+    """Return a copy of instance with its vCPU count adjusted, preserving HT ratio.
+
+    Callers that need to reason about a subset of an instance's vCPUs (for
+    example, penalizing a wide fan-out candidate down to a smaller effective
+    core count) must not change `cpu` without also scaling `cpu_cores` by the
+    same ratio: doing so silently flips the `cores < cpu` hyper-threading
+    signal that `cpu_headroom_target` relies on to pick the right headroom
+    multiplier.
+    """
+    ht_ratio = instance.cores / instance.cpu
+    new_cores = max(1, round(effective_cpu * ht_ratio))
+    return instance.model_copy(update={"cpu": effective_cpu, "cpu_cores": new_cores})
+
+
 def cpu_headroom_target(instance: Instance, buffers: Optional[Buffers] = None) -> float:
     """Determine an approximate headroom target for an instance.
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -8,9 +8,11 @@ from service_capacity_modeling.interface import Buffer
 from service_capacity_modeling.interface import BufferComponent
 from service_capacity_modeling.interface import BufferIntent
 from service_capacity_modeling.interface import Buffers
+from service_capacity_modeling.interface import Instance
 from service_capacity_modeling.models.common import buffer_for_components
 from service_capacity_modeling.models.common import cpu_headroom_target
 from service_capacity_modeling.models.common import DerivedBuffers
+from service_capacity_modeling.models.common import with_effective_cpu
 
 
 def test_m5_same_headroom_as_r5():
@@ -37,6 +39,47 @@ def test_seventh_gen_instance_reflects_non_ht_boost():
     m7a4xl = cpu_headroom_target(planner.instance("m7a.4xlarge"))
     assert m7a4xl < m6i4xl
     assert m7a4xl == approx(0.16, rel=0.05)
+
+
+def test_with_effective_cpu_preserves_ht_ratio():
+    ht_instance = Instance(
+        name="test.ht", cpu=16, cpu_cores=8, cpu_ghz=3.0, ram_gib=32, net_mbps=1000
+    )
+    no_ht_instance = Instance(
+        name="test.no-ht", cpu=16, cpu_cores=16, cpu_ghz=3.0, ram_gib=32, net_mbps=1000
+    )
+
+    ht_resized = with_effective_cpu(ht_instance, 4)
+    no_ht_resized = with_effective_cpu(no_ht_instance, 4)
+
+    # HT ratio (cores/cpu) must survive the resize, not just the raw cpu count.
+    assert ht_resized.cpu == 4
+    assert ht_resized.cores == 2
+    assert ht_resized.cores < ht_resized.cpu
+
+    assert no_ht_resized.cpu == 4
+    assert no_ht_resized.cores == 4
+    assert no_ht_resized.cores == no_ht_resized.cpu
+
+    # cpu_headroom_target also scales with absolute cpu count (larger
+    # instances need less headroom), so compare against instances built
+    # directly at the resized cpu count rather than the pre-resize originals.
+    ht_reference = Instance(
+        name="test.ht-ref", cpu=4, cpu_cores=2, cpu_ghz=3.0, ram_gib=32, net_mbps=1000
+    )
+    no_ht_reference = Instance(
+        name="test.no-ht-ref",
+        cpu=4,
+        cpu_cores=4,
+        cpu_ghz=3.0,
+        ram_gib=32,
+        net_mbps=1000,
+    )
+    assert cpu_headroom_target(ht_resized) == cpu_headroom_target(ht_reference)
+    assert cpu_headroom_target(no_ht_resized) == cpu_headroom_target(no_ht_reference)
+    # Virtual (HT) threads don't get the physical-core boost, so they need
+    # more headroom reserved than real cores at the same vCPU count.
+    assert cpu_headroom_target(ht_resized) > cpu_headroom_target(no_ht_resized)
 
 
 def test_has_some_headroom():


### PR DESCRIPTION
# Summary
Adds a helper, with_effective_cpu(), for safely shrinking an instance's vCPU count.

Instances track both cpu (vCPU count) and cpu_cores (real physical cores) — that's how we know if an instance is hyperthreaded. If code changes cpu alone without scaling cpu_cores to match, the instance ends up in a nonsense state that flips the hyperthreaded signal cpu_headroom_target() uses, silently producing the wrong capacity headroom.

This helper resizes both fields together, preserving the original ratio, so callers that need a smaller effective CPU count (e.g. penalizing a candidate instance) can't hit this bug.

# Testing
- New test passes; full existing test suite passes with no changes

# Notes
- This PR is independent of [#315](https://github.com/Netflix-Skunkworks/service-capacity-modeling/pull/315) — different files, no shared dependency, can merge in either order.
- This is groundwork only. It doesn't fix any live bug by itself; a follow-up PR in the instance-recommendation service will switch its wide-fanout logic to use this helper instead of its current manual copy.