### PR TITLE
fix(read-only-kv): model SST memory overhead

### DIFF
--- a/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
+++ b/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
@@ -49,6 +49,14 @@ class CapacityResult(BaseModel):
     replica_count: int  # Replication factor
     partitions_per_node: int  # Partitions placed on each node
     nodes_for_one_copy: int  # Nodes needed for one complete copy of data
+    max_partitions_per_node_by_disk: int
+    max_partitions_per_node_by_memory: Optional[int] = None
+
+
+def _partitions_that_fit(capacity_gib: float, partition_size_gib: float) -> int:
+    """Floor a capacity ratio without losing an exact fit to float error."""
+    fit = capacity_gib / partition_size_gib
+    return math.floor(math.nextafter(fit, math.inf))
 
 
 def search_for_min_nodes(
@@ -67,21 +75,24 @@ def search_for_min_nodes(
         CapacityResult with the lowest node count, or None if no valid
         configuration exists within the constraints.
     """
-    max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
+    disk_ppn = _partitions_that_fit(
+        problem.disk_per_node_gib, problem.partition_size_gib
+    )
+    memory_ppn = None
     if problem.memory_per_partition_gib is not None:
         assert problem.memory_per_node_gib is not None
-        max_ppn = min(
-            max_ppn,
-            int(problem.memory_per_node_gib / problem.memory_per_partition_gib),
+        memory_ppn = _partitions_that_fit(
+            problem.memory_per_node_gib, problem.memory_per_partition_gib
         )
+
+    max_ppn = min(disk_ppn, memory_ppn) if memory_ppn is not None else disk_ppn
     if max_ppn < 1:
         return None
 
-    best_result: Optional[CapacityResult] = None
-    best_rank: Optional[tuple[int, int, int]] = None
-    for ppn in range(min(max_ppn, problem.n_partitions), 0, -1):
+    best_candidate: Optional[tuple[int, int, int, int]] = None
+    ppn = max_ppn
+    while ppn > 0:
         nodes_for_one_copy = math.ceil(problem.n_partitions / ppn)
-        reported_ppn = max_ppn if nodes_for_one_copy == 1 else ppn
 
         # Calculate minimum RF for CPU
         rf = max(
@@ -92,15 +103,23 @@ def search_for_min_nodes(
         total_nodes = max(nodes_for_one_copy * rf, 2)
 
         if total_nodes <= problem.max_nodes:
-            candidate = CapacityResult(
-                node_count=total_nodes,
-                replica_count=rf,
-                partitions_per_node=reported_ppn,
-                nodes_for_one_copy=nodes_for_one_copy,
-            )
-            candidate_rank = (total_nodes, -rf, -reported_ppn)
-            if best_rank is None or candidate_rank < best_rank:
-                best_result = candidate
-                best_rank = candidate_rank
+            candidate = (total_nodes, -rf, -ppn, nodes_for_one_copy)
+            if best_candidate is None or candidate[:3] < best_candidate[:3]:
+                best_candidate = candidate
 
-    return best_result
+        # All skipped densities have the same nodes_for_one_copy and therefore
+        # the same RF and node count. The current ppn wins their tie-break.
+        ppn = (problem.n_partitions - 1) // nodes_for_one_copy
+
+    if best_candidate is None:
+        return None
+
+    node_count, negative_rf, negative_ppn, nodes_for_one_copy = best_candidate
+    return CapacityResult(
+        node_count=node_count,
+        replica_count=-negative_rf,
+        partitions_per_node=-negative_ppn,
+        nodes_for_one_copy=nodes_for_one_copy,
+        max_partitions_per_node_by_disk=disk_ppn,
+        max_partitions_per_node_by_memory=memory_ppn,
+    )

--- a/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
+++ b/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
@@ -2,17 +2,19 @@
 Partition-Aware Capacity Planning Algorithm
 
 This module contains the core algorithm for partition-aware capacity planning.
-The algorithm optimizes for fault tolerance by preferring higher replication
-factors (RF) when multiple valid configurations exist.
+The algorithm minimizes node count and prefers higher replication factors (RF)
+when multiple valid configurations have the same node count.
 
-Key principle: Higher PPn → fewer base nodes → higher RF for same CPU → better
-fault tolerance.
+Key principle: Minimize cost first, then prefer fault tolerance among plans with
+the same cost.
 """
 
 import math
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
 
 
 class CapacityProblem(BaseModel):
@@ -21,10 +23,23 @@ class CapacityProblem(BaseModel):
     n_partitions: int  # Total number of partitions
     partition_size_gib: float  # Size of one partition (with buffer)
     disk_per_node_gib: float  # Effective disk capacity per node
+    memory_per_partition_gib: Optional[float] = Field(default=None, gt=0)
+    memory_per_node_gib: Optional[float] = Field(default=None, ge=0)
     cpu_per_node: int  # CPU cores per node
     cpu_needed: int  # Total CPU cores needed
     min_rf: int  # Minimum replication factor
     max_nodes: int  # Maximum allowed nodes in cluster
+
+    @model_validator(mode="after")
+    def memory_constraints_are_complete(self) -> "CapacityProblem":
+        """Require both memory values when partition placement uses memory."""
+        if (self.memory_per_partition_gib is None) != (
+            self.memory_per_node_gib is None
+        ):
+            raise ValueError(
+                "memory_per_partition_gib and memory_per_node_gib must be set together"
+            )
+        return self
 
 
 class CapacityResult(BaseModel):
@@ -36,33 +51,37 @@ class CapacityResult(BaseModel):
     nodes_for_one_copy: int  # Nodes needed for one complete copy of data
 
 
-def search_for_max_rf(
+def search_for_min_nodes(
     problem: CapacityProblem,
 ) -> Optional[CapacityResult]:
     """
-    Find the configuration with the highest RF (replication factor) that fits
-    within max_nodes.
+    Find the configuration with the fewest nodes that fits within max_nodes.
 
-    Higher RF = better fault tolerance. The algorithm searches from max PPn
-    down to 1, returning the first valid configuration found.
-
-    Why higher PPn gives higher RF:
-        Higher PPn → fewer nodes_for_one_copy → less CPU per copy →
-        need more copies (higher RF) to meet CPU requirements.
+    The algorithm evaluates every valid partition density. It prefers higher RF
+    for configurations with the same node count.
 
     Args:
         problem: The capacity planning problem parameters
 
     Returns:
-        CapacityResult with the highest RF configuration, or None if no valid
+        CapacityResult with the lowest node count, or None if no valid
         configuration exists within the constraints.
     """
     max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
+    if problem.memory_per_partition_gib is not None:
+        assert problem.memory_per_node_gib is not None
+        max_ppn = min(
+            max_ppn,
+            int(problem.memory_per_node_gib / problem.memory_per_partition_gib),
+        )
     if max_ppn < 1:
         return None
 
-    for ppn in range(max_ppn, 0, -1):
+    best_result: Optional[CapacityResult] = None
+    best_rank: Optional[tuple[int, int, int]] = None
+    for ppn in range(min(max_ppn, problem.n_partitions), 0, -1):
         nodes_for_one_copy = math.ceil(problem.n_partitions / ppn)
+        reported_ppn = max_ppn if nodes_for_one_copy == 1 else ppn
 
         # Calculate minimum RF for CPU
         rf = max(
@@ -73,11 +92,15 @@ def search_for_max_rf(
         total_nodes = max(nodes_for_one_copy * rf, 2)
 
         if total_nodes <= problem.max_nodes:
-            return CapacityResult(
+            candidate = CapacityResult(
                 node_count=total_nodes,
                 replica_count=rf,
-                partitions_per_node=ppn,
+                partitions_per_node=reported_ppn,
                 nodes_for_one_copy=nodes_for_one_copy,
             )
+            candidate_rank = (total_nodes, -rf, -reported_ppn)
+            if best_rank is None or candidate_rank < best_rank:
+                best_result = candidate
+                best_rank = candidate_rank
 
-    return None
+    return best_result

--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -56,6 +56,7 @@ from service_capacity_modeling.models.common import upsert_params
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.org.netflix.partition_aware_algorithm import (
     CapacityProblem,
     search_for_min_nodes,
@@ -108,14 +109,15 @@ class NflxReadOnlyKVArguments(BaseModel):
     )
     reserved_memory_gib: float = Field(
         default=8.0,
-        description="Reserved memory for the OS, JVM heap, block cache, "
-        "and other processes (GiB).",
+        description="Minimum memory reserved for the OS, JVM heap, block cache, "
+        "and other processes (GiB). Data-shape reservations take precedence when "
+        "their sum is larger.",
         ge=0,
     )
     sst_memory_overhead_ratio: float = Field(
         default=0.05,
-        description="Resident RocksDB table-reader memory as a ratio of SST data "
-        "placed on each node.",
+        description="Planning assumption for resident RocksDB table-reader memory "
+        "per complete data copy, as a ratio of SST data.",
         ge=0,
         le=1,
     )
@@ -136,6 +138,7 @@ def _estimate_read_only_kv_requirement(
     instance: Instance,
     desires: CapacityDesires,
     args: NflxReadOnlyKVArguments,
+    memory_buffer_ratio: float,
 ) -> CapacityRequirement:
     """Estimate the capacity requirement for the read-only KV regional cluster.
 
@@ -147,6 +150,8 @@ def _estimate_read_only_kv_requirement(
     Args:
         instance: The compute instance being considered
         desires: User's capacity desires
+        args: Read-only KV specific arguments
+        memory_buffer_ratio: Memory headroom applied to the SST estimate
 
     Returns:
         CapacityRequirement for the regional cluster
@@ -166,7 +171,9 @@ def _estimate_read_only_kv_requirement(
     )
 
     needed_sst_memory_gib = (
-        desires.data_shape.estimated_state_size_gib.mid * args.sst_memory_overhead_ratio
+        desires.data_shape.estimated_state_size_gib.mid
+        * args.sst_memory_overhead_ratio
+        * memory_buffer_ratio
     )
 
     # Network calculation (read-only, so only outbound read traffic)
@@ -183,21 +190,23 @@ def _estimate_read_only_kv_requirement(
     )
 
 
+# pylint: disable-next=too-many-positional-arguments
 def _compute_read_only_kv_regional_cluster(
     instance: Instance,
     requirement: CapacityRequirement,
     args: NflxReadOnlyKVArguments,
     partition_size_with_buffer_gib: float,
     disk_buffer_ratio: float,
+    memory_buffer_ratio: float,
+    reserved_memory_gib: float,
 ) -> Optional[RegionClusterCapacity]:
     """Compute the regional cluster configuration using the partition-aware algorithm.
 
     Partition-aware algorithm (local disks only):
-    1. CAPACITY FIRST: Calculate partitions_per_node from independent local disk
-       and resident SST memory constraints
-    2. Calculate nodes_for_one_copy = total_partitions / partitions_per_node
-    3. Start with min_replica_count, calculate initial node count
-    4. CHECK CPU: If not satisfied, increase replica_count (uses spare disk)
+    1. Calculate independent disk and resident SST memory partition ceilings.
+    2. Evaluate each distinct nodes-per-copy placement below those ceilings.
+    3. Calculate the replica count required by minimum RF and CPU for each placement.
+    4. Select the fewest nodes, then prefer higher RF and denser packing on ties.
 
     Note: Only supports local disks. EBS/attached disk is not supported because:
     - EBS disk is provisioned exactly for data needs (no spare space)
@@ -209,6 +218,8 @@ def _compute_read_only_kv_regional_cluster(
         args: Read-only KV specific arguments
         partition_size_with_buffer_gib: Size of one partition with disk buffer applied
         disk_buffer_ratio: Disk buffer ratio for headroom
+        memory_buffer_ratio: Memory buffer ratio for headroom
+        reserved_memory_gib: Total memory reserved outside SST table readers
 
     Returns:
         RegionClusterCapacity or None if configuration is not viable
@@ -229,11 +240,13 @@ def _compute_read_only_kv_regional_cluster(
     sst_memory_per_partition_gib = requirement.mem_gib.mid / args.total_num_partitions
     available_sst_memory_per_node_gib = None
     if args.sst_memory_overhead_ratio > 0:
-        available_sst_memory_per_node_gib = max(
-            0, instance.ram_gib - args.reserved_memory_gib
+        usable_memory_per_node_gib = usable_memory_gib(
+            instance, lambda _: reserved_memory_gib
         )
+        if usable_memory_per_node_gib <= 0:
+            return None
+        available_sst_memory_per_node_gib = usable_memory_per_node_gib
 
-    # Step 2: Use partition-aware algorithm to find optimal configuration
     problem = CapacityProblem(
         n_partitions=args.total_num_partitions,
         partition_size_gib=partition_size_with_buffer_gib,
@@ -268,13 +281,26 @@ def _compute_read_only_kv_regional_cluster(
         "read-only-kv.nodes_for_one_copy": result.nodes_for_one_copy,
         "read-only-kv.nodes_for_cpu": math.ceil(total_needed_cores / instance.cpu),
         "read-only-kv.sst_memory_overhead_ratio": args.sst_memory_overhead_ratio,
-        "read-only-kv.sst_memory_per_partition_gib": sst_memory_per_partition_gib,
-        "read-only-kv.sst_memory_per_copy_gib": requirement.mem_gib.mid,
-        "read-only-kv.total_sst_memory_gib": (
+        "read-only-kv.memory_buffer_ratio": memory_buffer_ratio,
+        "read-only-kv.reserved_memory_per_node_gib": reserved_memory_gib,
+        "read-only-kv.buffered_sst_memory_per_partition_gib": (
+            sst_memory_per_partition_gib
+        ),
+        "read-only-kv.estimated_sst_memory_per_copy_gib": (
+            requirement.mem_gib.mid / memory_buffer_ratio
+        ),
+        "read-only-kv.buffered_sst_memory_per_copy_gib": requirement.mem_gib.mid,
+        "read-only-kv.total_buffered_sst_memory_gib": (
             requirement.mem_gib.mid * result.replica_count
         ),
         "read-only-kv.available_sst_memory_per_node_gib": (
             available_sst_memory_per_node_gib
+        ),
+        "read-only-kv.max_partitions_per_node_by_disk": (
+            result.max_partitions_per_node_by_disk
+        ),
+        "read-only-kv.max_partitions_per_node_by_memory": (
+            result.max_partitions_per_node_by_memory
         ),
         EFFECTIVE_DISK_PER_NODE_GIB: effective_disk_per_node,
     }
@@ -321,30 +347,54 @@ def _estimate_read_only_kv_cluster(
     if instance.drive is None:
         return None
 
+    unreplicated_data_gib = desires.data_shape.estimated_state_size_gib.mid
+    if unreplicated_data_gib <= 0:
+        return None
+
+    memory_buffer = buffer_for_components(
+        buffers=desires.buffers, components=[BufferComponent.memory]
+    )
+    if memory_buffer.ratio <= 0:
+        return None
+
     # Calculate requirements
-    requirement = _estimate_read_only_kv_requirement(
-        instance=instance, desires=desires, args=args
+    per_copy_requirement = _estimate_read_only_kv_requirement(
+        instance=instance,
+        desires=desires,
+        args=args,
+        memory_buffer_ratio=memory_buffer.ratio,
     )
 
     # Compute disk buffer values inline (not via context)
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
-    unreplicated_data_gib = desires.data_shape.estimated_state_size_gib.mid
     partition_size_gib = unreplicated_data_gib / args.total_num_partitions
     partition_size_with_buffer_gib = partition_size_gib * disk_buffer.ratio
+    reserved_memory_gib = max(
+        args.reserved_memory_gib,
+        desires.data_shape.reserved_instance_app_mem_gib
+        + desires.data_shape.reserved_instance_system_mem_gib,
+    )
 
     # Compute cluster
     cluster = _compute_read_only_kv_regional_cluster(
         instance=instance,
-        requirement=requirement,
+        requirement=per_copy_requirement,
         args=args,
         partition_size_with_buffer_gib=partition_size_with_buffer_gib,
         disk_buffer_ratio=disk_buffer.ratio,
+        memory_buffer_ratio=memory_buffer.ratio,
+        reserved_memory_gib=reserved_memory_gib,
     )
 
     if cluster is None:
         return None
+
+    replica_count = int(cluster.cluster_params["read-only-kv.replica_count"])
+    regional_requirement = per_copy_requirement.model_copy(
+        update={"mem_gib": per_copy_requirement.mem_gib.scale(replica_count)}
+    )
 
     # Build cost breakdown using cluster_costs (consistent with CostAwareModel)
     rokv_costs = NflxReadOnlyKVCapacityModel.cluster_costs(
@@ -363,7 +413,7 @@ def _estimate_read_only_kv_cluster(
     )
 
     return CapacityPlan(
-        requirements=Requirements(regional=[requirement]),
+        requirements=Requirements(regional=[regional_requirement]),
         candidate_clusters=clusters,
         rank=clusters.total_annual_cost * (1 + penalty_ratio),
     )
@@ -456,6 +506,8 @@ class NflxReadOnlyKVCapacityModel(CapacityModel, CostAwareModel):
                 ),  # 67% utilization target
                 # Read-only: can run at high disk utilization
                 "disk": Buffer(ratio=1.15, components=[BufferComponent.disk]),  # 87%
+                # Keep the 5% SST estimate at or below 83.3% of its allocation.
+                "memory": Buffer(ratio=1.2, components=[BufferComponent.memory]),  # 83%
             },
         )
 

--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -58,7 +58,7 @@ from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
 from service_capacity_modeling.models.org.netflix.partition_aware_algorithm import (
     CapacityProblem,
-    search_for_max_rf,
+    search_for_min_nodes,
 )
 
 logger = logging.getLogger(__name__)
@@ -108,9 +108,16 @@ class NflxReadOnlyKVArguments(BaseModel):
     )
     reserved_memory_gib: float = Field(
         default=8.0,
-        description="Reserved memory for OS, bloom filters, index blocks, "
+        description="Reserved memory for the OS, JVM heap, block cache, "
         "and other processes (GiB).",
         ge=0,
+    )
+    sst_memory_overhead_ratio: float = Field(
+        default=0.05,
+        description="Resident RocksDB table-reader memory as a ratio of SST data "
+        "placed on each node.",
+        ge=0,
+        le=1,
     )
     large_instance_regret: float = Field(
         default=0.2,
@@ -120,13 +127,9 @@ class NflxReadOnlyKVArguments(BaseModel):
     )
 
 
-# TODO: Memory estimation is currently disabled because working_set_from_drive_and_slo
-# doesn't work well for large datasets (which is all of OODM use cases). The working
-# set calculation assumes a relationship between drive latency and SLO that doesn't
-# hold for large datasets where the working set is a small fraction of total data.
-# For now, we rely on the 30 GiB minimum RAM filter on instances and don't use
-# memory as a sizing constraint. Future work: implement a better memory estimation
-# that considers actual access patterns and cache hit rates for large datasets.
+# TODO: Data-block working set estimation remains disabled because
+# working_set_from_drive_and_slo does not work well for large OODM datasets.
+# Resident SST table-reader memory is modeled separately as a percentage of data.
 
 
 def _estimate_read_only_kv_requirement(
@@ -136,9 +139,10 @@ def _estimate_read_only_kv_requirement(
 ) -> CapacityRequirement:
     """Estimate the capacity requirement for the read-only KV regional cluster.
 
-    Note: For the partition-aware algorithm, we calculate requirements that are
-    independent of replica count. The actual replica count is determined by the
-    cluster computation based on partition placement and compute needs.
+    Note: For the partition-aware algorithm, we calculate requirements for one
+    complete data copy. The actual replica count is determined by the cluster
+    computation based on partition placement and compute needs. Cluster parameters
+    report the resulting total SST memory across all replicas.
 
     Args:
         instance: The compute instance being considered
@@ -161,8 +165,9 @@ def _estimate_read_only_kv_requirement(
         reference_shape=desires.reference_shape,
     )
 
-    # Memory: not used as sizing constraint (see TODO at top of file)
-    # Instances are filtered to require 30+ GiB RAM
+    needed_sst_memory_gib = (
+        desires.data_shape.estimated_state_size_gib.mid * args.sst_memory_overhead_ratio
+    )
 
     # Network calculation (read-only, so only outbound read traffic)
     needed_network_mbps = simple_network_mbps(desires)
@@ -171,7 +176,7 @@ def _estimate_read_only_kv_requirement(
         requirement_type=NflxReadOnlyKVCapacityModel.cluster_type,
         reference_shape=desires.reference_shape,
         cpu_cores=certain_int(needed_cores),
-        mem_gib=certain_float(0),  # Not used (see TODO at top of file)
+        mem_gib=certain_float(needed_sst_memory_gib),
         disk_gib=certain_float(0),  # Disk computed via partition-aware algorithm
         network_mbps=certain_float(needed_network_mbps),
         context={},
@@ -188,7 +193,8 @@ def _compute_read_only_kv_regional_cluster(
     """Compute the regional cluster configuration using the partition-aware algorithm.
 
     Partition-aware algorithm (local disks only):
-    1. DISK FIRST: Calculate partitions_per_node based on local disk capacity
+    1. CAPACITY FIRST: Calculate partitions_per_node from independent local disk
+       and resident SST memory constraints
     2. Calculate nodes_for_one_copy = total_partitions / partitions_per_node
     3. Start with min_replica_count, calculate initial node count
     4. CHECK CPU: If not satisfied, increase replica_count (uses spare disk)
@@ -213,7 +219,6 @@ def _compute_read_only_kv_regional_cluster(
 
     total_needed_cores = math.ceil(requirement.cpu_cores.mid)
 
-    # Step 1 (DISK): Calculate effective disk capacity per node using helper
     effective_disk_per_node = get_effective_disk_per_node_gib(
         instance=instance,
         drive=instance.drive,
@@ -221,18 +226,29 @@ def _compute_read_only_kv_regional_cluster(
         max_local_data_per_node_gib=args.max_data_per_node_gib,
     )
 
+    sst_memory_per_partition_gib = requirement.mem_gib.mid / args.total_num_partitions
+    available_sst_memory_per_node_gib = None
+    if args.sst_memory_overhead_ratio > 0:
+        available_sst_memory_per_node_gib = max(
+            0, instance.ram_gib - args.reserved_memory_gib
+        )
+
     # Step 2: Use partition-aware algorithm to find optimal configuration
     problem = CapacityProblem(
         n_partitions=args.total_num_partitions,
         partition_size_gib=partition_size_with_buffer_gib,
         disk_per_node_gib=effective_disk_per_node,
+        memory_per_partition_gib=(
+            sst_memory_per_partition_gib if args.sst_memory_overhead_ratio > 0 else None
+        ),
+        memory_per_node_gib=available_sst_memory_per_node_gib,
         cpu_per_node=instance.cpu,
         cpu_needed=total_needed_cores,
         min_rf=args.min_replica_count,
         max_nodes=args.max_regional_size,
     )
 
-    result = search_for_max_rf(problem)
+    result = search_for_min_nodes(problem)
     if result is None:
         return None
 
@@ -251,6 +267,15 @@ def _compute_read_only_kv_regional_cluster(
         "read-only-kv.partitions_per_node": result.partitions_per_node,
         "read-only-kv.nodes_for_one_copy": result.nodes_for_one_copy,
         "read-only-kv.nodes_for_cpu": math.ceil(total_needed_cores / instance.cpu),
+        "read-only-kv.sst_memory_overhead_ratio": args.sst_memory_overhead_ratio,
+        "read-only-kv.sst_memory_per_partition_gib": sst_memory_per_partition_gib,
+        "read-only-kv.sst_memory_per_copy_gib": requirement.mem_gib.mid,
+        "read-only-kv.total_sst_memory_gib": (
+            requirement.mem_gib.mid * result.replica_count
+        ),
+        "read-only-kv.available_sst_memory_per_node_gib": (
+            available_sst_memory_per_node_gib
+        ),
         EFFECTIVE_DISK_PER_NODE_GIB: effective_disk_per_node,
     }
     upsert_params(cluster, params)

--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -64,6 +64,9 @@ from service_capacity_modeling.models.org.netflix.partition_aware_algorithm impo
 
 logger = logging.getLogger(__name__)
 
+# A namespace opts in by supplying this named desired memory buffer.
+SST_MEMORY_BUFFER_NAME = "read_only_kv_sst_memory"
+
 
 def _compute_penalties(
     instance: Instance,
@@ -117,7 +120,8 @@ class NflxReadOnlyKVArguments(BaseModel):
     sst_memory_overhead_ratio: float = Field(
         default=0.05,
         description="Planning assumption for resident RocksDB table-reader memory "
-        "per complete data copy, as a ratio of SST data.",
+        "per complete data copy, as a ratio of SST data. Applied only when "
+        f"the {SST_MEMORY_BUFFER_NAME!r} desired memory buffer is present.",
         ge=0,
         le=1,
     )
@@ -137,7 +141,7 @@ class NflxReadOnlyKVArguments(BaseModel):
 def _estimate_read_only_kv_requirement(
     instance: Instance,
     desires: CapacityDesires,
-    args: NflxReadOnlyKVArguments,
+    sst_memory_overhead_ratio: float,
     memory_buffer_ratio: float,
 ) -> CapacityRequirement:
     """Estimate the capacity requirement for the read-only KV regional cluster.
@@ -150,7 +154,7 @@ def _estimate_read_only_kv_requirement(
     Args:
         instance: The compute instance being considered
         desires: User's capacity desires
-        args: Read-only KV specific arguments
+        sst_memory_overhead_ratio: Resident SST memory as a ratio of SST data
         memory_buffer_ratio: Memory headroom applied to the SST estimate
 
     Returns:
@@ -172,7 +176,7 @@ def _estimate_read_only_kv_requirement(
 
     needed_sst_memory_gib = (
         desires.data_shape.estimated_state_size_gib.mid
-        * args.sst_memory_overhead_ratio
+        * sst_memory_overhead_ratio
         * memory_buffer_ratio
     )
 
@@ -197,6 +201,7 @@ def _compute_read_only_kv_regional_cluster(
     args: NflxReadOnlyKVArguments,
     partition_size_with_buffer_gib: float,
     disk_buffer_ratio: float,
+    sst_memory_overhead_ratio: float,
     memory_buffer_ratio: float,
     reserved_memory_gib: float,
 ) -> Optional[RegionClusterCapacity]:
@@ -218,6 +223,7 @@ def _compute_read_only_kv_regional_cluster(
         args: Read-only KV specific arguments
         partition_size_with_buffer_gib: Size of one partition with disk buffer applied
         disk_buffer_ratio: Disk buffer ratio for headroom
+        sst_memory_overhead_ratio: Active resident SST memory estimate
         memory_buffer_ratio: Memory buffer ratio for headroom
         reserved_memory_gib: Total memory reserved outside SST table readers
 
@@ -239,7 +245,7 @@ def _compute_read_only_kv_regional_cluster(
 
     sst_memory_per_partition_gib = requirement.mem_gib.mid / args.total_num_partitions
     available_sst_memory_per_node_gib = None
-    if args.sst_memory_overhead_ratio > 0:
+    if sst_memory_overhead_ratio > 0:
         usable_memory_per_node_gib = usable_memory_gib(
             instance, lambda _: reserved_memory_gib
         )
@@ -252,7 +258,7 @@ def _compute_read_only_kv_regional_cluster(
         partition_size_gib=partition_size_with_buffer_gib,
         disk_per_node_gib=effective_disk_per_node,
         memory_per_partition_gib=(
-            sst_memory_per_partition_gib if args.sst_memory_overhead_ratio > 0 else None
+            sst_memory_per_partition_gib if sst_memory_overhead_ratio > 0 else None
         ),
         memory_per_node_gib=available_sst_memory_per_node_gib,
         cpu_per_node=instance.cpu,
@@ -273,37 +279,45 @@ def _compute_read_only_kv_regional_cluster(
     )
 
     # Add cluster parameters for provisioning
-    params = {
+    params: Dict[str, Any] = {
         "read-only-kv.total_num_partitions": args.total_num_partitions,
         "read-only-kv.min_replica_count": args.min_replica_count,
         "read-only-kv.replica_count": result.replica_count,
         "read-only-kv.partitions_per_node": result.partitions_per_node,
         "read-only-kv.nodes_for_one_copy": result.nodes_for_one_copy,
         "read-only-kv.nodes_for_cpu": math.ceil(total_needed_cores / instance.cpu),
-        "read-only-kv.sst_memory_overhead_ratio": args.sst_memory_overhead_ratio,
-        "read-only-kv.memory_buffer_ratio": memory_buffer_ratio,
-        "read-only-kv.reserved_memory_per_node_gib": reserved_memory_gib,
-        "read-only-kv.buffered_sst_memory_per_partition_gib": (
-            sst_memory_per_partition_gib
-        ),
-        "read-only-kv.estimated_sst_memory_per_copy_gib": (
-            requirement.mem_gib.mid / memory_buffer_ratio
-        ),
-        "read-only-kv.buffered_sst_memory_per_copy_gib": requirement.mem_gib.mid,
-        "read-only-kv.total_buffered_sst_memory_gib": (
-            requirement.mem_gib.mid * result.replica_count
-        ),
-        "read-only-kv.available_sst_memory_per_node_gib": (
-            available_sst_memory_per_node_gib
-        ),
-        "read-only-kv.max_partitions_per_node_by_disk": (
-            result.max_partitions_per_node_by_disk
-        ),
-        "read-only-kv.max_partitions_per_node_by_memory": (
-            result.max_partitions_per_node_by_memory
-        ),
         EFFECTIVE_DISK_PER_NODE_GIB: effective_disk_per_node,
     }
+    if sst_memory_overhead_ratio > 0:
+        params.update(
+            {
+                "read-only-kv.sst_memory_buffer": SST_MEMORY_BUFFER_NAME,
+                "read-only-kv.sst_memory_overhead_ratio": sst_memory_overhead_ratio,
+                "read-only-kv.memory_buffer_ratio": memory_buffer_ratio,
+                "read-only-kv.reserved_memory_per_node_gib": reserved_memory_gib,
+                "read-only-kv.buffered_sst_memory_per_partition_gib": (
+                    sst_memory_per_partition_gib
+                ),
+                "read-only-kv.estimated_sst_memory_per_copy_gib": (
+                    requirement.mem_gib.mid / memory_buffer_ratio
+                ),
+                "read-only-kv.buffered_sst_memory_per_copy_gib": (
+                    requirement.mem_gib.mid
+                ),
+                "read-only-kv.total_buffered_sst_memory_gib": (
+                    requirement.mem_gib.mid * result.replica_count
+                ),
+                "read-only-kv.available_sst_memory_per_node_gib": (
+                    available_sst_memory_per_node_gib
+                ),
+                "read-only-kv.max_partitions_per_node_by_disk": (
+                    result.max_partitions_per_node_by_disk
+                ),
+                "read-only-kv.max_partitions_per_node_by_memory": (
+                    result.max_partitions_per_node_by_memory
+                ),
+            }
+        )
     upsert_params(cluster, params)
 
     penalties = _compute_penalties(
@@ -351,18 +365,29 @@ def _estimate_read_only_kv_cluster(
     if unreplicated_data_gib <= 0:
         return None
 
-    memory_buffer = buffer_for_components(
-        buffers=desires.buffers, components=[BufferComponent.memory]
-    )
-    if memory_buffer.ratio <= 0:
-        return None
+    sst_memory_buffer = desires.buffers.desired.get(SST_MEMORY_BUFFER_NAME)
+    sst_memory_overhead_ratio = 0.0
+    memory_buffer_ratio = 1.0
+    if args.sst_memory_overhead_ratio > 0 and sst_memory_buffer is not None:
+        if set(sst_memory_buffer.components).intersection(
+            {BufferComponent.memory, BufferComponent.storage}
+        ):
+            memory_buffer = buffer_for_components(
+                buffers=desires.buffers, components=[BufferComponent.memory]
+            )
+            memory_buffer_ratio = memory_buffer.ratio
+        else:
+            memory_buffer_ratio = 0
+        if memory_buffer_ratio <= 0:
+            return None
+        sst_memory_overhead_ratio = args.sst_memory_overhead_ratio
 
     # Calculate requirements
     per_copy_requirement = _estimate_read_only_kv_requirement(
         instance=instance,
         desires=desires,
-        args=args,
-        memory_buffer_ratio=memory_buffer.ratio,
+        sst_memory_overhead_ratio=sst_memory_overhead_ratio,
+        memory_buffer_ratio=memory_buffer_ratio,
     )
 
     # Compute disk buffer values inline (not via context)
@@ -384,7 +409,8 @@ def _estimate_read_only_kv_cluster(
         args=args,
         partition_size_with_buffer_gib=partition_size_with_buffer_gib,
         disk_buffer_ratio=disk_buffer.ratio,
-        memory_buffer_ratio=memory_buffer.ratio,
+        sst_memory_overhead_ratio=sst_memory_overhead_ratio,
+        memory_buffer_ratio=memory_buffer_ratio,
         reserved_memory_gib=reserved_memory_gib,
     )
 
@@ -506,8 +532,6 @@ class NflxReadOnlyKVCapacityModel(CapacityModel, CostAwareModel):
                 ),  # 67% utilization target
                 # Read-only: can run at high disk utilization
                 "disk": Buffer(ratio=1.15, components=[BufferComponent.disk]),  # 87%
-                # Keep the 5% SST estimate at or below 83.3% of its allocation.
-                "memory": Buffer(ratio=1.2, components=[BufferComponent.memory]),  # 83%
             },
         )
 

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -1261,36 +1261,41 @@
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 434718.04
+      "read-only-kv.regional-clusters": 480930.32
     },
     "clusters": [
       {
-        "annual_cost": 434718.04,
+        "annual_cost": 480930.32,
         "cluster_params": {
-          "effective_disk_per_node_gib": 1900,
-          "read-only-kv.available_sst_memory_per_node_gib": 53.39,
+          "effective_disk_per_node_gib": 2355.2,
+          "read-only-kv.available_sst_memory_per_node_gib": 114.86,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 2880.0,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 5.625,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 2400.0,
+          "read-only-kv.max_partitions_per_node_by_disk": 21,
+          "read-only-kv.max_partitions_per_node_by_memory": 20,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 10,
-          "read-only-kv.nodes_for_one_copy": 47,
-          "read-only-kv.partitions_per_node": 11,
+          "read-only-kv.nodes_for_cpu": 5,
+          "read-only-kv.nodes_for_one_copy": 26,
+          "read-only-kv.partitions_per_node": 20,
           "read-only-kv.replica_count": 4,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 2400.0,
-          "read-only-kv.sst_memory_per_partition_gib": 4.6875,
-          "read-only-kv.total_num_partitions": 512,
-          "read-only-kv.total_sst_memory_gib": 9600.0
+          "read-only-kv.total_buffered_sst_memory_gib": 11520.0,
+          "read-only-kv.total_num_partitions": 512
         },
         "cluster_type": "read-only-kv",
-        "count": 188,
+        "count": 104,
         "deployment": "regional",
-        "instance": "i3.2xlarge"
+        "instance": "i3.4xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_large",
     "service_tier": 1,
-    "total_annual_cost": 434718.04
+    "total_annual_cost": 480930.32
   },
   {
     "annual_costs": {
@@ -1302,16 +1307,21 @@
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
           "read-only-kv.available_sst_memory_per_node_gib": 22.52,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 83.82000000000001,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 10.477500000000001,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 69.85000000000001,
+          "read-only-kv.max_partitions_per_node_by_disk": 4,
+          "read-only-kv.max_partitions_per_node_by_memory": 2,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 3,
           "read-only-kv.nodes_for_cpu": 12,
           "read-only-kv.nodes_for_one_copy": 4,
           "read-only-kv.partitions_per_node": 2,
           "read-only-kv.replica_count": 3,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 69.85000000000001,
-          "read-only-kv.sst_memory_per_partition_gib": 8.731250000000001,
-          "read-only-kv.total_num_partitions": 8,
-          "read-only-kv.total_sst_memory_gib": 209.55
+          "read-only-kv.total_buffered_sst_memory_gib": 251.46000000000004,
+          "read-only-kv.total_num_partitions": 8
         },
         "cluster_type": "read-only-kv",
         "count": 12,
@@ -1335,16 +1345,21 @@
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "read-only-kv.available_sst_memory_per_node_gib": 22.52,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 3.5999999999999996,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 0.22499999999999998,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 3.0,
+          "read-only-kv.max_partitions_per_node_by_disk": 102,
+          "read-only-kv.max_partitions_per_node_by_memory": 100,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 4,
           "read-only-kv.nodes_for_cpu": 5,
           "read-only-kv.nodes_for_one_copy": 1,
-          "read-only-kv.partitions_per_node": 102,
+          "read-only-kv.partitions_per_node": 100,
           "read-only-kv.replica_count": 5,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 3.0,
-          "read-only-kv.sst_memory_per_partition_gib": 0.1875,
-          "read-only-kv.total_num_partitions": 16,
-          "read-only-kv.total_sst_memory_gib": 15.0
+          "read-only-kv.total_buffered_sst_memory_gib": 18.0,
+          "read-only-kv.total_num_partitions": 16
         },
         "cluster_type": "read-only-kv",
         "count": 5,

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -1261,41 +1261,31 @@
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 480930.32
+      "read-only-kv.regional-clusters": 149967.0
     },
     "clusters": [
       {
-        "annual_cost": 480930.32,
+        "annual_cost": 149967.0,
         "cluster_params": {
-          "effective_disk_per_node_gib": 2355.2,
-          "read-only-kv.available_sst_memory_per_node_gib": 114.86,
-          "read-only-kv.buffered_sst_memory_per_copy_gib": 2880.0,
-          "read-only-kv.buffered_sst_memory_per_partition_gib": 5.625,
-          "read-only-kv.estimated_sst_memory_per_copy_gib": 2400.0,
-          "read-only-kv.max_partitions_per_node_by_disk": 21,
-          "read-only-kv.max_partitions_per_node_by_memory": 20,
-          "read-only-kv.memory_buffer_ratio": 1.2,
+          "effective_disk_per_node_gib": 2328,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 5,
-          "read-only-kv.nodes_for_one_copy": 26,
-          "read-only-kv.partitions_per_node": 20,
+          "read-only-kv.nodes_for_cpu": 15,
+          "read-only-kv.nodes_for_one_copy": 25,
+          "read-only-kv.partitions_per_node": 21,
           "read-only-kv.replica_count": 4,
-          "read-only-kv.reserved_memory_per_node_gib": 8.0,
-          "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.total_buffered_sst_memory_gib": 11520.0,
           "read-only-kv.total_num_partitions": 512
         },
         "cluster_type": "read-only-kv",
-        "count": 104,
+        "count": 100,
         "deployment": "regional",
-        "instance": "i3.4xlarge"
+        "instance": "i3en.xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_large",
     "service_tier": 1,
-    "total_annual_cost": 480930.32
+    "total_annual_cost": 149967.0
   },
   {
     "annual_costs": {
@@ -1306,21 +1296,11 @@
         "annual_cost": 14523.96,
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
-          "read-only-kv.available_sst_memory_per_node_gib": 22.52,
-          "read-only-kv.buffered_sst_memory_per_copy_gib": 83.82000000000001,
-          "read-only-kv.buffered_sst_memory_per_partition_gib": 10.477500000000001,
-          "read-only-kv.estimated_sst_memory_per_copy_gib": 69.85000000000001,
-          "read-only-kv.max_partitions_per_node_by_disk": 4,
-          "read-only-kv.max_partitions_per_node_by_memory": 2,
-          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 3,
           "read-only-kv.nodes_for_cpu": 12,
-          "read-only-kv.nodes_for_one_copy": 4,
-          "read-only-kv.partitions_per_node": 2,
-          "read-only-kv.replica_count": 3,
-          "read-only-kv.reserved_memory_per_node_gib": 8.0,
-          "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.total_buffered_sst_memory_gib": 251.46000000000004,
+          "read-only-kv.nodes_for_one_copy": 2,
+          "read-only-kv.partitions_per_node": 4,
+          "read-only-kv.replica_count": 6,
           "read-only-kv.total_num_partitions": 8
         },
         "cluster_type": "read-only-kv",
@@ -1344,21 +1324,11 @@
         "annual_cost": 7816.65,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
-          "read-only-kv.available_sst_memory_per_node_gib": 22.52,
-          "read-only-kv.buffered_sst_memory_per_copy_gib": 3.5999999999999996,
-          "read-only-kv.buffered_sst_memory_per_partition_gib": 0.22499999999999998,
-          "read-only-kv.estimated_sst_memory_per_copy_gib": 3.0,
-          "read-only-kv.max_partitions_per_node_by_disk": 102,
-          "read-only-kv.max_partitions_per_node_by_memory": 100,
-          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 4,
           "read-only-kv.nodes_for_cpu": 5,
           "read-only-kv.nodes_for_one_copy": 1,
-          "read-only-kv.partitions_per_node": 100,
+          "read-only-kv.partitions_per_node": 102,
           "read-only-kv.replica_count": 5,
-          "read-only-kv.reserved_memory_per_node_gib": 8.0,
-          "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.total_buffered_sst_memory_gib": 18.0,
           "read-only-kv.total_num_partitions": 16
         },
         "cluster_type": "read-only-kv",

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -1261,31 +1261,36 @@
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 149967.0
+      "read-only-kv.regional-clusters": 434718.04
     },
     "clusters": [
       {
-        "annual_cost": 149967.0,
+        "annual_cost": 434718.04,
         "cluster_params": {
-          "effective_disk_per_node_gib": 2328,
+          "effective_disk_per_node_gib": 1900,
+          "read-only-kv.available_sst_memory_per_node_gib": 53.39,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 15,
-          "read-only-kv.nodes_for_one_copy": 25,
-          "read-only-kv.partitions_per_node": 21,
+          "read-only-kv.nodes_for_cpu": 10,
+          "read-only-kv.nodes_for_one_copy": 47,
+          "read-only-kv.partitions_per_node": 11,
           "read-only-kv.replica_count": 4,
-          "read-only-kv.total_num_partitions": 512
+          "read-only-kv.sst_memory_overhead_ratio": 0.05,
+          "read-only-kv.sst_memory_per_copy_gib": 2400.0,
+          "read-only-kv.sst_memory_per_partition_gib": 4.6875,
+          "read-only-kv.total_num_partitions": 512,
+          "read-only-kv.total_sst_memory_gib": 9600.0
         },
         "cluster_type": "read-only-kv",
-        "count": 100,
+        "count": 188,
         "deployment": "regional",
-        "instance": "i3en.xlarge"
+        "instance": "i3.2xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_large",
     "service_tier": 1,
-    "total_annual_cost": 149967.0
+    "total_annual_cost": 434718.04
   },
   {
     "annual_costs": {
@@ -1296,12 +1301,17 @@
         "annual_cost": 14523.96,
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
+          "read-only-kv.available_sst_memory_per_node_gib": 22.52,
           "read-only-kv.min_replica_count": 3,
           "read-only-kv.nodes_for_cpu": 12,
-          "read-only-kv.nodes_for_one_copy": 2,
-          "read-only-kv.partitions_per_node": 4,
-          "read-only-kv.replica_count": 6,
-          "read-only-kv.total_num_partitions": 8
+          "read-only-kv.nodes_for_one_copy": 4,
+          "read-only-kv.partitions_per_node": 2,
+          "read-only-kv.replica_count": 3,
+          "read-only-kv.sst_memory_overhead_ratio": 0.05,
+          "read-only-kv.sst_memory_per_copy_gib": 69.85000000000001,
+          "read-only-kv.sst_memory_per_partition_gib": 8.731250000000001,
+          "read-only-kv.total_num_partitions": 8,
+          "read-only-kv.total_sst_memory_gib": 209.55
         },
         "cluster_type": "read-only-kv",
         "count": 12,
@@ -1324,12 +1334,17 @@
         "annual_cost": 7816.65,
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
+          "read-only-kv.available_sst_memory_per_node_gib": 22.52,
           "read-only-kv.min_replica_count": 4,
           "read-only-kv.nodes_for_cpu": 5,
           "read-only-kv.nodes_for_one_copy": 1,
           "read-only-kv.partitions_per_node": 102,
           "read-only-kv.replica_count": 5,
-          "read-only-kv.total_num_partitions": 16
+          "read-only-kv.sst_memory_overhead_ratio": 0.05,
+          "read-only-kv.sst_memory_per_copy_gib": 3.0,
+          "read-only-kv.sst_memory_per_partition_gib": 0.1875,
+          "read-only-kv.total_num_partitions": 16,
+          "read-only-kv.total_sst_memory_gib": 15.0
         },
         "cluster_type": "read-only-kv",
         "count": 5,

--- a/tests/netflix/test_partition_aware_algorithm.py
+++ b/tests/netflix/test_partition_aware_algorithm.py
@@ -1,18 +1,19 @@
 """
 Tests for the Partition-Aware Capacity Planning Algorithm.
 
-These tests verify the core algorithm behavior, especially the bias for higher
-replication factors (RF) which provides better fault tolerance.
+These tests verify the core algorithm behavior, especially minimizing node count
+while preferring higher replication factors (RF) for cost-equivalent plans.
 """
 
 import math
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
+import pytest
 
 from service_capacity_modeling.models.org.netflix.partition_aware_algorithm import (
     CapacityProblem,
-    search_for_max_rf,
+    search_for_min_nodes,
 )
 
 
@@ -30,7 +31,7 @@ class TestAlgorithmBasics:
             min_rf=2,
             max_nodes=100,
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
         assert result is None
 
     def test_returns_none_when_exceeds_max_nodes(self):
@@ -44,7 +45,7 @@ class TestAlgorithmBasics:
             min_rf=2,
             max_nodes=10,  # Very restrictive
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
         assert result is None
 
     def test_simple_case_returns_valid_result(self):
@@ -58,21 +59,108 @@ class TestAlgorithmBasics:
             min_rf=2,
             max_nodes=100,
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
         assert result.node_count <= problem.max_nodes
         assert result.replica_count >= problem.min_rf
 
+    def test_memory_limits_partitions_per_node_independently_from_disk(self):
+        """Memory can limit partition placement while disk remains unchanged."""
+        problem = CapacityProblem(
+            n_partitions=10,
+            partition_size_gib=100,
+            disk_per_node_gib=500,
+            memory_per_partition_gib=25,
+            memory_per_node_gib=50,
+            cpu_per_node=16,
+            cpu_needed=32,
+            min_rf=2,
+            max_nodes=100,
+        )
 
-class TestHigherRFBias:
-    """Tests that verify the algorithm's bias for higher replication factors."""
+        result = search_for_min_nodes(problem)
 
-    def test_chooses_max_ppn_when_it_fits(self):
-        """Algorithm chooses maximum PPn (highest RF) when it fits within max_nodes.
+        assert result is not None
+        assert result.partitions_per_node == 2
+        assert result.nodes_for_one_copy == 5
 
-        Higher PPn → fewer base nodes → higher RF for same CPU.
-        """
+    def test_returns_none_when_partition_exceeds_node_memory(self):
+        """Algorithm rejects a partition that cannot fit in node memory."""
+        problem = CapacityProblem(
+            n_partitions=10,
+            partition_size_gib=100,
+            disk_per_node_gib=500,
+            memory_per_partition_gib=60,
+            memory_per_node_gib=50,
+            cpu_per_node=16,
+            cpu_needed=32,
+            min_rf=2,
+            max_nodes=100,
+        )
+
+        assert search_for_min_nodes(problem) is None
+
+    def test_memory_driven_nodes_reduce_cpu_replica_count(self):
+        """Memory-driven nodes replace replicas that were needed only for CPU."""
+        problem = CapacityProblem(
+            n_partitions=8,
+            partition_size_gib=100,
+            disk_per_node_gib=500,
+            memory_per_partition_gib=25,
+            memory_per_node_gib=50,
+            cpu_per_node=1,
+            cpu_needed=12,
+            min_rf=2,
+            max_nodes=100,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.nodes_for_one_copy == 4
+        assert result.replica_count == 3
+        assert result.node_count == 12
+
+    def test_requires_complete_memory_constraint(self):
+        """Memory placement requires both the partition need and node capacity."""
+        with pytest.raises(ValueError, match="must be set together"):
+            CapacityProblem(
+                n_partitions=10,
+                partition_size_gib=100,
+                disk_per_node_gib=500,
+                memory_per_partition_gib=25,
+                cpu_per_node=16,
+                cpu_needed=32,
+                min_rf=2,
+                max_nodes=100,
+            )
+
+    def test_tiny_partitions_preserve_maximum_packing(self):
+        """Packing above the partition count is one equivalent search candidate."""
+        problem = CapacityProblem(
+            n_partitions=12,
+            partition_size_gib=0.1,
+            disk_per_node_gib=14_000,
+            cpu_per_node=16,
+            cpu_needed=16,
+            min_rf=2,
+            max_nodes=100,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.node_count == 2
+        assert result.nodes_for_one_copy == 1
+        assert result.partitions_per_node == 140_000
+
+
+class TestPlanSelection:
+    """Tests that verify cost and replication factor plan selection."""
+
+    def test_chooses_max_ppn_when_it_minimizes_nodes(self):
+        """Dense packing minimizes nodes when the minimum RF dominates."""
         problem = CapacityProblem(
             n_partitions=100,
             partition_size_gib=100,
@@ -82,7 +170,7 @@ class TestHigherRFBias:
             min_rf=2,
             max_nodes=1000,  # Relaxed constraint
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
         # With max_ppn=10, base=ceil(100/10)=10, cpu_per_copy=160 >= 64
@@ -91,14 +179,14 @@ class TestHigherRFBias:
         assert result.nodes_for_one_copy == 10
         assert result.replica_count == 2
 
-    def test_higher_ppn_gives_higher_rf_for_cpu_constrained(self):
-        """For CPU-constrained workloads, higher PPn results in higher RF.
+    def test_prefers_fewer_nodes_over_higher_rf(self):
+        """For CPU-constrained workloads, prefer fewer nodes over higher RF.
 
         Example: 200 partitions, 575 GiB each, 2048 GiB disk, need 3200 cores
         - PPn=3: base=67, needs RF=3 for CPU → 201 nodes
         - PPn=2: base=100, needs RF=2 for CPU → 200 nodes
 
-        Algorithm chooses PPn=3 (higher RF) even though it uses 1 more node.
+        The lower RF plan saves one node while satisfying the minimum RF.
         """
         problem = CapacityProblem(
             n_partitions=200,
@@ -109,21 +197,15 @@ class TestHigherRFBias:
             min_rf=2,
             max_nodes=10000,
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
-        assert result.partitions_per_node == 3  # Max PPn, not 2
-        assert result.replica_count == 3  # Higher RF
-        assert (
-            result.node_count == 201
-        )  # Slightly more nodes, but better fault tolerance
+        assert result.partitions_per_node == 2
+        assert result.replica_count == 2
+        assert result.node_count == 200
 
-    def test_falls_back_to_lower_ppn_when_max_exceeds_limit(self):
-        """Algorithm falls back to lower PPn when max PPn exceeds max_nodes.
-
-        This is where the algorithm shines: it finds solutions that a greedy
-        max-PPn approach would miss.
-        """
+    def test_returns_none_when_every_ppn_exceeds_limit(self):
+        """Algorithm returns None when no partition density fits the node limit."""
         problem = CapacityProblem(
             n_partitions=21,
             partition_size_gib=200,
@@ -139,12 +221,12 @@ class TestHigherRFBias:
         # PPn=3: base=7, cpu_per_copy=56, needs RF=3, nodes=21 > 10 ❌
         # PPn=2: base=11, cpu_per_copy=88, needs RF=2, nodes=22 > 10 ❌
 
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
         # All configurations exceed max_nodes
         assert result is None
 
-    def test_finds_first_valid_from_max_ppn(self):
-        """Algorithm returns first valid configuration starting from max PPn."""
+    def test_selects_cheapest_valid_configuration(self):
+        """Algorithm evaluates valid configurations instead of returning the first."""
         problem = CapacityProblem(
             n_partitions=100,
             partition_size_gib=100,
@@ -154,37 +236,36 @@ class TestHigherRFBias:
             min_rf=2,
             max_nodes=60,
         )
-        # PPn=5: base=20, cpu_per_copy=320, needs RF=3, nodes=60 ✓ FIRST VALID
-        # PPn=4: base=25, cpu_per_copy=400, needs RF=2, nodes=50 ✓ (fewer nodes)
+        # PPn=5: base=20, cpu_per_copy=320, needs RF=3, nodes=60
+        # PPn=4: base=25, cpu_per_copy=400, needs RF=2, nodes=50
 
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
-        # Algorithm returns PPn=5 (first valid from max), not PPn=4 (fewer nodes)
-        assert result.partitions_per_node == 5
-        assert result.replica_count == 3  # Higher RF
-        assert result.node_count == 60
+        assert result.partitions_per_node == 4
+        assert result.replica_count == 2
+        assert result.node_count == 50
 
-    def test_prefers_rf3_over_rf2_when_both_fit(self):
-        """When both RF=3 and RF=2 configurations fit, prefer higher RF."""
+    def test_prefers_higher_rf_for_equal_node_count(self):
+        """Prefer higher RF when two configurations use the same node count."""
         problem = CapacityProblem(
             n_partitions=30,
             partition_size_gib=100,
-            disk_per_node_gib=1000,  # max_ppn = 10
+            disk_per_node_gib=1500,  # max_ppn = 15
             cpu_per_node=16,
-            cpu_needed=96,  # 6 nodes worth
+            cpu_needed=80,  # 5 nodes worth
             min_rf=2,
             max_nodes=100,
         )
-        # PPn=10: base=3, cpu_per_copy=48, needs RF=2, nodes=6 ✓
-        # But PPn=10 is first, so we get RF=2
+        # PPn=15: base=2, needs RF=3, nodes=6
+        # PPn=10: base=3, needs RF=2, nodes=6
 
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
-        assert result.partitions_per_node == 10
-        # Algorithm gives RF=2 here because cpu_per_copy=48 < 96, so min_rf_for_cpu=2
-        assert result.replica_count == 2
+        assert result.node_count == 6
+        assert result.partitions_per_node == 15
+        assert result.replica_count == 3
 
 
 class TestAlgorithmProperties:
@@ -208,7 +289,7 @@ class TestAlgorithmProperties:
     @settings(max_examples=500, deadline=None)
     def test_result_satisfies_all_constraints(self, problem: CapacityProblem):
         """PROPERTY: Any result returned satisfies all constraints."""
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
         if result is None:
             return
 
@@ -228,51 +309,34 @@ class TestAlgorithmProperties:
 
     @given(problem=valid_problems())
     @settings(max_examples=500, deadline=None)
-    def test_no_higher_ppn_is_valid(self, problem: CapacityProblem):
-        """PROPERTY: No PPn higher than the chosen one is valid.
-
-        This confirms the algorithm returns the FIRST valid configuration
-        starting from max PPn (i.e., it prefers higher RF).
-        """
-        result = search_for_max_rf(problem)
+    def test_result_is_best_valid_configuration(self, problem: CapacityProblem):
+        """PROPERTY: No valid configuration has a better selection rank."""
+        result = search_for_min_nodes(problem)
         if result is None:
             return
 
         max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
 
-        # Check all PPn values higher than the chosen one
-        for ppn in range(max_ppn, result.partitions_per_node, -1):
+        result_rank = (
+            result.node_count,
+            -result.replica_count,
+            -result.partitions_per_node,
+        )
+        for ppn in range(max_ppn, 0, -1):
             base = math.ceil(problem.n_partitions / ppn)
-
-            if base >= 2:
-                min_rf = max(
-                    1, math.ceil(problem.cpu_needed / (base * problem.cpu_per_node))
-                )
-                rf = max(problem.min_rf, min_rf)
-                nodes = base * rf
-            else:
-                if 2 * problem.cpu_per_node >= problem.cpu_needed:
-                    rf = problem.min_rf
-                    nodes = max(2, rf)
-                else:
-                    rf = max(
-                        problem.min_rf,
-                        math.ceil(problem.cpu_needed / problem.cpu_per_node),
-                    )
-                    nodes = rf
-
-            # This higher PPn must exceed max_nodes
-            assert nodes > problem.max_nodes, (
-                f"Higher PPn={ppn} gives {nodes} nodes "
-                f"<= max_nodes={problem.max_nodes}, "
-                f"but algorithm chose PPn={result.partitions_per_node}"
+            rf = max(
+                problem.min_rf,
+                math.ceil(problem.cpu_needed / (base * problem.cpu_per_node)),
             )
+            nodes = max(base * rf, 2)
+            if nodes <= problem.max_nodes:
+                assert result_rank <= (nodes, -rf, -ppn)
 
     @given(problem=valid_problems())
     @settings(max_examples=500, deadline=None)
     def test_node_count_formula_is_correct(self, problem: CapacityProblem):
         """PROPERTY: node_count = nodes_for_one_copy * replica_count."""
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
         if result is None:
             return
 
@@ -302,10 +366,10 @@ class TestEdgeCases:
             min_rf=2,
             max_nodes=100,
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
-        # Algorithm returns first valid PPn from max (5), not 1
+        # Equal-cost plans retain the densest partition packing.
         assert result.partitions_per_node == 5
         assert result.nodes_for_one_copy == 1
         assert result.replica_count == 2  # min_rf (2*16=32 >= 32 cpu_needed)
@@ -322,7 +386,7 @@ class TestEdgeCases:
             min_rf=1,
             max_nodes=100,
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
         assert result.replica_count >= 1
@@ -338,7 +402,7 @@ class TestEdgeCases:
             min_rf=2,
             max_nodes=4,  # Exactly fits 2 nodes * 2 RF
         )
-        result = search_for_max_rf(problem)
+        result = search_for_min_nodes(problem)
 
         assert result is not None
         assert result.node_count == 4

--- a/tests/netflix/test_partition_aware_algorithm.py
+++ b/tests/netflix/test_partition_aware_algorithm.py
@@ -17,6 +17,44 @@ from service_capacity_modeling.models.org.netflix.partition_aware_algorithm impo
 )
 
 
+@st.composite
+def valid_problems(draw):
+    """Generate disk-only and memory-constrained capacity problems."""
+    n_partitions = draw(st.integers(min_value=1, max_value=1000))
+    partition_size_gib = draw(st.floats(min_value=1, max_value=500, allow_nan=False))
+    disk_per_node_gib = partition_size_gib * draw(
+        st.integers(min_value=1, max_value=40)
+    )
+    memory_per_partition_gib = None
+    memory_per_node_gib = None
+    if draw(st.booleans()):
+        memory_per_partition_gib = draw(
+            st.floats(min_value=0.1, max_value=100, allow_nan=False)
+        )
+        memory_per_node_gib = memory_per_partition_gib * draw(
+            st.integers(min_value=1, max_value=40)
+        )
+
+    cpu_per_node = draw(st.integers(min_value=2, max_value=128))
+    cpu_needed = draw(st.integers(min_value=1, max_value=10000))
+    min_rf = draw(st.integers(min_value=1, max_value=5))
+    max_nodes = n_partitions * max(
+        min_rf, math.ceil(cpu_needed / (n_partitions * cpu_per_node))
+    )
+
+    return CapacityProblem(
+        n_partitions=n_partitions,
+        partition_size_gib=partition_size_gib,
+        disk_per_node_gib=disk_per_node_gib,
+        memory_per_partition_gib=memory_per_partition_gib,
+        memory_per_node_gib=memory_per_node_gib,
+        cpu_per_node=cpu_per_node,
+        cpu_needed=cpu_needed,
+        min_rf=min_rf,
+        max_nodes=max_nodes,
+    )
+
+
 class TestAlgorithmBasics:
     """Basic functionality tests for the algorithm."""
 
@@ -84,6 +122,27 @@ class TestAlgorithmBasics:
         assert result is not None
         assert result.partitions_per_node == 2
         assert result.nodes_for_one_copy == 5
+        assert result.max_partitions_per_node_by_disk == 5
+        assert result.max_partitions_per_node_by_memory == 2
+
+    def test_exact_float_boundary_keeps_valid_partition_fit(self):
+        problem = CapacityProblem(
+            n_partitions=188,
+            partition_size_gib=1,
+            disk_per_node_gib=10_000,
+            memory_per_partition_gib=53.39 / 47,
+            memory_per_node_gib=53.39,
+            cpu_per_node=16,
+            cpu_needed=1,
+            min_rf=2,
+            max_nodes=8,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.partitions_per_node == 47
+        assert result.node_count == 8
 
     def test_returns_none_when_partition_exceeds_node_memory(self):
         """Algorithm rejects a partition that cannot fit in node memory."""
@@ -267,23 +326,41 @@ class TestPlanSelection:
         assert result.partitions_per_node == 15
         assert result.replica_count == 3
 
+    def test_skips_equivalent_partition_densities(self, monkeypatch):
+        real_ceil = math.ceil
+        ceil_calls = 0
+
+        def counting_ceil(value):
+            nonlocal ceil_calls
+            ceil_calls += 1
+            assert ceil_calls <= 5_000
+            return real_ceil(value)
+
+        monkeypatch.setattr(
+            "service_capacity_modeling.models.org.netflix."
+            "partition_aware_algorithm.math.ceil",
+            counting_ceil,
+        )
+        problem = CapacityProblem(
+            n_partitions=1_000_000,
+            partition_size_gib=1,
+            disk_per_node_gib=100_000,
+            cpu_per_node=16,
+            cpu_needed=10_000,
+            min_rf=2,
+            max_nodes=1_000_000_000,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.node_count == 625
+        assert result.replica_count == 25
+        assert result.partitions_per_node == 41_666
+
 
 class TestAlgorithmProperties:
     """Property-based tests using Hypothesis."""
-
-    @staticmethod
-    def valid_problems():
-        """Generate valid capacity problems."""
-        return st.builds(
-            CapacityProblem,
-            n_partitions=st.integers(min_value=1, max_value=1000),
-            partition_size_gib=st.floats(min_value=1, max_value=500),
-            disk_per_node_gib=st.floats(min_value=100, max_value=4000),
-            cpu_per_node=st.integers(min_value=2, max_value=128),
-            cpu_needed=st.integers(min_value=1, max_value=10000),
-            min_rf=st.integers(min_value=1, max_value=5),
-            max_nodes=st.integers(min_value=2, max_value=1000),
-        ).filter(lambda p: p.disk_per_node_gib >= p.partition_size_gib)
 
     @given(problem=valid_problems())
     @settings(max_examples=500, deadline=None)
@@ -300,8 +377,21 @@ class TestAlgorithmProperties:
         assert result.replica_count >= problem.min_rf
 
         # PPn is valid
-        max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
-        assert 1 <= result.partitions_per_node <= max_ppn
+        assert 1 <= result.partitions_per_node <= result.max_partitions_per_node_by_disk
+        used_disk_gib = result.partitions_per_node * problem.partition_size_gib
+        assert used_disk_gib <= math.nextafter(problem.disk_per_node_gib, math.inf)
+        if problem.memory_per_partition_gib is not None:
+            assert result.max_partitions_per_node_by_memory is not None
+            assert (
+                result.partitions_per_node <= result.max_partitions_per_node_by_memory
+            )
+            assert problem.memory_per_node_gib is not None
+            used_memory_gib = (
+                result.partitions_per_node * problem.memory_per_partition_gib
+            )
+            assert used_memory_gib <= math.nextafter(
+                problem.memory_per_node_gib, math.inf
+            )
 
         # CPU constraint satisfied
         total_cpu = result.node_count * problem.cpu_per_node
@@ -315,7 +405,21 @@ class TestAlgorithmProperties:
         if result is None:
             return
 
-        max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
+        disk_ppn = math.floor(
+            math.nextafter(
+                problem.disk_per_node_gib / problem.partition_size_gib, math.inf
+            )
+        )
+        max_ppn = disk_ppn
+        if problem.memory_per_partition_gib is not None:
+            assert problem.memory_per_node_gib is not None
+            memory_ppn = math.floor(
+                math.nextafter(
+                    problem.memory_per_node_gib / problem.memory_per_partition_gib,
+                    math.inf,
+                )
+            )
+            max_ppn = min(max_ppn, memory_ppn)
 
         result_rank = (
             result.node_count,
@@ -397,6 +501,8 @@ class TestEdgeCases:
             n_partitions=10,
             partition_size_gib=100,
             disk_per_node_gib=500,  # Exactly 5 partitions per node
+            memory_per_partition_gib=10,
+            memory_per_node_gib=50,
             cpu_per_node=16,
             cpu_needed=32,
             min_rf=2,
@@ -409,3 +515,5 @@ class TestEdgeCases:
         assert result.partitions_per_node == 5
         assert result.nodes_for_one_copy == 2
         assert result.replica_count == 2
+        assert result.max_partitions_per_node_by_disk == 5
+        assert result.max_partitions_per_node_by_memory == 5

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -36,7 +36,13 @@ from service_capacity_modeling.models.org.netflix.read_only_kv import (
     _compute_penalties,
 )
 from service_capacity_modeling.models.org.netflix.read_only_kv import (
+    _estimate_read_only_kv_cluster,
+)
+from service_capacity_modeling.models.org.netflix.read_only_kv import (
     NflxReadOnlyKVCapacityModel,
+)
+from service_capacity_modeling.models.org.netflix.read_only_kv import (
+    NflxReadOnlyKVArguments,
 )
 from tests.util import get_total_storage_gib
 from tests.util import has_local_storage
@@ -632,6 +638,139 @@ class TestReadOnlyKVMultiplePlans:
 
 class TestReadOnlyKVPartitionAwareAlgorithm:
     """Tests for the partition-aware capacity planning algorithm."""
+
+    def test_large_manifest_uses_memory_safe_lowest_cost_plan(self):
+        """A 1.3 TiB, 50k RPS workload cannot place one copy on one node."""
+        desires = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(50_000),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_int(1_300),
+            ),
+            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        )
+        instance = shapes.instance("i4i.2xlarge")
+
+        disk_only_plan = _estimate_read_only_kv_cluster(
+            instance=instance,
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=16,
+                sst_memory_overhead_ratio=0,
+            ),
+        )
+        memory_safe_plan = _estimate_read_only_kv_cluster(
+            instance=instance,
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=16),
+        )
+
+        assert disk_only_plan is not None
+        assert memory_safe_plan is not None
+        disk_only_cluster = disk_only_plan.candidate_clusters.regional[0]
+        memory_safe_cluster = memory_safe_plan.candidate_clusters.regional[0]
+        assert disk_only_cluster.cluster_params["read-only-kv.nodes_for_one_copy"] == 1
+        assert disk_only_cluster.cluster_params["read-only-kv.replica_count"] == 13
+        sst_memory_per_copy_gib = memory_safe_cluster.cluster_params[
+            "read-only-kv.sst_memory_per_copy_gib"
+        ]
+        available_sst_memory_per_node_gib = memory_safe_cluster.cluster_params[
+            "read-only-kv.available_sst_memory_per_node_gib"
+        ]
+        assert sst_memory_per_copy_gib == 65
+        assert available_sst_memory_per_node_gib == pytest.approx(53.04)
+        assert sst_memory_per_copy_gib > available_sst_memory_per_node_gib
+        assert (
+            memory_safe_cluster.cluster_params["read-only-kv.nodes_for_one_copy"] == 2
+        )
+        assert (
+            memory_safe_cluster.cluster_params[
+                "read-only-kv.sst_memory_per_partition_gib"
+            ]
+            * memory_safe_cluster.cluster_params["read-only-kv.partitions_per_node"]
+            <= available_sst_memory_per_node_gib
+        )
+        assert memory_safe_cluster.cluster_params["read-only-kv.replica_count"] == 7
+        assert memory_safe_cluster.count == 14
+
+    def test_sst_memory_overhead_limits_partitions_per_node(self):
+        """SST index memory limits packing before local disk is full."""
+        desires = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(2_000),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_int(13_000),
+            ),
+            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        )
+        instance = shapes.instance("i3en.2xlarge")
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=instance,
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 5
+        assert plan.requirements.regional[0].mem_gib.mid == pytest.approx(650)
+        assert cluster.cluster_params["effective_disk_per_node_gib"] == pytest.approx(
+            2048 * 1.15
+        )
+        assert cluster.cluster_params[
+            "read-only-kv.available_sst_memory_per_node_gib"
+        ] == pytest.approx(instance.ram_gib - 8)
+        assert cluster.cluster_params["read-only-kv.replica_count"] == 2
+        assert cluster.cluster_params["read-only-kv.total_sst_memory_gib"] == 1300
+
+    def test_sst_memory_overhead_can_be_disabled(self):
+        """A zero overhead ratio preserves disk-only partition packing."""
+        desires = CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(2_000),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_int(13_000),
+            ),
+            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        )
+        instance = shapes.instance("i3en.2xlarge")
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=instance,
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=64,
+                sst_memory_overhead_ratio=0,
+            ),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 10
+        assert plan.requirements.regional[0].mem_gib.mid == 0
+        assert (
+            cluster.cluster_params["read-only-kv.available_sst_memory_per_node_gib"]
+            is None
+        )
 
     def test_compute_heavy_increases_replica_count(self):
         """Test that compute-heavy workloads increase replica count.

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 Tests for Netflix Read-Only Key-Value capacity model.
 
@@ -639,6 +640,21 @@ class TestReadOnlyKVMultiplePlans:
 class TestReadOnlyKVPartitionAwareAlgorithm:
     """Tests for the partition-aware capacity planning algorithm."""
 
+    @pytest.fixture
+    def sst_memory_desires(self):
+        return CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(2_000),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(13_000)),
+            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        )
+
     def test_large_manifest_uses_memory_safe_lowest_cost_plan(self):
         """A 1.3 TiB, 50k RPS workload cannot place one copy on one node."""
         desires = CapacityDesires(
@@ -678,12 +694,12 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert disk_only_cluster.cluster_params["read-only-kv.nodes_for_one_copy"] == 1
         assert disk_only_cluster.cluster_params["read-only-kv.replica_count"] == 13
         sst_memory_per_copy_gib = memory_safe_cluster.cluster_params[
-            "read-only-kv.sst_memory_per_copy_gib"
+            "read-only-kv.buffered_sst_memory_per_copy_gib"
         ]
         available_sst_memory_per_node_gib = memory_safe_cluster.cluster_params[
             "read-only-kv.available_sst_memory_per_node_gib"
         ]
-        assert sst_memory_per_copy_gib == 65
+        assert sst_memory_per_copy_gib == 78
         assert available_sst_memory_per_node_gib == pytest.approx(53.04)
         assert sst_memory_per_copy_gib > available_sst_memory_per_node_gib
         assert (
@@ -691,7 +707,7 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         )
         assert (
             memory_safe_cluster.cluster_params[
-                "read-only-kv.sst_memory_per_partition_gib"
+                "read-only-kv.buffered_sst_memory_per_partition_gib"
             ]
             * memory_safe_cluster.cluster_params["read-only-kv.partitions_per_node"]
             <= available_sst_memory_per_node_gib
@@ -699,64 +715,54 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert memory_safe_cluster.cluster_params["read-only-kv.replica_count"] == 7
         assert memory_safe_cluster.count == 14
 
-    def test_sst_memory_overhead_limits_partitions_per_node(self):
+    def test_sst_memory_overhead_limits_partitions_per_node(self, sst_memory_desires):
         """SST index memory limits packing before local disk is full."""
-        desires = CapacityDesires(
-            service_tier=1,
-            query_pattern=QueryPattern(
-                access_pattern=AccessPattern.latency,
-                estimated_read_per_second=certain_int(2_000),
-                estimated_write_per_second=certain_int(0),
-                estimated_mean_read_latency_ms=certain_float(2.0),
-                estimated_mean_read_size_bytes=certain_int(2048),
-            ),
-            data_shape=DataShape(
-                estimated_state_size_gib=certain_int(13_000),
-            ),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
-        )
         instance = shapes.instance("i3en.2xlarge")
 
         plan = _estimate_read_only_kv_cluster(
             instance=instance,
-            desires=desires,
+            desires=sst_memory_desires,
             args=NflxReadOnlyKVArguments(total_num_partitions=64),
         )
 
         assert plan is not None
         cluster = plan.candidate_clusters.regional[0]
-        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 5
-        assert plan.requirements.regional[0].mem_gib.mid == pytest.approx(650)
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 4
+        assert plan.requirements.regional[0].mem_gib.mid == pytest.approx(1_560)
+        assert (
+            plan.requirements.regional[0].mem_gib.mid
+            == cluster.cluster_params["read-only-kv.total_buffered_sst_memory_gib"]
+        )
         assert cluster.cluster_params["effective_disk_per_node_gib"] == pytest.approx(
             2048 * 1.15
         )
         assert cluster.cluster_params[
             "read-only-kv.available_sst_memory_per_node_gib"
         ] == pytest.approx(instance.ram_gib - 8)
-        assert cluster.cluster_params["read-only-kv.replica_count"] == 2
-        assert cluster.cluster_params["read-only-kv.total_sst_memory_gib"] == 1300
-
-    def test_sst_memory_overhead_can_be_disabled(self):
-        """A zero overhead ratio preserves disk-only partition packing."""
-        desires = CapacityDesires(
-            service_tier=1,
-            query_pattern=QueryPattern(
-                access_pattern=AccessPattern.latency,
-                estimated_read_per_second=certain_int(2_000),
-                estimated_write_per_second=certain_int(0),
-                estimated_mean_read_latency_ms=certain_float(2.0),
-                estimated_mean_read_size_bytes=certain_int(2048),
-            ),
-            data_shape=DataShape(
-                estimated_state_size_gib=certain_int(13_000),
-            ),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_disk"] == 10
         )
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_memory"]
+            == 4
+        )
+        assert cluster.cluster_params["read-only-kv.memory_buffer_ratio"] == 1.2
+        assert cluster.cluster_params["read-only-kv.replica_count"] == 2
+        assert (
+            cluster.cluster_params["read-only-kv.estimated_sst_memory_per_copy_gib"]
+            == 650
+        )
+        assert (
+            cluster.cluster_params["read-only-kv.total_buffered_sst_memory_gib"] == 1560
+        )
+
+    def test_sst_memory_overhead_can_be_disabled(self, sst_memory_desires):
+        """A zero overhead ratio preserves disk-only partition packing."""
         instance = shapes.instance("i3en.2xlarge")
 
         plan = _estimate_read_only_kv_cluster(
             instance=instance,
-            desires=desires,
+            desires=sst_memory_desires,
             args=NflxReadOnlyKVArguments(
                 total_num_partitions=64,
                 sst_memory_overhead_ratio=0,
@@ -770,6 +776,132 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert (
             cluster.cluster_params["read-only-kv.available_sst_memory_per_node_gib"]
             is None
+        )
+
+    def test_disabled_sst_memory_ignores_memory_reservations(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 64
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=64,
+                sst_memory_overhead_ratio=0,
+            ),
+        )
+
+        assert plan is not None
+
+    @pytest.mark.parametrize(
+        "component, expected_disk_limit",
+        [(BufferComponent.memory, 10), (BufferComponent.storage, 9)],
+    )
+    def test_memory_buffer_limits_partition_packing(
+        self, sst_memory_desires, component, expected_disk_limit
+    ):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired["sst-headroom"] = Buffer(
+            ratio=2, components=[component]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.memory_buffer_ratio"] == 2.4
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 2
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_memory"]
+            == 2
+        )
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_disk"]
+            == expected_disk_limit
+        )
+
+    def test_data_shape_reservation_limits_partition_packing(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 40
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.reserved_memory_per_node_gib"] == 41
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 1
+
+    def test_reservation_exceeding_ram_rejects_instance(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 64
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is None
+
+    def test_zero_state_returns_no_plan(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.estimated_state_size_gib = certain_int(0)
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is None
+
+    @pytest.mark.parametrize("sst_memory_overhead_ratio", [0, 0.05])
+    def test_zero_memory_buffer_returns_no_plan(
+        self, sst_memory_desires, sst_memory_overhead_ratio
+    ):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired["memory"] = Buffer(
+            ratio=0, components=[BufferComponent.memory]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=64,
+                sst_memory_overhead_ratio=sst_memory_overhead_ratio,
+            ),
+        )
+
+        assert plan is None
+
+    def test_sst_memory_does_not_change_effective_disk(self, sst_memory_desires):
+        plans = [
+            _estimate_read_only_kv_cluster(
+                instance=shapes.instance("i3en.2xlarge"),
+                desires=sst_memory_desires,
+                args=NflxReadOnlyKVArguments(
+                    total_num_partitions=64,
+                    sst_memory_overhead_ratio=ratio,
+                ),
+            )
+            for ratio in (0.05, 0.15)
+        ]
+
+        assert all(plan is not None for plan in plans)
+        clusters = [plan.candidate_clusters.regional[0] for plan in plans if plan]
+        assert clusters[0].count != clusters[1].count
+        assert (
+            clusters[0].cluster_params["effective_disk_per_node_gib"]
+            == clusters[1].cluster_params["effective_disk_per_node_gib"]
         )
 
     def test_compute_heavy_increases_replica_count(self):

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -45,6 +45,9 @@ from service_capacity_modeling.models.org.netflix.read_only_kv import (
 from service_capacity_modeling.models.org.netflix.read_only_kv import (
     NflxReadOnlyKVArguments,
 )
+from service_capacity_modeling.models.org.netflix.read_only_kv import (
+    SST_MEMORY_BUFFER_NAME,
+)
 from tests.util import get_total_storage_gib
 from tests.util import has_local_storage
 
@@ -642,6 +645,10 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
 
     @pytest.fixture
     def sst_memory_desires(self):
+        buffers = NflxReadOnlyKVCapacityModel.default_buffers()
+        buffers.desired[SST_MEMORY_BUFFER_NAME] = Buffer(
+            ratio=1.2, components=[BufferComponent.memory]
+        )
         return CapacityDesires(
             service_tier=1,
             query_pattern=QueryPattern(
@@ -652,11 +659,15 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
                 estimated_mean_read_size_bytes=certain_int(2048),
             ),
             data_shape=DataShape(estimated_state_size_gib=certain_int(13_000)),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+            buffers=buffers,
         )
 
     def test_large_manifest_uses_memory_safe_lowest_cost_plan(self):
         """A 1.3 TiB, 50k RPS workload cannot place one copy on one node."""
+        buffers = NflxReadOnlyKVCapacityModel.default_buffers()
+        buffers.desired[SST_MEMORY_BUFFER_NAME] = Buffer(
+            ratio=1.2, components=[BufferComponent.memory]
+        )
         desires = CapacityDesires(
             service_tier=1,
             query_pattern=QueryPattern(
@@ -669,7 +680,7 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
             data_shape=DataShape(
                 estimated_state_size_gib=certain_int(1_300),
             ),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+            buffers=buffers,
         )
         instance = shapes.instance("i4i.2xlarge")
 
@@ -714,6 +725,68 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         )
         assert memory_safe_cluster.cluster_params["read-only-kv.replica_count"] == 7
         assert memory_safe_cluster.count == 14
+
+    def test_sst_memory_requires_named_buffer(self, sst_memory_desires):
+        """The SST estimate remains dormant without an explicit opt-in buffer."""
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired.pop(SST_MEMORY_BUFFER_NAME)
+        desires.buffers.desired["other-memory"] = Buffer(
+            ratio=2, components=[BufferComponent.memory]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 10
+        assert plan.requirements.regional[0].mem_gib.mid == 0
+        assert "read-only-kv.sst_memory_overhead_ratio" not in cluster.cluster_params
+
+    def test_planner_merges_named_sst_memory_buffer(self, sst_memory_desires):
+        """The namespace buffer survives merging with model defaults."""
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers = Buffers(
+            desired={
+                SST_MEMORY_BUFFER_NAME: Buffer(
+                    ratio=1.2, components=[BufferComponent.memory]
+                )
+            }
+        )
+
+        plan = planner.plan_certain(
+            model_name="org.netflix.read-only-kv",
+            region="us-east-1",
+            desires=desires,
+            extra_model_arguments={"total_num_partitions": 64},
+            instance_families=["i3en"],
+        )[0]
+
+        cluster = plan.candidate_clusters.regional[0]
+        assert (
+            cluster.cluster_params["read-only-kv.sst_memory_buffer"]
+            == SST_MEMORY_BUFFER_NAME
+        )
+        assert cluster.cluster_params["read-only-kv.memory_buffer_ratio"] == 1.2
+
+    def test_named_sst_memory_buffer_requires_memory_component(
+        self, sst_memory_desires
+    ):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired[SST_MEMORY_BUFFER_NAME] = Buffer(
+            ratio=1.2, components=[BufferComponent.compute]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is None
 
     def test_sst_memory_overhead_limits_partitions_per_node(self, sst_memory_desires):
         """SST index memory limits packing before local disk is full."""
@@ -774,8 +847,8 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 10
         assert plan.requirements.regional[0].mem_gib.mid == 0
         assert (
-            cluster.cluster_params["read-only-kv.available_sst_memory_per_node_gib"]
-            is None
+            "read-only-kv.available_sst_memory_per_node_gib"
+            not in cluster.cluster_params
         )
 
     def test_disabled_sst_memory_ignores_memory_reservations(self, sst_memory_desires):
@@ -863,10 +936,7 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
 
         assert plan is None
 
-    @pytest.mark.parametrize("sst_memory_overhead_ratio", [0, 0.05])
-    def test_zero_memory_buffer_returns_no_plan(
-        self, sst_memory_desires, sst_memory_overhead_ratio
-    ):
+    def test_zero_memory_buffer_returns_no_plan(self, sst_memory_desires):
         desires = sst_memory_desires.model_copy(deep=True)
         desires.buffers.desired["memory"] = Buffer(
             ratio=0, components=[BufferComponent.memory]
@@ -875,10 +945,7 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         plan = _estimate_read_only_kv_cluster(
             instance=shapes.instance("i3en.2xlarge"),
             desires=desires,
-            args=NflxReadOnlyKVArguments(
-                total_num_partitions=64,
-                sst_memory_overhead_ratio=sst_memory_overhead_ratio,
-            ),
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
         )
 
         assert plan is None


### PR DESCRIPTION
## Summary

- model resident RocksDB SST table-reader metadata as an opt-in memory placement constraint
- retain legacy disk-only placement unless the workload supplies the named `read_only_kv_sst_memory` desired buffer
- enforce disk and memory as independent partition-placement constraints for opted-in workloads
- evaluate exact partition-density breakpoints and select the plan with the fewest nodes
- preserve higher replication factor as the tie-breaker for plans with equal node count

The named buffer must target `memory` or generic `storage`. Its ratio composes with other applicable memory and storage buffers, so a ratio of 1.2 applies 20% headroom to the configurable 5% SST estimate. Setting `sst_memory_overhead_ratio` to 0 remains an explicit disk-only kill switch.

Workloads without the named buffer do not publish an SST memory requirement, apply memory reservations, or change placement. Generated fleet baselines therefore remain identical to the existing disk-only baselines.

## Placement safety

For opted-in workloads, the planner:

- reserves the greater of the model minimum and workload app plus system reservations
- derives usable node memory with the existing memory abstraction
- applies explicit memory and generic storage buffers
- rejects shapes with non-positive usable memory
- reports buffered regional SST memory across all replicas
- exposes independent disk and memory partition ceilings
- preserves exact floating-point fits and skips equivalent partition densities

## Regression coverage

An anonymized large-manifest regression proves that the named buffer prevents one complete copy from being placed on a node when buffered SST metadata exceeds usable memory. Separate regressions prove that unnamed memory buffers do not activate the feature, the named buffer survives planner default merging, invalid components are rejected, the zero-ratio kill switch restores disk-only behavior, and lower-cost replica/partition combinations win.

## Verification

- Python 3.12 suite: 833 passed, 1 skipped
- focused partition-aware and read-only KV suite: 62 passed
- cost regression suite: 25 passed
- baseline capture: 19/19 certain and 3/3 uncertain scenarios
- generated cost baselines match the existing disk-only values
- Ruff lint and formatting: passed
- Python 3.12 mypy: passed
- targeted Pylint: 10/10

The aggregate local pre-commit command remains blocked by its existing Python 3.9/3.10 hooks parsing Python 3.12 type-alias syntax. The Python 3.12 checks above pass.
