### PR TITLE
feat(time-series): default the Cassandra tier to EBS

### DIFF
--- a/service_capacity_modeling/models/org/netflix/time_series.py
+++ b/service_capacity_modeling/models/org/netflix/time_series.py
@@ -22,6 +22,42 @@ from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models import CapacityModel
 
 
+# These bailouts send the Cassandra tier back to regular local disk planning.
+CASSANDRA_EBS_MAX_READ_PER_SECOND = 200_000
+CASSANDRA_EBS_MIN_STATE_SIZE_GIB = 1024
+
+# Ordered bailout rules, each a (name, predicate over the Cassandra facing
+# desires) pair. The first rule that holds wins and names the reason we stayed
+# on local disks.
+CASSANDRA_EBS_BAILOUTS: Tuple[Tuple[str, Callable[[CapacityDesires], bool]], ...] = (
+    (
+        "read_throughput",
+        lambda desires: desires.query_pattern.estimated_read_per_second.mid
+        > CASSANDRA_EBS_MAX_READ_PER_SECOND,
+    ),
+    (
+        "state_size",
+        lambda desires: desires.data_shape.estimated_state_size_gib.mid
+        < CASSANDRA_EBS_MIN_STATE_SIZE_GIB,
+    ),
+)
+
+
+def cassandra_ebs_bailout(cassandra_desires: CapacityDesires) -> Optional[str]:
+    """Name of the first rule keeping the Cassandra tier on local disks.
+
+    Pass the desires Cassandra will actually be planned with, so after
+    TimeSeries read amplification: the read rule is about load landing on
+    Cassandra, not load landing on the TimeSeries tier. An unstated dataset
+    size reads as zero and therefore bails out to local disks. Returns None
+    when nothing bails out and the tier should plan on EBS.
+    """
+    for name, applies in CASSANDRA_EBS_BAILOUTS:
+        if applies(cassandra_desires):
+            return name
+    return None
+
+
 class NflxTimeSeriesCapacityModel(CapacityModel):
     @staticmethod
     def capacity_plan(
@@ -64,8 +100,8 @@ class NflxTimeSeriesCapacityModel(CapacityModel):
         # as well, e.g. if the latency SLO is reduced
         ts_config = TimeSeriesConfiguration(extra_model_arguments)
 
-        def _modify_cassandra_desires(user_desires: CapacityDesires) -> CapacityDesires:
-            modified = user_desires.model_copy(deep=True)
+        def _modify_cassandra_desires(desires: CapacityDesires) -> CapacityDesires:
+            modified = desires.model_copy(deep=True)
             modified.query_pattern.estimated_read_per_second = (
                 modified.query_pattern.estimated_read_per_second.scale(
                     ts_config.read_amplification
@@ -81,6 +117,12 @@ class NflxTimeSeriesCapacityModel(CapacityModel):
                 AccessConsistency.eventual
             )
             return relaxed
+
+        # require_local_disks defaults true and on its own excuses every EBS-only
+        # instance, so asking for EBS has to clear it too.
+        if cassandra_ebs_bailout(_modify_cassandra_desires(user_desires)) is None:
+            extra_model_arguments["require_local_disks"] = False
+            extra_model_arguments["require_attached_disks"] = True
 
         if ts_config.search_enabled:
             return (

--- a/service_capacity_modeling/models/org/netflix/time_series.py
+++ b/service_capacity_modeling/models/org/netflix/time_series.py
@@ -22,40 +22,10 @@ from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models import CapacityModel
 
 
-# These bailouts send the Cassandra tier back to regular local disk planning.
+# The Cassandra tier plans on EBS unless it is too read hot for attached disks
+# or the dataset is too small for decoupling storage from compute to pay off.
 CASSANDRA_EBS_MAX_READ_PER_SECOND = 200_000
 CASSANDRA_EBS_MIN_STATE_SIZE_GIB = 1024
-
-# Ordered bailout rules, each a (name, predicate over the Cassandra facing
-# desires) pair. The first rule that holds wins and names the reason we stayed
-# on local disks.
-CASSANDRA_EBS_BAILOUTS: Tuple[Tuple[str, Callable[[CapacityDesires], bool]], ...] = (
-    (
-        "read_throughput",
-        lambda desires: desires.query_pattern.estimated_read_per_second.mid
-        > CASSANDRA_EBS_MAX_READ_PER_SECOND,
-    ),
-    (
-        "state_size",
-        lambda desires: desires.data_shape.estimated_state_size_gib.mid
-        < CASSANDRA_EBS_MIN_STATE_SIZE_GIB,
-    ),
-)
-
-
-def cassandra_ebs_bailout(cassandra_desires: CapacityDesires) -> Optional[str]:
-    """Name of the first rule keeping the Cassandra tier on local disks.
-
-    Pass the desires Cassandra will actually be planned with, so after
-    TimeSeries read amplification: the read rule is about load landing on
-    Cassandra, not load landing on the TimeSeries tier. An unstated dataset
-    size reads as zero and therefore bails out to local disks. Returns None
-    when nothing bails out and the tier should plan on EBS.
-    """
-    for name, applies in CASSANDRA_EBS_BAILOUTS:
-        if applies(cassandra_desires):
-            return name
-    return None
 
 
 class NflxTimeSeriesCapacityModel(CapacityModel):
@@ -118,9 +88,19 @@ class NflxTimeSeriesCapacityModel(CapacityModel):
             )
             return relaxed
 
-        # require_local_disks defaults true and on its own excuses every EBS-only
-        # instance, so asking for EBS has to clear it too.
-        if cassandra_ebs_bailout(_modify_cassandra_desires(user_desires)) is None:
+        # Decide on the desires Cassandra is actually planned with, so after
+        # TimeSeries read amplification: the read ceiling is about load landing
+        # on Cassandra, not load landing on the TimeSeries tier.
+        cassandra_desires = _modify_cassandra_desires(user_desires)
+        if (
+            cassandra_desires.query_pattern.estimated_read_per_second.mid
+            <= CASSANDRA_EBS_MAX_READ_PER_SECOND
+            and cassandra_desires.data_shape.estimated_state_size_gib.mid
+            >= CASSANDRA_EBS_MIN_STATE_SIZE_GIB
+        ):
+            # Allow EBS instances, then require them: without the first there
+            # are no EBS candidates, without the second local disks may win.
+            # We explicitly put higher premium on EBS due to ease of maintenance.
             extra_model_arguments["require_local_disks"] = False
             extra_model_arguments["require_attached_disks"] = True
 

--- a/tests/netflix/test_time_series_cassandra_ebs.py
+++ b/tests/netflix/test_time_series_cassandra_ebs.py
@@ -1,4 +1,4 @@
-"""TimeSeries planning its Cassandra tier on EBS, and the bailouts off it.
+"""TimeSeries planning its Cassandra tier on EBS, and the cases that stay local.
 
 Every case plans a real TimeSeries namespace end to end, so what is asserted is
 the disk type the Cassandra tier actually lands on.
@@ -12,7 +12,6 @@ from service_capacity_modeling.interface import CapacityDesires
 from service_capacity_modeling.interface import DataShape
 from service_capacity_modeling.interface import Interval
 from service_capacity_modeling.interface import QueryPattern
-from service_capacity_modeling.models.org.netflix import time_series
 from service_capacity_modeling.models.org.netflix.time_series import (
     CASSANDRA_EBS_MAX_READ_PER_SECOND,
 )
@@ -151,8 +150,8 @@ def test_high_read_namespace_stays_on_local_disks(reads_per_second, on_ebs):
     ids=["amplifies_to_the_ceiling", "amplifies_over_the_ceiling"],
 )
 def test_read_amplification_counts_against_the_read_ceiling(reads_per_second, on_ebs):
-    # The bailout is about load landing on Cassandra, so a namespace well under
-    # the ceiling at its own front door can still be over it once amplified.
+    # The read ceiling is about load landing on Cassandra, so a namespace well
+    # under it at its own front door can still be over it once amplified.
     clusters = _cassandra_tier(
         _namespace(4_000, reads_per_second), AMPLIFYING_NAMESPACE
     )
@@ -165,26 +164,6 @@ def test_namespace_without_a_stated_size_stays_on_local_disks():
     unsized.data_shape = DataShape()
 
     _assert_on_local_disks(_cassandra_tier(unsized))
-
-
-def test_bailout_rules_are_extensible(monkeypatch):
-    # One tuple entry is the whole extension point: this namespace lands on EBS
-    # in test_large_low_read_namespace_lands_on_ebs, and a write ceiling sends
-    # it back to local disks without touching anything else.
-    monkeypatch.setattr(
-        time_series,
-        "CASSANDRA_EBS_BAILOUTS",
-        time_series.CASSANDRA_EBS_BAILOUTS
-        + (
-            (
-                "write_throughput",
-                lambda desires: desires.query_pattern.estimated_write_per_second.mid
-                > 10_000,
-            ),
-        ),
-    )
-
-    _assert_on_local_disks(_cassandra_tier(_namespace(4_000, 10_000)))
 
 
 def test_uncertain_plan_of_a_large_low_read_namespace_lands_on_ebs():

--- a/tests/netflix/test_time_series_cassandra_ebs.py
+++ b/tests/netflix/test_time_series_cassandra_ebs.py
@@ -1,0 +1,218 @@
+"""TimeSeries planning its Cassandra tier on EBS, and the bailouts off it.
+
+Every case plans a real TimeSeries namespace end to end, so what is asserted is
+the disk type the Cassandra tier actually lands on.
+"""
+
+import pytest
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Interval
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.models.org.netflix import time_series
+from service_capacity_modeling.models.org.netflix.time_series import (
+    CASSANDRA_EBS_MAX_READ_PER_SECOND,
+)
+from service_capacity_modeling.models.org.netflix.time_series import (
+    CASSANDRA_EBS_MIN_STATE_SIZE_GIB,
+)
+
+# A namespace retaining 30 days of events, read back one day at a time. The
+# read interval fits inside a slice, so Cassandra sees one read per TS read.
+NAMESPACE = {
+    "ts.read-interval": "PT24H",
+    "ts.hot.retention-interval": "PT720H",
+    "ts.events-per-day-per-ts": "10",
+    "ts.event-size": "1024",
+}
+
+# A denser namespace whose day of events spills into five buckets per id, so
+# every TimeSeries read fans out to five Cassandra reads.
+AMPLIFYING_NAMESPACE = {
+    "ts.read-interval": "PT24H",
+    "ts.hot.retention-interval": "PT96H",
+    "ts.events-per-day-per-ts": "1000",
+    "ts.event-size": "20000",
+}
+READ_AMPLIFICATION = 5
+
+
+def _namespace(
+    state_gib: int, reads_per_second: int, writes_per_second: int = 50_000
+) -> CapacityDesires:
+    """A TimeSeries namespace: steady event ingest with range reads over it."""
+    return CapacityDesires(
+        service_tier=1,
+        query_pattern=QueryPattern(
+            access_pattern=AccessPattern.throughput,
+            estimated_read_per_second=Interval(
+                low=reads_per_second // 2,
+                mid=reads_per_second,
+                high=reads_per_second * 2,
+                confidence=0.98,
+            ),
+            estimated_write_per_second=Interval(
+                low=writes_per_second // 2,
+                mid=writes_per_second,
+                high=writes_per_second * 2,
+                confidence=0.98,
+            ),
+            estimated_mean_read_size_bytes=Interval(
+                low=1024, mid=4096, high=65536, confidence=0.95
+            ),
+            estimated_mean_write_size_bytes=Interval(
+                low=128, mid=1024, high=4096, confidence=0.95
+            ),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=Interval(
+                low=state_gib // 2,
+                mid=state_gib,
+                high=state_gib * 2,
+                confidence=0.98,
+            ),
+        ),
+    )
+
+
+def _cassandra_tier(desires: CapacityDesires, namespace=None):
+    plan = planner.plan_certain(
+        model_name="org.netflix.time-series",
+        region="us-east-1",
+        desires=desires,
+        extra_model_arguments=dict(namespace or NAMESPACE),
+    )[0]
+    clusters = [
+        cluster
+        for cluster in plan.candidate_clusters.zonal
+        if cluster.cluster_type == "cassandra"
+    ]
+    assert clusters, "planner returned no Cassandra tier at all"
+    return clusters
+
+
+def _assert_on_ebs(clusters):
+    for cluster in clusters:
+        assert cluster.instance.drive is None, (
+            f"{cluster.instance.name} has local disks"
+        )
+        assert [drive.name for drive in cluster.attached_drives] == ["gp3"]
+
+
+def _assert_on_local_disks(clusters):
+    for cluster in clusters:
+        assert cluster.instance.drive is not None, (
+            f"{cluster.instance.name} is EBS only"
+        )
+        assert not cluster.attached_drives
+
+
+def test_large_low_read_namespace_lands_on_ebs():
+    _assert_on_ebs(_cassandra_tier(_namespace(4_000, 10_000)))
+
+
+@pytest.mark.parametrize(
+    "state_gib,on_ebs",
+    [
+        (CASSANDRA_EBS_MIN_STATE_SIZE_GIB, True),
+        (CASSANDRA_EBS_MIN_STATE_SIZE_GIB - 1, False),
+    ],
+    ids=["at_one_tib", "just_under_one_tib"],
+)
+def test_namespace_smaller_than_one_tib_stays_on_local_disks(state_gib, on_ebs):
+    clusters = _cassandra_tier(_namespace(state_gib, 10_000))
+
+    (_assert_on_ebs if on_ebs else _assert_on_local_disks)(clusters)
+
+
+@pytest.mark.parametrize(
+    "reads_per_second,on_ebs",
+    [
+        (CASSANDRA_EBS_MAX_READ_PER_SECOND, True),
+        (CASSANDRA_EBS_MAX_READ_PER_SECOND + 1, False),
+    ],
+    ids=["at_the_read_ceiling", "just_over_the_read_ceiling"],
+)
+def test_high_read_namespace_stays_on_local_disks(reads_per_second, on_ebs):
+    clusters = _cassandra_tier(_namespace(4_000, reads_per_second))
+
+    (_assert_on_ebs if on_ebs else _assert_on_local_disks)(clusters)
+
+
+@pytest.mark.parametrize(
+    "reads_per_second,on_ebs",
+    [
+        (CASSANDRA_EBS_MAX_READ_PER_SECOND // READ_AMPLIFICATION, True),
+        (CASSANDRA_EBS_MAX_READ_PER_SECOND // READ_AMPLIFICATION + 1, False),
+    ],
+    ids=["amplifies_to_the_ceiling", "amplifies_over_the_ceiling"],
+)
+def test_read_amplification_counts_against_the_read_ceiling(reads_per_second, on_ebs):
+    # The bailout is about load landing on Cassandra, so a namespace well under
+    # the ceiling at its own front door can still be over it once amplified.
+    clusters = _cassandra_tier(
+        _namespace(4_000, reads_per_second), AMPLIFYING_NAMESPACE
+    )
+
+    (_assert_on_ebs if on_ebs else _assert_on_local_disks)(clusters)
+
+
+def test_namespace_without_a_stated_size_stays_on_local_disks():
+    unsized = _namespace(4_000, 10_000)
+    unsized.data_shape = DataShape()
+
+    _assert_on_local_disks(_cassandra_tier(unsized))
+
+
+def test_bailout_rules_are_extensible(monkeypatch):
+    # One tuple entry is the whole extension point: this namespace lands on EBS
+    # in test_large_low_read_namespace_lands_on_ebs, and a write ceiling sends
+    # it back to local disks without touching anything else.
+    monkeypatch.setattr(
+        time_series,
+        "CASSANDRA_EBS_BAILOUTS",
+        time_series.CASSANDRA_EBS_BAILOUTS
+        + (
+            (
+                "write_throughput",
+                lambda desires: desires.query_pattern.estimated_write_per_second.mid
+                > 10_000,
+            ),
+        ),
+    )
+
+    _assert_on_local_disks(_cassandra_tier(_namespace(4_000, 10_000)))
+
+
+def test_uncertain_plan_of_a_large_low_read_namespace_lands_on_ebs():
+    plan = planner.plan(
+        model_name="org.netflix.time-series",
+        region="us-east-1",
+        desires=_namespace(4_000, 10_000),
+        extra_model_arguments=dict(NAMESPACE),
+        simulations=32,
+    ).least_regret[0]
+
+    _assert_on_ebs(
+        [
+            cluster
+            for cluster in plan.candidate_clusters.zonal
+            if cluster.cluster_type == "cassandra"
+        ]
+    )
+
+
+def test_timeseries_tier_is_unchanged_by_the_ebs_choice():
+    plan = planner.plan_certain(
+        model_name="org.netflix.time-series",
+        region="us-east-1",
+        desires=_namespace(4_000, 10_000),
+        extra_model_arguments=dict(NAMESPACE),
+    )[0]
+
+    assert [cluster.cluster_type for cluster in plan.candidate_clusters.regional] == [
+        "dgwts"
+    ]


### PR DESCRIPTION
Move TimeSeries capacity planning to only provision EBS instancy type for vast majority of workloads to simplify support an maintenance. 