### PR TITLE
fix(read-only-kv): harden SST memory placement

### DIFF
--- a/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
+++ b/service_capacity_modeling/models/org/netflix/partition_aware_algorithm.py
@@ -49,6 +49,14 @@ class CapacityResult(BaseModel):
     replica_count: int  # Replication factor
     partitions_per_node: int  # Partitions placed on each node
     nodes_for_one_copy: int  # Nodes needed for one complete copy of data
+    max_partitions_per_node_by_disk: int
+    max_partitions_per_node_by_memory: Optional[int] = None
+
+
+def _partitions_that_fit(capacity_gib: float, partition_size_gib: float) -> int:
+    """Floor a capacity ratio without losing an exact fit to float error."""
+    fit = capacity_gib / partition_size_gib
+    return math.floor(math.nextafter(fit, math.inf))
 
 
 def search_for_min_nodes(
@@ -67,21 +75,24 @@ def search_for_min_nodes(
         CapacityResult with the lowest node count, or None if no valid
         configuration exists within the constraints.
     """
-    max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
+    disk_ppn = _partitions_that_fit(
+        problem.disk_per_node_gib, problem.partition_size_gib
+    )
+    memory_ppn = None
     if problem.memory_per_partition_gib is not None:
         assert problem.memory_per_node_gib is not None
-        max_ppn = min(
-            max_ppn,
-            int(problem.memory_per_node_gib / problem.memory_per_partition_gib),
+        memory_ppn = _partitions_that_fit(
+            problem.memory_per_node_gib, problem.memory_per_partition_gib
         )
+
+    max_ppn = min(disk_ppn, memory_ppn) if memory_ppn is not None else disk_ppn
     if max_ppn < 1:
         return None
 
-    best_result: Optional[CapacityResult] = None
-    best_rank: Optional[tuple[int, int, int]] = None
-    for ppn in range(min(max_ppn, problem.n_partitions), 0, -1):
+    best_candidate: Optional[tuple[int, int, int, int]] = None
+    ppn = max_ppn
+    while ppn > 0:
         nodes_for_one_copy = math.ceil(problem.n_partitions / ppn)
-        reported_ppn = max_ppn if nodes_for_one_copy == 1 else ppn
 
         # Calculate minimum RF for CPU
         rf = max(
@@ -92,15 +103,23 @@ def search_for_min_nodes(
         total_nodes = max(nodes_for_one_copy * rf, 2)
 
         if total_nodes <= problem.max_nodes:
-            candidate = CapacityResult(
-                node_count=total_nodes,
-                replica_count=rf,
-                partitions_per_node=reported_ppn,
-                nodes_for_one_copy=nodes_for_one_copy,
-            )
-            candidate_rank = (total_nodes, -rf, -reported_ppn)
-            if best_rank is None or candidate_rank < best_rank:
-                best_result = candidate
-                best_rank = candidate_rank
+            candidate = (total_nodes, -rf, -ppn, nodes_for_one_copy)
+            if best_candidate is None or candidate[:3] < best_candidate[:3]:
+                best_candidate = candidate
 
-    return best_result
+        # All skipped densities have the same nodes_for_one_copy and therefore
+        # the same RF and node count. The current ppn wins their tie-break.
+        ppn = (problem.n_partitions - 1) // nodes_for_one_copy
+
+    if best_candidate is None:
+        return None
+
+    node_count, negative_rf, negative_ppn, nodes_for_one_copy = best_candidate
+    return CapacityResult(
+        node_count=node_count,
+        replica_count=-negative_rf,
+        partitions_per_node=-negative_ppn,
+        nodes_for_one_copy=nodes_for_one_copy,
+        max_partitions_per_node_by_disk=disk_ppn,
+        max_partitions_per_node_by_memory=memory_ppn,
+    )

--- a/service_capacity_modeling/models/org/netflix/read_only_kv.py
+++ b/service_capacity_modeling/models/org/netflix/read_only_kv.py
@@ -56,6 +56,7 @@ from service_capacity_modeling.models.common import upsert_params
 from service_capacity_modeling.models.common import normalize_cores
 from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.common import sqrt_staffed_cores
+from service_capacity_modeling.models.common import usable_memory_gib
 from service_capacity_modeling.models.org.netflix.partition_aware_algorithm import (
     CapacityProblem,
     search_for_min_nodes,
@@ -108,14 +109,15 @@ class NflxReadOnlyKVArguments(BaseModel):
     )
     reserved_memory_gib: float = Field(
         default=8.0,
-        description="Reserved memory for the OS, JVM heap, block cache, "
-        "and other processes (GiB).",
+        description="Minimum memory reserved for the OS, JVM heap, block cache, "
+        "and other processes (GiB). Data-shape reservations take precedence when "
+        "their sum is larger.",
         ge=0,
     )
     sst_memory_overhead_ratio: float = Field(
         default=0.05,
-        description="Resident RocksDB table-reader memory as a ratio of SST data "
-        "placed on each node.",
+        description="Planning assumption for resident RocksDB table-reader memory "
+        "per complete data copy, as a ratio of SST data.",
         ge=0,
         le=1,
     )
@@ -136,6 +138,7 @@ def _estimate_read_only_kv_requirement(
     instance: Instance,
     desires: CapacityDesires,
     args: NflxReadOnlyKVArguments,
+    memory_buffer_ratio: float,
 ) -> CapacityRequirement:
     """Estimate the capacity requirement for the read-only KV regional cluster.
 
@@ -147,6 +150,8 @@ def _estimate_read_only_kv_requirement(
     Args:
         instance: The compute instance being considered
         desires: User's capacity desires
+        args: Read-only KV specific arguments
+        memory_buffer_ratio: Memory headroom applied to the SST estimate
 
     Returns:
         CapacityRequirement for the regional cluster
@@ -166,7 +171,9 @@ def _estimate_read_only_kv_requirement(
     )
 
     needed_sst_memory_gib = (
-        desires.data_shape.estimated_state_size_gib.mid * args.sst_memory_overhead_ratio
+        desires.data_shape.estimated_state_size_gib.mid
+        * args.sst_memory_overhead_ratio
+        * memory_buffer_ratio
     )
 
     # Network calculation (read-only, so only outbound read traffic)
@@ -183,21 +190,23 @@ def _estimate_read_only_kv_requirement(
     )
 
 
+# pylint: disable-next=too-many-positional-arguments
 def _compute_read_only_kv_regional_cluster(
     instance: Instance,
     requirement: CapacityRequirement,
     args: NflxReadOnlyKVArguments,
     partition_size_with_buffer_gib: float,
     disk_buffer_ratio: float,
+    memory_buffer_ratio: float,
+    reserved_memory_gib: float,
 ) -> Optional[RegionClusterCapacity]:
     """Compute the regional cluster configuration using the partition-aware algorithm.
 
     Partition-aware algorithm (local disks only):
-    1. CAPACITY FIRST: Calculate partitions_per_node from independent local disk
-       and resident SST memory constraints
-    2. Calculate nodes_for_one_copy = total_partitions / partitions_per_node
-    3. Start with min_replica_count, calculate initial node count
-    4. CHECK CPU: If not satisfied, increase replica_count (uses spare disk)
+    1. Calculate independent disk and resident SST memory partition ceilings.
+    2. Evaluate each distinct nodes-per-copy placement below those ceilings.
+    3. Calculate the replica count required by minimum RF and CPU for each placement.
+    4. Select the fewest nodes, then prefer higher RF and denser packing on ties.
 
     Note: Only supports local disks. EBS/attached disk is not supported because:
     - EBS disk is provisioned exactly for data needs (no spare space)
@@ -209,6 +218,8 @@ def _compute_read_only_kv_regional_cluster(
         args: Read-only KV specific arguments
         partition_size_with_buffer_gib: Size of one partition with disk buffer applied
         disk_buffer_ratio: Disk buffer ratio for headroom
+        memory_buffer_ratio: Memory buffer ratio for headroom
+        reserved_memory_gib: Total memory reserved outside SST table readers
 
     Returns:
         RegionClusterCapacity or None if configuration is not viable
@@ -229,11 +240,13 @@ def _compute_read_only_kv_regional_cluster(
     sst_memory_per_partition_gib = requirement.mem_gib.mid / args.total_num_partitions
     available_sst_memory_per_node_gib = None
     if args.sst_memory_overhead_ratio > 0:
-        available_sst_memory_per_node_gib = max(
-            0, instance.ram_gib - args.reserved_memory_gib
+        usable_memory_per_node_gib = usable_memory_gib(
+            instance, lambda _: reserved_memory_gib
         )
+        if usable_memory_per_node_gib <= 0:
+            return None
+        available_sst_memory_per_node_gib = usable_memory_per_node_gib
 
-    # Step 2: Use partition-aware algorithm to find optimal configuration
     problem = CapacityProblem(
         n_partitions=args.total_num_partitions,
         partition_size_gib=partition_size_with_buffer_gib,
@@ -268,13 +281,26 @@ def _compute_read_only_kv_regional_cluster(
         "read-only-kv.nodes_for_one_copy": result.nodes_for_one_copy,
         "read-only-kv.nodes_for_cpu": math.ceil(total_needed_cores / instance.cpu),
         "read-only-kv.sst_memory_overhead_ratio": args.sst_memory_overhead_ratio,
-        "read-only-kv.sst_memory_per_partition_gib": sst_memory_per_partition_gib,
-        "read-only-kv.sst_memory_per_copy_gib": requirement.mem_gib.mid,
-        "read-only-kv.total_sst_memory_gib": (
+        "read-only-kv.memory_buffer_ratio": memory_buffer_ratio,
+        "read-only-kv.reserved_memory_per_node_gib": reserved_memory_gib,
+        "read-only-kv.buffered_sst_memory_per_partition_gib": (
+            sst_memory_per_partition_gib
+        ),
+        "read-only-kv.estimated_sst_memory_per_copy_gib": (
+            requirement.mem_gib.mid / memory_buffer_ratio
+        ),
+        "read-only-kv.buffered_sst_memory_per_copy_gib": requirement.mem_gib.mid,
+        "read-only-kv.total_buffered_sst_memory_gib": (
             requirement.mem_gib.mid * result.replica_count
         ),
         "read-only-kv.available_sst_memory_per_node_gib": (
             available_sst_memory_per_node_gib
+        ),
+        "read-only-kv.max_partitions_per_node_by_disk": (
+            result.max_partitions_per_node_by_disk
+        ),
+        "read-only-kv.max_partitions_per_node_by_memory": (
+            result.max_partitions_per_node_by_memory
         ),
         EFFECTIVE_DISK_PER_NODE_GIB: effective_disk_per_node,
     }
@@ -321,30 +347,54 @@ def _estimate_read_only_kv_cluster(
     if instance.drive is None:
         return None
 
+    unreplicated_data_gib = desires.data_shape.estimated_state_size_gib.mid
+    if unreplicated_data_gib <= 0:
+        return None
+
+    memory_buffer = buffer_for_components(
+        buffers=desires.buffers, components=[BufferComponent.memory]
+    )
+    if memory_buffer.ratio <= 0:
+        return None
+
     # Calculate requirements
-    requirement = _estimate_read_only_kv_requirement(
-        instance=instance, desires=desires, args=args
+    per_copy_requirement = _estimate_read_only_kv_requirement(
+        instance=instance,
+        desires=desires,
+        args=args,
+        memory_buffer_ratio=memory_buffer.ratio,
     )
 
     # Compute disk buffer values inline (not via context)
     disk_buffer = buffer_for_components(
         buffers=desires.buffers, components=[BufferComponent.disk]
     )
-    unreplicated_data_gib = desires.data_shape.estimated_state_size_gib.mid
     partition_size_gib = unreplicated_data_gib / args.total_num_partitions
     partition_size_with_buffer_gib = partition_size_gib * disk_buffer.ratio
+    reserved_memory_gib = max(
+        args.reserved_memory_gib,
+        desires.data_shape.reserved_instance_app_mem_gib
+        + desires.data_shape.reserved_instance_system_mem_gib,
+    )
 
     # Compute cluster
     cluster = _compute_read_only_kv_regional_cluster(
         instance=instance,
-        requirement=requirement,
+        requirement=per_copy_requirement,
         args=args,
         partition_size_with_buffer_gib=partition_size_with_buffer_gib,
         disk_buffer_ratio=disk_buffer.ratio,
+        memory_buffer_ratio=memory_buffer.ratio,
+        reserved_memory_gib=reserved_memory_gib,
     )
 
     if cluster is None:
         return None
+
+    replica_count = int(cluster.cluster_params["read-only-kv.replica_count"])
+    regional_requirement = per_copy_requirement.model_copy(
+        update={"mem_gib": per_copy_requirement.mem_gib.scale(replica_count)}
+    )
 
     # Build cost breakdown using cluster_costs (consistent with CostAwareModel)
     rokv_costs = NflxReadOnlyKVCapacityModel.cluster_costs(
@@ -363,7 +413,7 @@ def _estimate_read_only_kv_cluster(
     )
 
     return CapacityPlan(
-        requirements=Requirements(regional=[requirement]),
+        requirements=Requirements(regional=[regional_requirement]),
         candidate_clusters=clusters,
         rank=clusters.total_annual_cost * (1 + penalty_ratio),
     )
@@ -456,6 +506,8 @@ class NflxReadOnlyKVCapacityModel(CapacityModel, CostAwareModel):
                 ),  # 67% utilization target
                 # Read-only: can run at high disk utilization
                 "disk": Buffer(ratio=1.15, components=[BufferComponent.disk]),  # 87%
+                # Keep the 5% SST estimate at or below 83.3% of its allocation.
+                "memory": Buffer(ratio=1.2, components=[BufferComponent.memory]),  # 83%
             },
         )
 

--- a/service_capacity_modeling/tools/data/baseline_costs.json
+++ b/service_capacity_modeling/tools/data/baseline_costs.json
@@ -1261,36 +1261,41 @@
   },
   {
     "annual_costs": {
-      "read-only-kv.regional-clusters": 434718.04
+      "read-only-kv.regional-clusters": 480930.32
     },
     "clusters": [
       {
-        "annual_cost": 434718.04,
+        "annual_cost": 480930.32,
         "cluster_params": {
-          "effective_disk_per_node_gib": 1900,
-          "read-only-kv.available_sst_memory_per_node_gib": 53.39,
+          "effective_disk_per_node_gib": 2355.2,
+          "read-only-kv.available_sst_memory_per_node_gib": 114.86,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 2880.0,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 5.625,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 2400.0,
+          "read-only-kv.max_partitions_per_node_by_disk": 21,
+          "read-only-kv.max_partitions_per_node_by_memory": 20,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 4,
-          "read-only-kv.nodes_for_cpu": 10,
-          "read-only-kv.nodes_for_one_copy": 47,
-          "read-only-kv.partitions_per_node": 11,
+          "read-only-kv.nodes_for_cpu": 5,
+          "read-only-kv.nodes_for_one_copy": 26,
+          "read-only-kv.partitions_per_node": 20,
           "read-only-kv.replica_count": 4,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 2400.0,
-          "read-only-kv.sst_memory_per_partition_gib": 4.6875,
-          "read-only-kv.total_num_partitions": 512,
-          "read-only-kv.total_sst_memory_gib": 9600.0
+          "read-only-kv.total_buffered_sst_memory_gib": 11520.0,
+          "read-only-kv.total_num_partitions": 512
         },
         "cluster_type": "read-only-kv",
-        "count": 188,
+        "count": 104,
         "deployment": "regional",
-        "instance": "i3.2xlarge"
+        "instance": "i3.4xlarge"
       }
     ],
     "model": "org.netflix.read-only-kv",
     "region": "us-east-1",
     "scenario": "read_only_kv_large",
     "service_tier": 1,
-    "total_annual_cost": 434718.04
+    "total_annual_cost": 480930.32
   },
   {
     "annual_costs": {
@@ -1302,16 +1307,21 @@
         "cluster_params": {
           "effective_disk_per_node_gib": 873,
           "read-only-kv.available_sst_memory_per_node_gib": 22.52,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 83.82000000000001,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 10.477500000000001,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 69.85000000000001,
+          "read-only-kv.max_partitions_per_node_by_disk": 4,
+          "read-only-kv.max_partitions_per_node_by_memory": 2,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 3,
           "read-only-kv.nodes_for_cpu": 12,
           "read-only-kv.nodes_for_one_copy": 4,
           "read-only-kv.partitions_per_node": 2,
           "read-only-kv.replica_count": 3,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 69.85000000000001,
-          "read-only-kv.sst_memory_per_partition_gib": 8.731250000000001,
-          "read-only-kv.total_num_partitions": 8,
-          "read-only-kv.total_sst_memory_gib": 209.55
+          "read-only-kv.total_buffered_sst_memory_gib": 251.46000000000004,
+          "read-only-kv.total_num_partitions": 8
         },
         "cluster_type": "read-only-kv",
         "count": 12,
@@ -1335,16 +1345,21 @@
         "cluster_params": {
           "effective_disk_per_node_gib": 441,
           "read-only-kv.available_sst_memory_per_node_gib": 22.52,
+          "read-only-kv.buffered_sst_memory_per_copy_gib": 3.5999999999999996,
+          "read-only-kv.buffered_sst_memory_per_partition_gib": 0.22499999999999998,
+          "read-only-kv.estimated_sst_memory_per_copy_gib": 3.0,
+          "read-only-kv.max_partitions_per_node_by_disk": 102,
+          "read-only-kv.max_partitions_per_node_by_memory": 100,
+          "read-only-kv.memory_buffer_ratio": 1.2,
           "read-only-kv.min_replica_count": 4,
           "read-only-kv.nodes_for_cpu": 5,
           "read-only-kv.nodes_for_one_copy": 1,
-          "read-only-kv.partitions_per_node": 102,
+          "read-only-kv.partitions_per_node": 100,
           "read-only-kv.replica_count": 5,
+          "read-only-kv.reserved_memory_per_node_gib": 8.0,
           "read-only-kv.sst_memory_overhead_ratio": 0.05,
-          "read-only-kv.sst_memory_per_copy_gib": 3.0,
-          "read-only-kv.sst_memory_per_partition_gib": 0.1875,
-          "read-only-kv.total_num_partitions": 16,
-          "read-only-kv.total_sst_memory_gib": 15.0
+          "read-only-kv.total_buffered_sst_memory_gib": 18.0,
+          "read-only-kv.total_num_partitions": 16
         },
         "cluster_type": "read-only-kv",
         "count": 5,

--- a/tests/netflix/test_partition_aware_algorithm.py
+++ b/tests/netflix/test_partition_aware_algorithm.py
@@ -17,6 +17,44 @@ from service_capacity_modeling.models.org.netflix.partition_aware_algorithm impo
 )
 
 
+@st.composite
+def valid_problems(draw):
+    """Generate disk-only and memory-constrained capacity problems."""
+    n_partitions = draw(st.integers(min_value=1, max_value=1000))
+    partition_size_gib = draw(st.floats(min_value=1, max_value=500, allow_nan=False))
+    disk_per_node_gib = partition_size_gib * draw(
+        st.integers(min_value=1, max_value=40)
+    )
+    memory_per_partition_gib = None
+    memory_per_node_gib = None
+    if draw(st.booleans()):
+        memory_per_partition_gib = draw(
+            st.floats(min_value=0.1, max_value=100, allow_nan=False)
+        )
+        memory_per_node_gib = memory_per_partition_gib * draw(
+            st.integers(min_value=1, max_value=40)
+        )
+
+    cpu_per_node = draw(st.integers(min_value=2, max_value=128))
+    cpu_needed = draw(st.integers(min_value=1, max_value=10000))
+    min_rf = draw(st.integers(min_value=1, max_value=5))
+    max_nodes = n_partitions * max(
+        min_rf, math.ceil(cpu_needed / (n_partitions * cpu_per_node))
+    )
+
+    return CapacityProblem(
+        n_partitions=n_partitions,
+        partition_size_gib=partition_size_gib,
+        disk_per_node_gib=disk_per_node_gib,
+        memory_per_partition_gib=memory_per_partition_gib,
+        memory_per_node_gib=memory_per_node_gib,
+        cpu_per_node=cpu_per_node,
+        cpu_needed=cpu_needed,
+        min_rf=min_rf,
+        max_nodes=max_nodes,
+    )
+
+
 class TestAlgorithmBasics:
     """Basic functionality tests for the algorithm."""
 
@@ -84,6 +122,27 @@ class TestAlgorithmBasics:
         assert result is not None
         assert result.partitions_per_node == 2
         assert result.nodes_for_one_copy == 5
+        assert result.max_partitions_per_node_by_disk == 5
+        assert result.max_partitions_per_node_by_memory == 2
+
+    def test_exact_float_boundary_keeps_valid_partition_fit(self):
+        problem = CapacityProblem(
+            n_partitions=188,
+            partition_size_gib=1,
+            disk_per_node_gib=10_000,
+            memory_per_partition_gib=53.39 / 47,
+            memory_per_node_gib=53.39,
+            cpu_per_node=16,
+            cpu_needed=1,
+            min_rf=2,
+            max_nodes=8,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.partitions_per_node == 47
+        assert result.node_count == 8
 
     def test_returns_none_when_partition_exceeds_node_memory(self):
         """Algorithm rejects a partition that cannot fit in node memory."""
@@ -267,23 +326,41 @@ class TestPlanSelection:
         assert result.partitions_per_node == 15
         assert result.replica_count == 3
 
+    def test_skips_equivalent_partition_densities(self, monkeypatch):
+        real_ceil = math.ceil
+        ceil_calls = 0
+
+        def counting_ceil(value):
+            nonlocal ceil_calls
+            ceil_calls += 1
+            assert ceil_calls <= 5_000
+            return real_ceil(value)
+
+        monkeypatch.setattr(
+            "service_capacity_modeling.models.org.netflix."
+            "partition_aware_algorithm.math.ceil",
+            counting_ceil,
+        )
+        problem = CapacityProblem(
+            n_partitions=1_000_000,
+            partition_size_gib=1,
+            disk_per_node_gib=100_000,
+            cpu_per_node=16,
+            cpu_needed=10_000,
+            min_rf=2,
+            max_nodes=1_000_000_000,
+        )
+
+        result = search_for_min_nodes(problem)
+
+        assert result is not None
+        assert result.node_count == 625
+        assert result.replica_count == 25
+        assert result.partitions_per_node == 41_666
+
 
 class TestAlgorithmProperties:
     """Property-based tests using Hypothesis."""
-
-    @staticmethod
-    def valid_problems():
-        """Generate valid capacity problems."""
-        return st.builds(
-            CapacityProblem,
-            n_partitions=st.integers(min_value=1, max_value=1000),
-            partition_size_gib=st.floats(min_value=1, max_value=500),
-            disk_per_node_gib=st.floats(min_value=100, max_value=4000),
-            cpu_per_node=st.integers(min_value=2, max_value=128),
-            cpu_needed=st.integers(min_value=1, max_value=10000),
-            min_rf=st.integers(min_value=1, max_value=5),
-            max_nodes=st.integers(min_value=2, max_value=1000),
-        ).filter(lambda p: p.disk_per_node_gib >= p.partition_size_gib)
 
     @given(problem=valid_problems())
     @settings(max_examples=500, deadline=None)
@@ -300,8 +377,21 @@ class TestAlgorithmProperties:
         assert result.replica_count >= problem.min_rf
 
         # PPn is valid
-        max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
-        assert 1 <= result.partitions_per_node <= max_ppn
+        assert 1 <= result.partitions_per_node <= result.max_partitions_per_node_by_disk
+        used_disk_gib = result.partitions_per_node * problem.partition_size_gib
+        assert used_disk_gib <= math.nextafter(problem.disk_per_node_gib, math.inf)
+        if problem.memory_per_partition_gib is not None:
+            assert result.max_partitions_per_node_by_memory is not None
+            assert (
+                result.partitions_per_node <= result.max_partitions_per_node_by_memory
+            )
+            assert problem.memory_per_node_gib is not None
+            used_memory_gib = (
+                result.partitions_per_node * problem.memory_per_partition_gib
+            )
+            assert used_memory_gib <= math.nextafter(
+                problem.memory_per_node_gib, math.inf
+            )
 
         # CPU constraint satisfied
         total_cpu = result.node_count * problem.cpu_per_node
@@ -315,7 +405,21 @@ class TestAlgorithmProperties:
         if result is None:
             return
 
-        max_ppn = int(problem.disk_per_node_gib / problem.partition_size_gib)
+        disk_ppn = math.floor(
+            math.nextafter(
+                problem.disk_per_node_gib / problem.partition_size_gib, math.inf
+            )
+        )
+        max_ppn = disk_ppn
+        if problem.memory_per_partition_gib is not None:
+            assert problem.memory_per_node_gib is not None
+            memory_ppn = math.floor(
+                math.nextafter(
+                    problem.memory_per_node_gib / problem.memory_per_partition_gib,
+                    math.inf,
+                )
+            )
+            max_ppn = min(max_ppn, memory_ppn)
 
         result_rank = (
             result.node_count,
@@ -397,6 +501,8 @@ class TestEdgeCases:
             n_partitions=10,
             partition_size_gib=100,
             disk_per_node_gib=500,  # Exactly 5 partitions per node
+            memory_per_partition_gib=10,
+            memory_per_node_gib=50,
             cpu_per_node=16,
             cpu_needed=32,
             min_rf=2,
@@ -409,3 +515,5 @@ class TestEdgeCases:
         assert result.partitions_per_node == 5
         assert result.nodes_for_one_copy == 2
         assert result.replica_count == 2
+        assert result.max_partitions_per_node_by_disk == 5
+        assert result.max_partitions_per_node_by_memory == 5

--- a/tests/netflix/test_read_only_kv.py
+++ b/tests/netflix/test_read_only_kv.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 Tests for Netflix Read-Only Key-Value capacity model.
 
@@ -639,6 +640,21 @@ class TestReadOnlyKVMultiplePlans:
 class TestReadOnlyKVPartitionAwareAlgorithm:
     """Tests for the partition-aware capacity planning algorithm."""
 
+    @pytest.fixture
+    def sst_memory_desires(self):
+        return CapacityDesires(
+            service_tier=1,
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                estimated_read_per_second=certain_int(2_000),
+                estimated_write_per_second=certain_int(0),
+                estimated_mean_read_latency_ms=certain_float(2.0),
+                estimated_mean_read_size_bytes=certain_int(2048),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(13_000)),
+            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        )
+
     def test_large_manifest_uses_memory_safe_lowest_cost_plan(self):
         """A 1.3 TiB, 50k RPS workload cannot place one copy on one node."""
         desires = CapacityDesires(
@@ -678,12 +694,12 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert disk_only_cluster.cluster_params["read-only-kv.nodes_for_one_copy"] == 1
         assert disk_only_cluster.cluster_params["read-only-kv.replica_count"] == 13
         sst_memory_per_copy_gib = memory_safe_cluster.cluster_params[
-            "read-only-kv.sst_memory_per_copy_gib"
+            "read-only-kv.buffered_sst_memory_per_copy_gib"
         ]
         available_sst_memory_per_node_gib = memory_safe_cluster.cluster_params[
             "read-only-kv.available_sst_memory_per_node_gib"
         ]
-        assert sst_memory_per_copy_gib == 65
+        assert sst_memory_per_copy_gib == 78
         assert available_sst_memory_per_node_gib == pytest.approx(53.04)
         assert sst_memory_per_copy_gib > available_sst_memory_per_node_gib
         assert (
@@ -691,7 +707,7 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         )
         assert (
             memory_safe_cluster.cluster_params[
-                "read-only-kv.sst_memory_per_partition_gib"
+                "read-only-kv.buffered_sst_memory_per_partition_gib"
             ]
             * memory_safe_cluster.cluster_params["read-only-kv.partitions_per_node"]
             <= available_sst_memory_per_node_gib
@@ -699,64 +715,54 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert memory_safe_cluster.cluster_params["read-only-kv.replica_count"] == 7
         assert memory_safe_cluster.count == 14
 
-    def test_sst_memory_overhead_limits_partitions_per_node(self):
+    def test_sst_memory_overhead_limits_partitions_per_node(self, sst_memory_desires):
         """SST index memory limits packing before local disk is full."""
-        desires = CapacityDesires(
-            service_tier=1,
-            query_pattern=QueryPattern(
-                access_pattern=AccessPattern.latency,
-                estimated_read_per_second=certain_int(2_000),
-                estimated_write_per_second=certain_int(0),
-                estimated_mean_read_latency_ms=certain_float(2.0),
-                estimated_mean_read_size_bytes=certain_int(2048),
-            ),
-            data_shape=DataShape(
-                estimated_state_size_gib=certain_int(13_000),
-            ),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
-        )
         instance = shapes.instance("i3en.2xlarge")
 
         plan = _estimate_read_only_kv_cluster(
             instance=instance,
-            desires=desires,
+            desires=sst_memory_desires,
             args=NflxReadOnlyKVArguments(total_num_partitions=64),
         )
 
         assert plan is not None
         cluster = plan.candidate_clusters.regional[0]
-        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 5
-        assert plan.requirements.regional[0].mem_gib.mid == pytest.approx(650)
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 4
+        assert plan.requirements.regional[0].mem_gib.mid == pytest.approx(1_560)
+        assert (
+            plan.requirements.regional[0].mem_gib.mid
+            == cluster.cluster_params["read-only-kv.total_buffered_sst_memory_gib"]
+        )
         assert cluster.cluster_params["effective_disk_per_node_gib"] == pytest.approx(
             2048 * 1.15
         )
         assert cluster.cluster_params[
             "read-only-kv.available_sst_memory_per_node_gib"
         ] == pytest.approx(instance.ram_gib - 8)
-        assert cluster.cluster_params["read-only-kv.replica_count"] == 2
-        assert cluster.cluster_params["read-only-kv.total_sst_memory_gib"] == 1300
-
-    def test_sst_memory_overhead_can_be_disabled(self):
-        """A zero overhead ratio preserves disk-only partition packing."""
-        desires = CapacityDesires(
-            service_tier=1,
-            query_pattern=QueryPattern(
-                access_pattern=AccessPattern.latency,
-                estimated_read_per_second=certain_int(2_000),
-                estimated_write_per_second=certain_int(0),
-                estimated_mean_read_latency_ms=certain_float(2.0),
-                estimated_mean_read_size_bytes=certain_int(2048),
-            ),
-            data_shape=DataShape(
-                estimated_state_size_gib=certain_int(13_000),
-            ),
-            buffers=NflxReadOnlyKVCapacityModel.default_buffers(),
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_disk"] == 10
         )
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_memory"]
+            == 4
+        )
+        assert cluster.cluster_params["read-only-kv.memory_buffer_ratio"] == 1.2
+        assert cluster.cluster_params["read-only-kv.replica_count"] == 2
+        assert (
+            cluster.cluster_params["read-only-kv.estimated_sst_memory_per_copy_gib"]
+            == 650
+        )
+        assert (
+            cluster.cluster_params["read-only-kv.total_buffered_sst_memory_gib"] == 1560
+        )
+
+    def test_sst_memory_overhead_can_be_disabled(self, sst_memory_desires):
+        """A zero overhead ratio preserves disk-only partition packing."""
         instance = shapes.instance("i3en.2xlarge")
 
         plan = _estimate_read_only_kv_cluster(
             instance=instance,
-            desires=desires,
+            desires=sst_memory_desires,
             args=NflxReadOnlyKVArguments(
                 total_num_partitions=64,
                 sst_memory_overhead_ratio=0,
@@ -770,6 +776,132 @@ class TestReadOnlyKVPartitionAwareAlgorithm:
         assert (
             cluster.cluster_params["read-only-kv.available_sst_memory_per_node_gib"]
             is None
+        )
+
+    def test_disabled_sst_memory_ignores_memory_reservations(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 64
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=64,
+                sst_memory_overhead_ratio=0,
+            ),
+        )
+
+        assert plan is not None
+
+    @pytest.mark.parametrize(
+        "component, expected_disk_limit",
+        [(BufferComponent.memory, 10), (BufferComponent.storage, 9)],
+    )
+    def test_memory_buffer_limits_partition_packing(
+        self, sst_memory_desires, component, expected_disk_limit
+    ):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired["sst-headroom"] = Buffer(
+            ratio=2, components=[component]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.memory_buffer_ratio"] == 2.4
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 2
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_memory"]
+            == 2
+        )
+        assert (
+            cluster.cluster_params["read-only-kv.max_partitions_per_node_by_disk"]
+            == expected_disk_limit
+        )
+
+    def test_data_shape_reservation_limits_partition_packing(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 40
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is not None
+        cluster = plan.candidate_clusters.regional[0]
+        assert cluster.cluster_params["read-only-kv.reserved_memory_per_node_gib"] == 41
+        assert cluster.cluster_params["read-only-kv.partitions_per_node"] == 1
+
+    def test_reservation_exceeding_ram_rejects_instance(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.reserved_instance_app_mem_gib = 64
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is None
+
+    def test_zero_state_returns_no_plan(self, sst_memory_desires):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.data_shape.estimated_state_size_gib = certain_int(0)
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(total_num_partitions=64),
+        )
+
+        assert plan is None
+
+    @pytest.mark.parametrize("sst_memory_overhead_ratio", [0, 0.05])
+    def test_zero_memory_buffer_returns_no_plan(
+        self, sst_memory_desires, sst_memory_overhead_ratio
+    ):
+        desires = sst_memory_desires.model_copy(deep=True)
+        desires.buffers.desired["memory"] = Buffer(
+            ratio=0, components=[BufferComponent.memory]
+        )
+
+        plan = _estimate_read_only_kv_cluster(
+            instance=shapes.instance("i3en.2xlarge"),
+            desires=desires,
+            args=NflxReadOnlyKVArguments(
+                total_num_partitions=64,
+                sst_memory_overhead_ratio=sst_memory_overhead_ratio,
+            ),
+        )
+
+        assert plan is None
+
+    def test_sst_memory_does_not_change_effective_disk(self, sst_memory_desires):
+        plans = [
+            _estimate_read_only_kv_cluster(
+                instance=shapes.instance("i3en.2xlarge"),
+                desires=sst_memory_desires,
+                args=NflxReadOnlyKVArguments(
+                    total_num_partitions=64,
+                    sst_memory_overhead_ratio=ratio,
+                ),
+            )
+            for ratio in (0.05, 0.15)
+        ]
+
+        assert all(plan is not None for plan in plans)
+        clusters = [plan.candidate_clusters.regional[0] for plan in plans if plan]
+        assert clusters[0].count != clusters[1].count
+        assert (
+            clusters[0].cluster_params["effective_disk_per_node_gib"]
+            == clusters[1].cluster_params["effective_disk_per_node_gib"]
         )
 
     def test_compute_heavy_increases_replica_count(self):


### PR DESCRIPTION
## Summary

This is an opt-in safety patch for #318. It leaves Wschor's branch unchanged and can be merged into that branch if the additional OOM protection and cost are acceptable.

The patch keeps disk and SST memory as independent placement constraints. It applies the existing memory abstractions to the 5% SST table-reader estimate:

- `buffer_for_components(..., [BufferComponent.memory])`, including generic `storage` fallbacks
- `max(reserved_memory_gib, app reservation + system reservation)`
- `usable_memory_gib`, with non-positive usable memory rejected
- a default 1.2 memory buffer, so the 5% estimate consumes at most 83.3% of its modeled allocation

`sst_memory_overhead_ratio=0` still gives disk-only placement and bypasses SST-specific memory rejection.

## Placement algorithm

The exact search evaluates one candidate for each distinct `nodes_for_one_copy` quotient:

```python
ppn = (n_partitions - 1) // nodes_for_one_copy
```

Every skipped density has the same nodes per copy, replica count, and node count. The evaluated density wins the existing dense-packing tie-break, so the result is identical to exhaustive search while running in O(sqrt(partitions)) candidates. A one-ULP normalization preserves exact floating-point fits.

The planner reports the independent disk and memory partition ceilings rather than a single ambiguous `capacity_limited_by` label. Raw estimated SST memory and buffered SST allocation also have distinct parameter names.

## Memory contract

The placement calculation uses buffered memory for one complete copy. After the algorithm selects RF, `CapacityRequirement.mem_gib` reports the buffered regional total across all copies. This matches the regional requirement contract used by plan comparison.

The 5% coefficient remains a configurable planning assumption, not a measured upper bound. The default 1.2 buffer protects the modeled fit against a coefficient increase from 5% to about 6.126% in the large baseline, a 22.5% margin. Calibration against production RocksDB resident memory remains a separate decision.

## Cost impact

| Version | Large baseline | Annual cost |
| --- | --- | ---: |
| Existing disk-only baseline | 100 × `i3en.xlarge` | $149,967.00 |
| #318 current head | 188 × `i3.2xlarge` | $434,718.04 |
| This safety patch | 104 × `i3.4xlarge` | $480,930.32 |

This patch adds 10.6% over #318. The roughly 3.2x increase versus the existing baseline comes from admitting SST memory as a real bin-packing constraint; the incremental increase here is the explicit 20% memory buffer. Effective disk is unchanged by the SST ratio.

For the selected large plan, disk allows 21 partitions per node and buffered SST memory allows 20. Each node has 114.86 GiB available for SST readers and receives 112.5 GiB of buffered SST allocation.

## Verification

- Full Python 3.12 suite: 829 passed, 1 skipped
- Focused partition-aware and read-only KV suite: 60 passed
- `tox -e pre-commit`: passed, including Ruff, mypy, pylint 10/10, and baseline capture
- Baseline capture: 19/19 certain and 3/3 uncertain scenarios
- Partition algorithm coverage: 100%; read-only KV coverage: 97% focused, 98% full suite
- Independent exhaustive-oracle reviews found no optimizer mismatch across randomized disk-only and memory-constrained problems
- Independent post-fix review: approved with no remaining actionable findings
