### PR TITLE
Add Valkey ElastiCache capacity model

### DIFF
--- a/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved_elasticache-on-demand.json
+++ b/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved_elasticache-on-demand.json
@@ -3,46 +3,46 @@
     "drives": {},
     "instances": {
       "cache.r7g.12xlarge": {
-        "annual_cost": 16509.1
+        "annual_cost": 36686.88
       },
       "cache.r7g.16xlarge": {
-        "annual_cost": 22015.28
+        "annual_cost": 48922.85
       },
       "cache.r7g.2xlarge": {
-        "annual_cost": 2753.09
+        "annual_cost": 6117.98
       },
       "cache.r7g.4xlarge": {
-        "annual_cost": 5503.03
+        "annual_cost": 12228.96
       },
       "cache.r7g.8xlarge": {
-        "annual_cost": 11009.22
+        "annual_cost": 24464.93
       },
       "cache.r7g.large": {
-        "annual_cost": 690.64
+        "annual_cost": 1534.75
       },
       "cache.r7g.xlarge": {
-        "annual_cost": 1378.12
+        "annual_cost": 3062.5
       },
       "cache.r8g.12xlarge": {
-        "annual_cost": 16608.43
+        "annual_cost": 36907.63
       },
       "cache.r8g.16xlarge": {
-        "annual_cost": 22144.97
+        "annual_cost": 49211.05
       },
       "cache.r8g.2xlarge": {
-        "annual_cost": 2768.07
+        "annual_cost": 6151.27
       },
       "cache.r8g.4xlarge": {
-        "annual_cost": 5536.14
+        "annual_cost": 12302.54
       },
       "cache.r8g.8xlarge": {
-        "annual_cost": 11072.29
+        "annual_cost": 24605.09
       },
       "cache.r8g.large": {
-        "annual_cost": 692.22
+        "annual_cost": 1538.26
       },
       "cache.r8g.xlarge": {
-        "annual_cost": 1384.04
+        "annual_cost": 3075.64
       }
     },
     "services": {},

--- a/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved_elasticache.json
+++ b/service_capacity_modeling/hardware/profiles/pricing/aws/3yr-reserved_elasticache.json
@@ -1,0 +1,51 @@
+{
+  "us-east-1": {
+    "drives": {},
+    "instances": {
+      "cache.r7g.12xlarge": {
+        "annual_cost": 16509.1
+      },
+      "cache.r7g.16xlarge": {
+        "annual_cost": 22015.28
+      },
+      "cache.r7g.2xlarge": {
+        "annual_cost": 2753.09
+      },
+      "cache.r7g.4xlarge": {
+        "annual_cost": 5503.03
+      },
+      "cache.r7g.8xlarge": {
+        "annual_cost": 11009.22
+      },
+      "cache.r7g.large": {
+        "annual_cost": 690.64
+      },
+      "cache.r7g.xlarge": {
+        "annual_cost": 1378.12
+      },
+      "cache.r8g.12xlarge": {
+        "annual_cost": 16608.43
+      },
+      "cache.r8g.16xlarge": {
+        "annual_cost": 22144.97
+      },
+      "cache.r8g.2xlarge": {
+        "annual_cost": 2768.07
+      },
+      "cache.r8g.4xlarge": {
+        "annual_cost": 5536.14
+      },
+      "cache.r8g.8xlarge": {
+        "annual_cost": 11072.29
+      },
+      "cache.r8g.large": {
+        "annual_cost": 692.22
+      },
+      "cache.r8g.xlarge": {
+        "annual_cost": 1384.04
+      }
+    },
+    "services": {},
+    "zones_in_region": 3
+  }
+}

--- a/service_capacity_modeling/hardware/profiles/shapes/aws/manual_valkey_instances.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/manual_valkey_instances.json
@@ -1,0 +1,186 @@
+{
+  "instances": {
+    "cache.r7g.large": {
+      "name": "cache.r7g.large",
+      "cpu": 2,
+      "cpu_cores": 2,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 13.07,
+      "net_mbps": 937.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.xlarge": {
+      "name": "cache.r7g.xlarge",
+      "cpu": 4,
+      "cpu_cores": 4,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 26.32,
+      "net_mbps": 1876.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.2xlarge": {
+      "name": "cache.r7g.2xlarge",
+      "cpu": 8,
+      "cpu_cores": 8,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 52.82,
+      "net_mbps": 3750.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.4xlarge": {
+      "name": "cache.r7g.4xlarge",
+      "cpu": 16,
+      "cpu_cores": 16,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 105.81,
+      "net_mbps": 7500.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.8xlarge": {
+      "name": "cache.r7g.8xlarge",
+      "cpu": 32,
+      "cpu_cores": 32,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 209.55,
+      "net_mbps": 15000.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.12xlarge": {
+      "name": "cache.r7g.12xlarge",
+      "cpu": 48,
+      "cpu_cores": 48,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 317.77,
+      "net_mbps": 22500.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r7g.16xlarge": {
+      "name": "cache.r7g.16xlarge",
+      "cpu": 64,
+      "cpu_cores": 64,
+      "cpu_ghz": 2.6,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 419.09,
+      "net_mbps": 30000.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.large": {
+      "name": "cache.r8g.large",
+      "cpu": 2,
+      "cpu_cores": 2,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 14.18,
+      "net_mbps": 937.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.xlarge": {
+      "name": "cache.r8g.xlarge",
+      "cpu": 4,
+      "cpu_cores": 4,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 29.68,
+      "net_mbps": 1876.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.2xlarge": {
+      "name": "cache.r8g.2xlarge",
+      "cpu": 8,
+      "cpu_cores": 8,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 61.33,
+      "net_mbps": 3750.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.4xlarge": {
+      "name": "cache.r8g.4xlarge",
+      "cpu": 16,
+      "cpu_cores": 16,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 124.65,
+      "net_mbps": 7500.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.8xlarge": {
+      "name": "cache.r8g.8xlarge",
+      "cpu": 32,
+      "cpu_cores": 32,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 251.27,
+      "net_mbps": 15000.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.12xlarge": {
+      "name": "cache.r8g.12xlarge",
+      "cpu": 48,
+      "cpu_cores": 48,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 377.9,
+      "net_mbps": 22500.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    },
+    "cache.r8g.16xlarge": {
+      "name": "cache.r8g.16xlarge",
+      "cpu": 64,
+      "cpu_cores": 64,
+      "cpu_ghz": 2.8,
+      "cpu_ipc_scale": 1.5,
+      "ram_gib": 504.52,
+      "net_mbps": 30000.0,
+      "drive": null,
+      "platforms": [
+        "Valkey"
+      ]
+    }
+  }
+}

--- a/service_capacity_modeling/interface.py
+++ b/service_capacity_modeling/interface.py
@@ -386,6 +386,9 @@ class Platform(StrEnum):
     aurora_postgres = "Aurora PostgreSQL"
     """AWS Aurora PostgreSQL-compatible managed database platform"""
 
+    valkey = "Valkey"
+    """AWS ElastiCache for Valkey managed cache platform"""
+
 
 class Instance(ExcludeUnsetModel):
     """Represents a cloud instance aka Hardware Shape

--- a/service_capacity_modeling/models/org/netflix/__init__.py
+++ b/service_capacity_modeling/models/org/netflix/__init__.py
@@ -22,6 +22,7 @@ from .rds import nflx_rds_capacity_model
 from .search import nflx_search_capacity_model
 from .stateless_java import nflx_java_app_capacity_model
 from .time_series import nflx_time_series_capacity_model
+from .valkey import nflx_valkey_capacity_model
 from .wal import nflx_wal_capacity_model
 from .zookeeper import nflx_zookeeper_capacity_model
 
@@ -32,6 +33,7 @@ def models() -> Dict[str, Any]:
         "org.netflix.stateless-java": nflx_java_app_capacity_model,
         "org.netflix.key-value": nflx_key_value_capacity_model,
         "org.netflix.time-series": nflx_time_series_capacity_model,
+        "org.netflix.valkey": nflx_valkey_capacity_model,
         "org.netflix.counter": nflx_counter_capacity_model,
         "org.netflix.zookeeper": nflx_zookeeper_capacity_model,
         "org.netflix.evcache": nflx_evcache_capacity_model,

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Any
 from typing import Dict
 from typing import FrozenSet
+from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
 
@@ -130,11 +131,143 @@ class NflxValkeyArguments(BaseModel):
     )
 
 
+class _ValkeyMemoryRequirement(NamedTuple):
+    item_count: float
+    item_payload_size_bytes: int
+    item_memory_overhead_bytes: int
+    estimated_state_size_gib: float
+    memory_overhead_gib: float
+    total_data_memory_gib: float
+    required_memory_gib: float
+
+
+class _ValkeyCPURequirement(NamedTuple):
+    simple_ops_per_second: int
+    lua_ops_per_second: int
+    write_cpu_units: float
+    total_cpu_units: float
+
+
+class _ValkeyTopology(NamedTuple):
+    node_count: int
+    shards: int
+    node_copies: int
+
+
+def _estimate_valkey_memory(
+    desires: CapacityDesires,
+    args: NflxValkeyArguments,
+) -> _ValkeyMemoryRequirement:
+    write_size_bytes = desires.query_pattern.estimated_mean_write_size_bytes.mid
+    compression_ratio = max(1.0, desires.data_shape.estimated_compression_ratio.mid)
+    value_size_bytes = math.ceil(write_size_bytes / compression_ratio)
+    item_payload_size_bytes = args.key_size_bytes + value_size_bytes
+    item_memory_overhead_bytes = _valkey_item_overhead_bytes(
+        key_size_bytes=args.key_size_bytes,
+        value_size_bytes=value_size_bytes,
+    )
+
+    estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
+    if estimated_state_size_gib > 0:
+        uncompressed_item_size_bytes = args.key_size_bytes + write_size_bytes
+        if uncompressed_item_size_bytes <= 0:
+            raise ValueError(
+                "Valkey key size or value size must be positive when estimating "
+                "per-item overhead for explicit state"
+            )
+        item_count = (
+            estimated_state_size_gib * GIB_IN_BYTES / uncompressed_item_size_bytes
+        )
+    else:
+        item_count = (
+            desires.query_pattern.estimated_write_per_second.mid
+            * iso_to_seconds(args.ttl)
+        )
+
+    estimated_state_size_gib = item_count * item_payload_size_bytes / GIB_IN_BYTES
+    memory_overhead_gib = item_count * item_memory_overhead_bytes / GIB_IN_BYTES
+    total_data_memory_gib = estimated_state_size_gib + memory_overhead_gib
+    return _ValkeyMemoryRequirement(
+        item_count=item_count,
+        item_payload_size_bytes=item_payload_size_bytes,
+        item_memory_overhead_bytes=item_memory_overhead_bytes,
+        estimated_state_size_gib=estimated_state_size_gib,
+        memory_overhead_gib=memory_overhead_gib,
+        total_data_memory_gib=total_data_memory_gib,
+        required_memory_gib=(
+            total_data_memory_gib / (1 - VALKEY_AWS_MEMORY_RESERVATION)
+        ),
+    )
+
+
+def _estimate_valkey_cpu(
+    instance: Instance,
+    desires: CapacityDesires,
+    args: NflxValkeyArguments,
+) -> _ValkeyCPURequirement:
+    read_ops_per_second = desires.query_pattern.estimated_read_per_second.mid
+    write_ops_per_second = desires.query_pattern.estimated_write_per_second.mid
+    simple_ops_per_second = _valkey_ops_per_second(instance, use_lua=False)
+    lua_ops_per_second = _valkey_ops_per_second(instance, use_lua=True)
+    lua_write_ops_per_second = write_ops_per_second * args.lua_write_percent
+    simple_write_ops_per_second = write_ops_per_second - lua_write_ops_per_second
+    write_cpu_units = (
+        simple_write_ops_per_second / simple_ops_per_second
+        + lua_write_ops_per_second / lua_ops_per_second
+    )
+    return _ValkeyCPURequirement(
+        simple_ops_per_second=simple_ops_per_second,
+        lua_ops_per_second=lua_ops_per_second,
+        write_cpu_units=write_cpu_units,
+        total_cpu_units=(write_cpu_units + read_ops_per_second / simple_ops_per_second),
+    )
+
+
+def _select_valkey_topology(
+    instance: Instance,
+    desires: CapacityDesires,
+    memory: _ValkeyMemoryRequirement,
+    cpu: _ValkeyCPURequirement,
+) -> _ValkeyTopology:
+    min_shards = max(
+        1,
+        math.ceil(cpu.write_cpu_units),
+        math.ceil(memory.required_memory_gib / instance.ram_gib),
+    )
+    min_node_copies = (
+        2
+        if desires.data_shape.durability_slo_order.mid >= VALKEY_DURABILITY_THRESHOLD
+        else 1
+    )
+    required_nodes = math.ceil(cpu.total_cpu_units)
+
+    # Extra shards and read replicas use the same node type and price. Evaluate
+    # the possible shard counts and retain the topology with the fewest nodes.
+    topology: Optional[_ValkeyTopology] = None
+    for shards in range(min_shards, max(min_shards, required_nodes) + 1):
+        node_copies = max(
+            min_node_copies,
+            math.ceil(required_nodes / shards),
+        )
+        if node_copies - 1 > VALKEY_MAX_READ_REPLICAS_PER_SHARD:
+            continue
+        candidate = _ValkeyTopology(
+            node_count=shards * node_copies,
+            shards=shards,
+            node_copies=node_copies,
+        )
+        if topology is None or candidate < topology:
+            topology = candidate
+
+    assert topology is not None
+    return topology
+
+
 class NflxValkeyCapacityModel(CapacityModel):
     cluster_type = "valkey"
 
     @staticmethod
-    def capacity_plan(  # pylint: disable=too-many-locals
+    def capacity_plan(
         instance: Instance,
         drive: Drive,
         context: RegionContext,
@@ -148,126 +281,60 @@ class NflxValkeyCapacityModel(CapacityModel):
             return None
 
         args = NflxValkeyArguments.model_validate(extra_model_arguments)
-        read_ops_per_second = desires.query_pattern.estimated_read_per_second.mid
-        write_ops_per_second = desires.query_pattern.estimated_write_per_second.mid
-        compression_ratio = max(1.0, desires.data_shape.estimated_compression_ratio.mid)
-        value_size_bytes = math.ceil(
-            desires.query_pattern.estimated_mean_write_size_bytes.mid
-            / compression_ratio
+        memory = _estimate_valkey_memory(desires=desires, args=args)
+        cpu = _estimate_valkey_cpu(instance=instance, desires=desires, args=args)
+        topology = _select_valkey_topology(
+            instance=instance,
+            desires=desires,
+            memory=memory,
+            cpu=cpu,
         )
-        item_payload_size_bytes = args.key_size_bytes + value_size_bytes
-        item_memory_overhead_bytes = _valkey_item_overhead_bytes(
-            key_size_bytes=args.key_size_bytes,
-            value_size_bytes=value_size_bytes,
-        )
-        estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
-        if estimated_state_size_gib > 0:
-            uncompressed_item_size_bytes = (
-                args.key_size_bytes
-                + desires.query_pattern.estimated_mean_write_size_bytes.mid
-            )
-            if uncompressed_item_size_bytes <= 0:
-                raise ValueError(
-                    "Valkey key size or value size must be positive when estimating "
-                    "per-item overhead for explicit state"
-                )
-            item_count = (
-                estimated_state_size_gib * GIB_IN_BYTES / uncompressed_item_size_bytes
-            )
-        else:
-            item_count = write_ops_per_second * iso_to_seconds(args.ttl)
-        estimated_state_size_gib = item_count * item_payload_size_bytes / GIB_IN_BYTES
-        memory_overhead_gib = item_count * item_memory_overhead_bytes / GIB_IN_BYTES
-        total_data_memory_gib = estimated_state_size_gib + memory_overhead_gib
-        required_memory_gib = total_data_memory_gib / (
-            1 - VALKEY_AWS_MEMORY_RESERVATION
-        )
-
-        simple_ops_per_second = _valkey_ops_per_second(instance, use_lua=False)
-        lua_ops_per_second = _valkey_ops_per_second(instance, use_lua=True)
-        lua_write_ops_per_second = write_ops_per_second * args.lua_write_percent
-        simple_write_ops_per_second = write_ops_per_second - lua_write_ops_per_second
-        write_cpu_units = (
-            simple_write_ops_per_second / simple_ops_per_second
-            + lua_write_ops_per_second / lua_ops_per_second
-        )
-        total_cpu_units = write_cpu_units + (
-            read_ops_per_second / simple_ops_per_second
-        )
-        min_shards = max(
-            1,
-            math.ceil(write_cpu_units),
-            math.ceil(required_memory_gib / instance.ram_gib),
-        )
-        min_node_copies = (
-            2
-            if desires.data_shape.durability_slo_order.mid
-            >= VALKEY_DURABILITY_THRESHOLD
-            else 1
-        )
-        required_nodes = math.ceil(total_cpu_units)
-
-        # Extra shards and read replicas use the same node type and price. Evaluate
-        # the possible shard counts and retain the topology with the fewest nodes.
-        topology: Optional[Tuple[int, int, int]] = None
-        for shards in range(min_shards, max(min_shards, required_nodes) + 1):
-            node_copies = max(
-                min_node_copies,
-                math.ceil(required_nodes / shards),
-            )
-            if node_copies - 1 > VALKEY_MAX_READ_REPLICAS_PER_SHARD:
-                continue
-            candidate = (shards * node_copies, shards, node_copies)
-            if topology is None or candidate < topology:
-                topology = candidate
-
-        assert topology is not None
-        node_count, shards, node_copies = topology
-        read_replicas_per_shard = node_copies - 1
+        read_replicas_per_shard = topology.node_copies - 1
         cluster_params = {
-            "valkey.shards": shards,
+            "valkey.shards": topology.shards,
             "valkey.read_replicas_per_shard": read_replicas_per_shard,
             "valkey.max_read_replicas_per_shard": (VALKEY_MAX_READ_REPLICAS_PER_SHARD),
             "valkey.lua_write_percent": args.lua_write_percent,
-            "valkey.simple_ops_per_second_per_node": simple_ops_per_second,
-            "valkey.lua_ops_per_second_per_node": lua_ops_per_second,
-            "valkey.cpu_capacity_units_required": total_cpu_units,
+            "valkey.simple_ops_per_second_per_node": cpu.simple_ops_per_second,
+            "valkey.lua_ops_per_second_per_node": cpu.lua_ops_per_second,
+            "valkey.cpu_capacity_units_required": cpu.total_cpu_units,
             "valkey.engine_version": VALKEY_ENGINE_VERSION,
-            "valkey.item_count": item_count,
-            "valkey.item_payload_size_bytes": item_payload_size_bytes,
-            "valkey.item_memory_overhead_bytes": item_memory_overhead_bytes,
-            "valkey.estimated_state_size_gib": estimated_state_size_gib,
-            "valkey.memory_overhead_gib": memory_overhead_gib,
-            "valkey.total_data_memory_gib": total_data_memory_gib,
-            "valkey.required_memory_gib": required_memory_gib,
+            "valkey.item_count": memory.item_count,
+            "valkey.item_payload_size_bytes": memory.item_payload_size_bytes,
+            "valkey.item_memory_overhead_bytes": memory.item_memory_overhead_bytes,
+            "valkey.estimated_state_size_gib": memory.estimated_state_size_gib,
+            "valkey.memory_overhead_gib": memory.memory_overhead_gib,
+            "valkey.total_data_memory_gib": memory.total_data_memory_gib,
+            "valkey.required_memory_gib": memory.required_memory_gib,
             "valkey.aws_memory_reservation_percent": (VALKEY_AWS_MEMORY_RESERVATION),
             "valkey.usable_memory_per_node_gib": (
                 instance.ram_gib * (1 - VALKEY_AWS_MEMORY_RESERVATION)
             ),
             "valkey.read_capacity_ops_per_second": round(
-                max(0, node_count - write_cpu_units) * simple_ops_per_second
+                max(0, topology.node_count - cpu.write_cpu_units)
+                * cpu.simple_ops_per_second
             ),
             "valkey.write_capacity_ops_per_second": (
                 round(
-                    shards
+                    topology.shards
                     / (
-                        (1 - args.lua_write_percent) / simple_ops_per_second
-                        + args.lua_write_percent / lua_ops_per_second
+                        (1 - args.lua_write_percent) / cpu.simple_ops_per_second
+                        + args.lua_write_percent / cpu.lua_ops_per_second
                     )
                 )
             ),
         }
         cluster = RegionClusterCapacity(
             cluster_type=NflxValkeyCapacityModel.cluster_type,
-            count=node_count,
+            count=topology.node_count,
             instance=instance,
             cluster_params=cluster_params,
         )
         requirement = CapacityRequirement(
             requirement_type="valkey-regional",
             reference_shape=instance,
-            cpu_cores=certain_int(node_count),
-            mem_gib=certain_float(required_memory_gib * node_copies),
+            cpu_cores=certain_int(topology.node_count),
+            mem_gib=certain_float(memory.required_memory_gib * topology.node_copies),
             network_mbps=certain_float(simple_network_mbps(desires)),
             context=cluster_params,
         )

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -138,7 +138,6 @@ class _ValkeyMemoryRequirement(NamedTuple):
     estimated_state_size_gib: float
     memory_overhead_gib: float
     total_data_memory_gib: float
-    required_memory_gib: float
 
 
 class _ValkeyCPURequirement(NamedTuple):
@@ -194,9 +193,6 @@ def _estimate_valkey_memory(
         estimated_state_size_gib=estimated_state_size_gib,
         memory_overhead_gib=memory_overhead_gib,
         total_data_memory_gib=total_data_memory_gib,
-        required_memory_gib=(
-            total_data_memory_gib / (1 - VALKEY_AWS_MEMORY_RESERVATION)
-        ),
     )
 
 
@@ -229,10 +225,11 @@ def _select_valkey_topology(
     memory: _ValkeyMemoryRequirement,
     cpu: _ValkeyCPURequirement,
 ) -> _ValkeyTopology:
+    usable_memory_per_node_gib = instance.ram_gib * (1 - VALKEY_AWS_MEMORY_RESERVATION)
     min_shards = max(
         1,
         math.ceil(cpu.write_cpu_units),
-        math.ceil(memory.required_memory_gib / instance.ram_gib),
+        math.ceil(memory.total_data_memory_gib / usable_memory_per_node_gib),
     )
     min_node_copies = (
         2
@@ -305,7 +302,6 @@ class NflxValkeyCapacityModel(CapacityModel):
             "valkey.estimated_state_size_gib": memory.estimated_state_size_gib,
             "valkey.memory_overhead_gib": memory.memory_overhead_gib,
             "valkey.total_data_memory_gib": memory.total_data_memory_gib,
-            "valkey.required_memory_gib": memory.required_memory_gib,
             "valkey.aws_memory_reservation_percent": (VALKEY_AWS_MEMORY_RESERVATION),
             "valkey.usable_memory_per_node_gib": (
                 instance.ram_gib * (1 - VALKEY_AWS_MEMORY_RESERVATION)
@@ -334,7 +330,7 @@ class NflxValkeyCapacityModel(CapacityModel):
             requirement_type="valkey-regional",
             reference_shape=instance,
             cpu_cores=certain_int(topology.node_count),
-            mem_gib=certain_float(memory.required_memory_gib * topology.node_copies),
+            mem_gib=certain_float(memory.total_data_memory_gib * topology.node_copies),
             network_mbps=certain_float(simple_network_mbps(desires)),
             context=cluster_params,
         )

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -9,6 +9,7 @@ from typing import Tuple
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import model_validator
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -46,6 +47,10 @@ VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
 VALKEY_ENGINE_VERSION = "8.1"
 VALKEY_ITEM_METADATA_BYTES = 31
+VALKEY_DEFAULT_KEY_SIZE_BYTES = 16
+VALKEY_DEFAULT_VALUE_SIZE_BYTES = 50
+VALKEY_MAX_MEASURED_OVERHEAD_VALUE_BYTES = 128
+VALKEY_DEFAULT_MAX_NODES_PER_CLUSTER = 90
 
 
 def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
@@ -66,7 +71,7 @@ def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
 
 
 def _jemalloc_size_class(requested_bytes: int) -> int:
-    """Return the allocator size class for a key or value allocation."""
+    """Return the allocator size class, extrapolating beyond the measured curve."""
     quantum = 8
     upper_bound = 64
     while requested_bytes > upper_bound:
@@ -104,11 +109,10 @@ def _valkey_item_overhead_bytes(
 class NflxValkeyArguments(BaseModel):
     key_size_bytes: int = Field(
         alias="valkey.key_size_bytes",
-        default=16,
+        default=VALKEY_DEFAULT_KEY_SIZE_BYTES,
         ge=0,
         description=(
-            "Average key size. Used with value size, WPS, and TTL when total "
-            "state size is not supplied."
+            "Average key size within QueryPattern's total read/write item size."
         ),
     )
     ttl: str = Field(
@@ -129,12 +133,29 @@ class NflxValkeyArguments(BaseModel):
             "operations consume weighted shares of the same node CPU capacity."
         ),
     )
+    max_nodes_per_cluster: int = Field(
+        alias="valkey.max_nodes_per_cluster",
+        default=VALKEY_DEFAULT_MAX_NODES_PER_CLUSTER,
+        ge=1,
+        description=(
+            "Maximum nodes allowed in one ElastiCache cluster. Defaults to AWS's "
+            "standard 90-node cluster quota; increase only with an approved quota."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_ttl(self) -> "NflxValkeyArguments":
+        if iso_to_seconds(self.ttl) <= 0:
+            raise ValueError("valkey.ttl must be a positive, finite duration")
+        return self
 
 
 class _ValkeyMemoryRequirement(NamedTuple):
     item_count: float
+    value_size_bytes: int
     item_payload_size_bytes: int
     item_memory_overhead_bytes: int
+    item_overhead_extrapolated: bool
     estimated_state_size_gib: float
     memory_overhead_gib: float
     total_data_memory_gib: float
@@ -145,6 +166,8 @@ class _ValkeyCPURequirement(NamedTuple):
     lua_ops_per_second: int
     write_cpu_units: float
     total_cpu_units: float
+    write_network_mbps: float
+    total_network_mbps: float
 
 
 class _ValkeyTopology(NamedTuple):
@@ -157,26 +180,32 @@ def _estimate_valkey_memory(
     desires: CapacityDesires,
     args: NflxValkeyArguments,
 ) -> _ValkeyMemoryRequirement:
-    write_size_bytes = desires.query_pattern.estimated_mean_write_size_bytes.mid
+    item_size_bytes = desires.query_pattern.estimated_mean_write_size_bytes.mid
+    if item_size_bytes < args.key_size_bytes:
+        raise ValueError(
+            "Valkey total item size must be greater than or equal to key size"
+        )
     compression_ratio = max(1.0, desires.data_shape.estimated_compression_ratio.mid)
-    value_size_bytes = math.ceil(write_size_bytes / compression_ratio)
+    value_size_bytes = math.ceil(
+        (item_size_bytes - args.key_size_bytes) / compression_ratio
+    )
     item_payload_size_bytes = args.key_size_bytes + value_size_bytes
     item_memory_overhead_bytes = _valkey_item_overhead_bytes(
         key_size_bytes=args.key_size_bytes,
         value_size_bytes=value_size_bytes,
     )
 
+    requested_item_count = desires.data_shape.estimated_state_item_count
     estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
-    if estimated_state_size_gib > 0:
-        uncompressed_item_size_bytes = args.key_size_bytes + write_size_bytes
-        if uncompressed_item_size_bytes <= 0:
+    if requested_item_count is not None and requested_item_count.mid > 0:
+        item_count = requested_item_count.mid
+    elif estimated_state_size_gib > 0:
+        if item_size_bytes <= 0:
             raise ValueError(
-                "Valkey key size or value size must be positive when estimating "
-                "per-item overhead for explicit state"
+                "Valkey total item size must be positive when estimating per-item "
+                "overhead for explicit state"
             )
-        item_count = (
-            estimated_state_size_gib * GIB_IN_BYTES / uncompressed_item_size_bytes
-        )
+        item_count = estimated_state_size_gib * GIB_IN_BYTES / item_size_bytes
     else:
         item_count = (
             desires.query_pattern.estimated_write_per_second.mid
@@ -188,8 +217,12 @@ def _estimate_valkey_memory(
     total_data_memory_gib = estimated_state_size_gib + memory_overhead_gib
     return _ValkeyMemoryRequirement(
         item_count=item_count,
+        value_size_bytes=value_size_bytes,
         item_payload_size_bytes=item_payload_size_bytes,
         item_memory_overhead_bytes=item_memory_overhead_bytes,
+        item_overhead_extrapolated=(
+            value_size_bytes > VALKEY_MAX_MEASURED_OVERHEAD_VALUE_BYTES
+        ),
         estimated_state_size_gib=estimated_state_size_gib,
         memory_overhead_gib=memory_overhead_gib,
         total_data_memory_gib=total_data_memory_gib,
@@ -216,6 +249,13 @@ def _estimate_valkey_cpu(
         lua_ops_per_second=lua_ops_per_second,
         write_cpu_units=write_cpu_units,
         total_cpu_units=(write_cpu_units + read_ops_per_second / simple_ops_per_second),
+        write_network_mbps=(
+            write_ops_per_second
+            * desires.query_pattern.estimated_mean_write_size_bytes.mid
+            * 8
+            / 1_000_000
+        ),
+        total_network_mbps=simple_network_mbps(desires),
     )
 
 
@@ -224,11 +264,13 @@ def _select_valkey_topology(
     desires: CapacityDesires,
     memory: _ValkeyMemoryRequirement,
     cpu: _ValkeyCPURequirement,
-) -> _ValkeyTopology:
+    args: NflxValkeyArguments,
+) -> Optional[_ValkeyTopology]:
     usable_memory_per_node_gib = instance.ram_gib * (1 - VALKEY_AWS_MEMORY_RESERVATION)
     min_shards = max(
         1,
         math.ceil(cpu.write_cpu_units),
+        math.ceil(cpu.write_network_mbps / instance.net_mbps),
         math.ceil(memory.total_data_memory_gib / usable_memory_per_node_gib),
     )
     min_node_copies = (
@@ -236,12 +278,24 @@ def _select_valkey_topology(
         if desires.data_shape.durability_slo_order.mid >= VALKEY_DURABILITY_THRESHOLD
         else 1
     )
-    required_nodes = math.ceil(cpu.total_cpu_units)
+    required_nodes = max(
+        math.ceil(cpu.total_cpu_units),
+        math.ceil(cpu.total_network_mbps / instance.net_mbps),
+    )
+    if (
+        required_nodes > args.max_nodes_per_cluster
+        or min_shards * min_node_copies > args.max_nodes_per_cluster
+    ):
+        return None
 
-    # Extra shards and read replicas use the same node type and price. Evaluate
-    # the possible shard counts and retain the topology with the fewest nodes.
+    # Reads and keys are assumed uniform across shards, so every shard needs the
+    # same replica count. Evaluate complete uniform topologies by total node count.
     topology: Optional[_ValkeyTopology] = None
-    for shards in range(min_shards, max(min_shards, required_nodes) + 1):
+    max_shards = args.max_nodes_per_cluster // min_node_copies
+    for shards in range(
+        min_shards,
+        min(max_shards, max(min_shards, required_nodes)) + 1,
+    ):
         node_copies = max(
             min_node_copies,
             math.ceil(required_nodes / shards),
@@ -253,10 +307,11 @@ def _select_valkey_topology(
             shards=shards,
             node_copies=node_copies,
         )
+        if candidate.node_count > args.max_nodes_per_cluster:
+            continue
         if topology is None or candidate < topology:
             topology = candidate
 
-    assert topology is not None
     return topology
 
 
@@ -285,7 +340,10 @@ class NflxValkeyCapacityModel(CapacityModel):
             desires=desires,
             memory=memory,
             cpu=cpu,
+            args=args,
         )
+        if topology is None:
+            return None
         read_replicas_per_shard = topology.node_copies - 1
         cluster_params = {
             "valkey.shards": topology.shards,
@@ -295,10 +353,17 @@ class NflxValkeyCapacityModel(CapacityModel):
             "valkey.simple_ops_per_second_per_node": cpu.simple_ops_per_second,
             "valkey.lua_ops_per_second_per_node": cpu.lua_ops_per_second,
             "valkey.cpu_capacity_units_required": cpu.total_cpu_units,
+            "valkey.write_network_mbps_required": cpu.write_network_mbps,
+            "valkey.network_mbps_required": cpu.total_network_mbps,
+            "valkey.network_mbps_capacity": (topology.node_count * instance.net_mbps),
+            "valkey.max_nodes_per_cluster": args.max_nodes_per_cluster,
+            "valkey.assumes_uniform_key_distribution": True,
             "valkey.engine_version": VALKEY_ENGINE_VERSION,
             "valkey.item_count": memory.item_count,
+            "valkey.value_size_bytes": memory.value_size_bytes,
             "valkey.item_payload_size_bytes": memory.item_payload_size_bytes,
             "valkey.item_memory_overhead_bytes": memory.item_memory_overhead_bytes,
+            "valkey.item_overhead_extrapolated": memory.item_overhead_extrapolated,
             "valkey.estimated_state_size_gib": memory.estimated_state_size_gib,
             "valkey.memory_overhead_gib": memory.memory_overhead_gib,
             "valkey.total_data_memory_gib": memory.total_data_memory_gib,
@@ -331,7 +396,7 @@ class NflxValkeyCapacityModel(CapacityModel):
             reference_shape=instance,
             cpu_cores=certain_int(topology.node_count),
             mem_gib=certain_float(memory.total_data_memory_gib * topology.node_copies),
-            network_mbps=certain_float(simple_network_mbps(desires)),
+            network_mbps=certain_float(cpu.total_network_mbps),
             context=cluster_params,
         )
         return CapacityPlan(
@@ -367,6 +432,8 @@ class NflxValkeyCapacityModel(CapacityModel):
     def default_desires(
         user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
     ) -> CapacityDesires:
+        args = NflxValkeyArguments.model_validate(extra_model_arguments)
+        default_item_size_bytes = args.key_size_bytes + VALKEY_DEFAULT_VALUE_SIZE_BYTES
         return CapacityDesires(
             query_pattern=QueryPattern(
                 access_pattern=AccessPattern.latency,
@@ -378,8 +445,8 @@ class NflxValkeyCapacityModel(CapacityModel):
                         target_consistency=AccessConsistency.never,
                     ),
                 ),
-                estimated_mean_read_size_bytes=certain_int(50),
-                estimated_mean_write_size_bytes=certain_int(50),
+                estimated_mean_read_size_bytes=certain_int(default_item_size_bytes),
+                estimated_mean_write_size_bytes=certain_int(default_item_size_bytes),
                 estimated_mean_read_latency_ms=certain_float(1),
                 estimated_mean_write_latency_ms=certain_float(1),
                 read_latency_slo_ms=FixedInterval(

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from typing import Any
 from typing import Dict
 from typing import FrozenSet
-from typing import Literal
 from typing import Optional
 from typing import Tuple
 
@@ -44,13 +43,8 @@ VALKEY_MAX_LUA_OPS_PER_SECOND = 150_000
 VALKEY_DURABILITY_THRESHOLD = 1_000
 VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
-VALKEY_ITEM_METADATA_BYTES = {
-    "7.2": 60,
-    "8": 52,
-    "8.0": 52,
-    "8.1": 31,
-}
-ValkeyEngineVersion = Literal["7.2", "8", "8.0", "8.1"]
+VALKEY_ENGINE_VERSION = "8.1"
+VALKEY_ITEM_METADATA_BYTES = 31
 
 
 def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
@@ -83,24 +77,27 @@ def _jemalloc_size_class(requested_bytes: int) -> int:
 def _valkey_item_overhead_bytes(
     key_size_bytes: int,
     value_size_bytes: int,
-    engine_version: ValkeyEngineVersion,
 ) -> int:
-    """Estimate metadata and allocator slack for one key/value item."""
-    metadata_bytes = VALKEY_ITEM_METADATA_BYTES[engine_version]
+    """Estimate Valkey 8.1 metadata and allocator slack for one item."""
     key_allocation = _jemalloc_size_class(key_size_bytes + 4)
     key_allocation_slack = key_allocation - key_size_bytes
-    if engine_version == "8.1" and value_size_bytes < 32:
+    if value_size_bytes < 32:
         # The 8.1 curve has a separate compact-value branch below 32 bytes.
         baseline_16_byte_key_slack = 8
         return (
-            metadata_bytes
+            VALKEY_ITEM_METADATA_BYTES
             + _jemalloc_size_class(value_size_bytes + 7)
             - value_size_bytes
             + key_allocation_slack
             - baseline_16_byte_key_slack
         )
     value_allocation = _jemalloc_size_class(value_size_bytes + 4)
-    return metadata_bytes + key_allocation_slack + value_allocation - value_size_bytes
+    return (
+        VALKEY_ITEM_METADATA_BYTES
+        + key_allocation_slack
+        + value_allocation
+        - value_size_bytes
+    )
 
 
 class NflxValkeyArguments(BaseModel):
@@ -120,11 +117,6 @@ class NflxValkeyArguments(BaseModel):
             "ISO-8601 key TTL. Used with key size, value size, and WPS when "
             "total state size is not supplied."
         ),
-    )
-    engine_version: ValkeyEngineVersion = Field(
-        alias="valkey.engine_version",
-        default="8.1",
-        description="Valkey engine version used for per-item memory overhead.",
     )
     lua_write_percent: float = Field(
         alias="valkey.lua_write_percent",
@@ -167,7 +159,6 @@ class NflxValkeyCapacityModel(CapacityModel):
         item_memory_overhead_bytes = _valkey_item_overhead_bytes(
             key_size_bytes=args.key_size_bytes,
             value_size_bytes=value_size_bytes,
-            engine_version=args.engine_version,
         )
         estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
         if estimated_state_size_gib > 0:
@@ -241,7 +232,7 @@ class NflxValkeyCapacityModel(CapacityModel):
             "valkey.simple_ops_per_second_per_node": simple_ops_per_second,
             "valkey.lua_ops_per_second_per_node": lua_ops_per_second,
             "valkey.cpu_capacity_units_required": total_cpu_units,
-            "valkey.engine_version": args.engine_version,
+            "valkey.engine_version": VALKEY_ENGINE_VERSION,
             "valkey.item_count": item_count,
             "valkey.item_payload_size_bytes": item_payload_size_bytes,
             "valkey.item_memory_overhead_bytes": item_memory_overhead_bytes,

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -10,6 +10,7 @@ from typing import Tuple
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
+from pydantic import NonNegativeFloat
 
 from service_capacity_modeling.interface import AccessConsistency
 from service_capacity_modeling.interface import AccessPattern
@@ -143,13 +144,13 @@ class NflxValkeyArguments(BaseModel):
             "standard 90-node cluster quota; increase only with an approved quota."
         ),
     )
-    sync_durability_surcharge: float = Field(
+    sync_durability_surcharge: Dict[str, NonNegativeFloat] = Field(
         alias="valkey.sync_durability_surcharge",
-        default=0,
-        ge=0,
+        default_factory=dict,
         description=(
-            "Hourly SyncDurability surcharge per Valkey node. Applied only when "
-            "the requested durability SLO requires synchronous durability."
+            "Hourly SyncDurability surcharge per Valkey node, keyed by instance "
+            "type. Applied only when the requested durability SLO requires "
+            "synchronous durability."
         ),
     )
 
@@ -405,9 +406,10 @@ class NflxValkeyCapacityModel(CapacityModel):
         requires_sync_durability = (
             desires.data_shape.durability_slo_order.mid >= VALKEY_DURABILITY_THRESHOLD
         )
-        if requires_sync_durability and args.sync_durability_surcharge > 0:
+        sync_durability_surcharge = args.sync_durability_surcharge.get(instance.name, 0)
+        if requires_sync_durability and sync_durability_surcharge > 0:
             annual_costs["valkey.sync-durability"] = (
-                Decimal(str(args.sync_durability_surcharge))
+                Decimal(str(sync_durability_surcharge))
                 * topology.node_count
                 * VALKEY_HOURS_PER_YEAR
             )

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -46,6 +46,7 @@ VALKEY_DURABILITY_THRESHOLD = 1_000
 VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
 VALKEY_ENGINE_VERSION = "8.1"
+VALKEY_HOURS_PER_YEAR = 8760
 VALKEY_8_1_BENCHMARK_BASE_OVERHEAD_BYTES = 31
 VALKEY_DEFAULT_KEY_SIZE_BYTES = 16
 VALKEY_DEFAULT_VALUE_SIZE_BYTES = 50
@@ -140,6 +141,15 @@ class NflxValkeyArguments(BaseModel):
         description=(
             "Maximum nodes allowed in one ElastiCache cluster. Defaults to AWS's "
             "standard 90-node cluster quota; increase only with an approved quota."
+        ),
+    )
+    sync_durability_surcharge: float = Field(
+        alias="valkey.sync_durability_surcharge",
+        default=0,
+        ge=0,
+        description=(
+            "Hourly SyncDurability surcharge per Valkey node. Applied only when "
+            "the requested durability SLO requires synchronous durability."
         ),
     )
 
@@ -391,6 +401,16 @@ class NflxValkeyCapacityModel(CapacityModel):
             instance=instance,
             cluster_params=cluster_params,
         )
+        annual_costs = {"valkey.regional-clusters": Decimal(str(cluster.annual_cost))}
+        requires_sync_durability = (
+            desires.data_shape.durability_slo_order.mid >= VALKEY_DURABILITY_THRESHOLD
+        )
+        if requires_sync_durability and args.sync_durability_surcharge > 0:
+            annual_costs["valkey.sync-durability"] = (
+                Decimal(str(args.sync_durability_surcharge))
+                * topology.node_count
+                * VALKEY_HOURS_PER_YEAR
+            )
         requirement = CapacityRequirement(
             requirement_type="valkey-regional",
             reference_shape=instance,
@@ -405,9 +425,7 @@ class NflxValkeyCapacityModel(CapacityModel):
                 regrets=("spend", "mem"),
             ),
             candidate_clusters=Clusters(
-                annual_costs={
-                    "valkey.regional-clusters": Decimal(str(cluster.annual_cost))
-                },
+                annual_costs=annual_costs,
                 regional=[cluster],
             ),
         )

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -34,7 +34,7 @@ from service_capacity_modeling.models.common import simple_network_mbps
 from service_capacity_modeling.models.org.netflix.iso_date_math import iso_to_seconds
 
 
-VALKEY_MIN_CPU_SPEED_GHZ = 2.5
+VALKEY_MIN_CPU_SPEED_GHZ = 2.6
 VALKEY_MAX_CPU_SPEED_GHZ = 3.5
 VALKEY_MIN_OPS_PER_SECOND = 700_000
 VALKEY_MAX_OPS_PER_SECOND = 1_000_000

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -1,0 +1,276 @@
+import math
+from decimal import Decimal
+from typing import Any
+from typing import Dict
+from typing import FrozenSet
+from typing import Optional
+from typing import Tuple
+
+from pydantic import BaseModel
+from pydantic import Field
+
+from service_capacity_modeling.interface import AccessConsistency
+from service_capacity_modeling.interface import AccessPattern
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import CapacityPlan
+from service_capacity_modeling.interface import CapacityRequirement
+from service_capacity_modeling.interface import certain_float
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import Clusters
+from service_capacity_modeling.interface import Consistency
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import FixedInterval
+from service_capacity_modeling.interface import GIB_IN_BYTES
+from service_capacity_modeling.interface import GlobalConsistency
+from service_capacity_modeling.interface import Instance
+from service_capacity_modeling.interface import Platform
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionClusterCapacity
+from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.interface import Requirements
+from service_capacity_modeling.models import CapacityModel
+from service_capacity_modeling.models.common import simple_network_mbps
+from service_capacity_modeling.models.org.netflix.iso_date_math import iso_to_seconds
+
+
+VALKEY_MIN_CPU_SPEED_GHZ = 2.5
+VALKEY_MAX_CPU_SPEED_GHZ = 3.5
+VALKEY_MIN_OPS_PER_SECOND = 700_000
+VALKEY_MAX_OPS_PER_SECOND = 1_000_000
+VALKEY_MIN_LUA_OPS_PER_SECOND = 50_000
+VALKEY_MAX_LUA_OPS_PER_SECOND = 150_000
+VALKEY_DURABILITY_THRESHOLD = 1_000
+VALKEY_AWS_MEMORY_RESERVATION = 0.25
+VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
+
+
+def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
+    """Estimate one shard's throughput from its single-thread CPU speed."""
+    speed_ratio = min(
+        1.0,
+        max(
+            0.0,
+            (instance.cpu_ghz - VALKEY_MIN_CPU_SPEED_GHZ)
+            / (VALKEY_MAX_CPU_SPEED_GHZ - VALKEY_MIN_CPU_SPEED_GHZ),
+        ),
+    )
+    if use_lua:
+        low, high = VALKEY_MIN_LUA_OPS_PER_SECOND, VALKEY_MAX_LUA_OPS_PER_SECOND
+    else:
+        low, high = VALKEY_MIN_OPS_PER_SECOND, VALKEY_MAX_OPS_PER_SECOND
+    return round(low + speed_ratio * (high - low))
+
+
+class NflxValkeyArguments(BaseModel):
+    key_size_bytes: int = Field(
+        alias="valkey.key_size_bytes",
+        default=64,
+        ge=0,
+        description=(
+            "Average key size. Used with value size, WPS, and TTL when total "
+            "state size is not supplied."
+        ),
+    )
+    ttl: str = Field(
+        alias="valkey.ttl",
+        default="PT24H",
+        description=(
+            "ISO-8601 key TTL. Used with key size, value size, and WPS when "
+            "total state size is not supplied."
+        ),
+    )
+    lua_write_percent: float = Field(
+        alias="valkey.lua_write_percent",
+        default=0,
+        ge=0,
+        le=1,
+        description=(
+            "Fraction of writes that execute Lua, from 0 to 1. Lua and ordinary "
+            "operations consume weighted shares of the same node CPU capacity."
+        ),
+    )
+
+
+class NflxValkeyCapacityModel(CapacityModel):
+    cluster_type = "valkey"
+
+    @staticmethod
+    def capacity_plan(  # pylint: disable=too-many-locals
+        instance: Instance,
+        drive: Drive,
+        context: RegionContext,
+        desires: CapacityDesires,
+        extra_model_arguments: Dict[str, Any],
+    ) -> Optional[CapacityPlan]:
+        _ = drive
+        _ = context
+
+        if Platform.valkey not in instance.platforms or instance.ram_gib <= 0:
+            return None
+
+        args = NflxValkeyArguments.model_validate(extra_model_arguments)
+        read_ops_per_second = desires.query_pattern.estimated_read_per_second.mid
+        write_ops_per_second = desires.query_pattern.estimated_write_per_second.mid
+        compression_ratio = max(1.0, desires.data_shape.estimated_compression_ratio.mid)
+        estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
+        if estimated_state_size_gib <= 0:
+            estimated_state_size_gib = (
+                (
+                    args.key_size_bytes
+                    + desires.query_pattern.estimated_mean_write_size_bytes.mid
+                )
+                * write_ops_per_second
+                * iso_to_seconds(args.ttl)
+                / GIB_IN_BYTES
+            )
+        estimated_state_size_gib /= compression_ratio
+        required_memory_gib = estimated_state_size_gib / (
+            1 - VALKEY_AWS_MEMORY_RESERVATION
+        )
+
+        simple_ops_per_second = _valkey_ops_per_second(instance, use_lua=False)
+        lua_ops_per_second = _valkey_ops_per_second(instance, use_lua=True)
+        lua_write_ops_per_second = write_ops_per_second * args.lua_write_percent
+        simple_write_ops_per_second = write_ops_per_second - lua_write_ops_per_second
+        write_cpu_units = (
+            simple_write_ops_per_second / simple_ops_per_second
+            + lua_write_ops_per_second / lua_ops_per_second
+        )
+        total_cpu_units = write_cpu_units + (
+            read_ops_per_second / simple_ops_per_second
+        )
+        min_shards = max(
+            1,
+            math.ceil(write_cpu_units),
+            math.ceil(required_memory_gib / instance.ram_gib),
+        )
+        min_node_copies = (
+            2
+            if desires.data_shape.durability_slo_order.mid
+            >= VALKEY_DURABILITY_THRESHOLD
+            else 1
+        )
+        required_nodes = math.ceil(total_cpu_units)
+
+        # Extra shards and read replicas use the same node type and price. Evaluate
+        # the possible shard counts and retain the topology with the fewest nodes.
+        topology: Optional[Tuple[int, int, int]] = None
+        for shards in range(min_shards, max(min_shards, required_nodes) + 1):
+            node_copies = max(
+                min_node_copies,
+                math.ceil(required_nodes / shards),
+            )
+            if node_copies - 1 > VALKEY_MAX_READ_REPLICAS_PER_SHARD:
+                continue
+            candidate = (shards * node_copies, shards, node_copies)
+            if topology is None or candidate < topology:
+                topology = candidate
+
+        assert topology is not None
+        node_count, shards, node_copies = topology
+        read_replicas_per_shard = node_copies - 1
+        cluster_params = {
+            "valkey.shards": shards,
+            "valkey.read_replicas_per_shard": read_replicas_per_shard,
+            "valkey.max_read_replicas_per_shard": (VALKEY_MAX_READ_REPLICAS_PER_SHARD),
+            "valkey.lua_write_percent": args.lua_write_percent,
+            "valkey.simple_ops_per_second_per_node": simple_ops_per_second,
+            "valkey.lua_ops_per_second_per_node": lua_ops_per_second,
+            "valkey.cpu_capacity_units_required": total_cpu_units,
+            "valkey.estimated_state_size_gib": estimated_state_size_gib,
+            "valkey.required_memory_gib": required_memory_gib,
+            "valkey.aws_memory_reservation_percent": (VALKEY_AWS_MEMORY_RESERVATION),
+            "valkey.usable_memory_per_node_gib": (
+                instance.ram_gib * (1 - VALKEY_AWS_MEMORY_RESERVATION)
+            ),
+            "valkey.read_capacity_ops_per_second": round(
+                max(0, node_count - write_cpu_units) * simple_ops_per_second
+            ),
+            "valkey.write_capacity_ops_per_second": (
+                round(
+                    shards
+                    / (
+                        (1 - args.lua_write_percent) / simple_ops_per_second
+                        + args.lua_write_percent / lua_ops_per_second
+                    )
+                )
+            ),
+        }
+        cluster = RegionClusterCapacity(
+            cluster_type=NflxValkeyCapacityModel.cluster_type,
+            count=node_count,
+            instance=instance,
+            cluster_params=cluster_params,
+        )
+        requirement = CapacityRequirement(
+            requirement_type="valkey-regional",
+            reference_shape=instance,
+            cpu_cores=certain_int(node_count),
+            mem_gib=certain_float(required_memory_gib * node_copies),
+            network_mbps=certain_float(simple_network_mbps(desires)),
+            context=cluster_params,
+        )
+        return CapacityPlan(
+            requirements=Requirements(
+                regional=[requirement],
+                regrets=("spend", "mem"),
+            ),
+            candidate_clusters=Clusters(
+                annual_costs={
+                    "valkey.regional-clusters": Decimal(str(cluster.annual_cost))
+                },
+                regional=[cluster],
+            ),
+        )
+
+    @staticmethod
+    def description() -> str:
+        return "Netflix Valkey on ElastiCache Capacity Model"
+
+    @staticmethod
+    def extra_model_arguments_schema() -> Dict[str, Any]:
+        return NflxValkeyArguments.model_json_schema()
+
+    @staticmethod
+    def preferred_families() -> Optional[FrozenSet[str]]:
+        return frozenset(("cache.r7g", "cache.r8g"))
+
+    @staticmethod
+    def allowed_platforms() -> Tuple[Platform, ...]:
+        return (Platform.valkey,)
+
+    @staticmethod
+    def default_desires(
+        user_desires: CapacityDesires, extra_model_arguments: Dict[str, Any]
+    ) -> CapacityDesires:
+        return CapacityDesires(
+            query_pattern=QueryPattern(
+                access_pattern=AccessPattern.latency,
+                access_consistency=GlobalConsistency(
+                    same_region=Consistency(
+                        target_consistency=AccessConsistency.linearizable_stale,
+                    ),
+                    cross_region=Consistency(
+                        target_consistency=AccessConsistency.never,
+                    ),
+                ),
+                estimated_mean_read_size_bytes=certain_int(1024),
+                estimated_mean_write_size_bytes=certain_int(1024),
+                estimated_mean_read_latency_ms=certain_float(1),
+                estimated_mean_write_latency_ms=certain_float(1),
+                read_latency_slo_ms=FixedInterval(
+                    low=0.5, mid=2, high=5, confidence=0.98
+                ),
+                write_latency_slo_ms=FixedInterval(
+                    low=0.5, mid=2, high=5, confidence=0.98
+                ),
+            ),
+            data_shape=DataShape(
+                reserved_instance_app_mem_gib=0,
+                reserved_instance_system_mem_gib=0,
+            ),
+        )
+
+
+nflx_valkey_capacity_model = NflxValkeyCapacityModel()

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -382,8 +382,8 @@ class NflxValkeyCapacityModel(CapacityModel):
                         target_consistency=AccessConsistency.never,
                     ),
                 ),
-                estimated_mean_read_size_bytes=certain_int(1024),
-                estimated_mean_write_size_bytes=certain_int(1024),
+                estimated_mean_read_size_bytes=certain_int(50),
+                estimated_mean_write_size_bytes=certain_int(50),
                 estimated_mean_read_latency_ms=certain_float(1),
                 estimated_mean_write_latency_ms=certain_float(1),
                 read_latency_slo_ms=FixedInterval(

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Any
 from typing import Dict
 from typing import FrozenSet
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 
@@ -43,6 +44,13 @@ VALKEY_MAX_LUA_OPS_PER_SECOND = 150_000
 VALKEY_DURABILITY_THRESHOLD = 1_000
 VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
+VALKEY_ITEM_METADATA_BYTES = {
+    "7.2": 60,
+    "8": 52,
+    "8.0": 52,
+    "8.1": 31,
+}
+ValkeyEngineVersion = Literal["7.2", "8", "8.0", "8.1"]
 
 
 def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
@@ -62,10 +70,43 @@ def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
     return round(low + speed_ratio * (high - low))
 
 
+def _jemalloc_size_class(requested_bytes: int) -> int:
+    """Return the allocator size class for a key or value allocation."""
+    quantum = 8
+    upper_bound = 64
+    while requested_bytes > upper_bound:
+        quantum *= 2
+        upper_bound *= 2
+    return max(quantum, math.ceil(requested_bytes / quantum) * quantum)
+
+
+def _valkey_item_overhead_bytes(
+    key_size_bytes: int,
+    value_size_bytes: int,
+    engine_version: ValkeyEngineVersion,
+) -> int:
+    """Estimate metadata and allocator slack for one key/value item."""
+    metadata_bytes = VALKEY_ITEM_METADATA_BYTES[engine_version]
+    key_allocation = _jemalloc_size_class(key_size_bytes + 4)
+    key_allocation_slack = key_allocation - key_size_bytes
+    if engine_version == "8.1" and value_size_bytes < 32:
+        # The 8.1 curve has a separate compact-value branch below 32 bytes.
+        baseline_16_byte_key_slack = 8
+        return (
+            metadata_bytes
+            + _jemalloc_size_class(value_size_bytes + 7)
+            - value_size_bytes
+            + key_allocation_slack
+            - baseline_16_byte_key_slack
+        )
+    value_allocation = _jemalloc_size_class(value_size_bytes + 4)
+    return metadata_bytes + key_allocation_slack + value_allocation - value_size_bytes
+
+
 class NflxValkeyArguments(BaseModel):
     key_size_bytes: int = Field(
         alias="valkey.key_size_bytes",
-        default=64,
+        default=16,
         ge=0,
         description=(
             "Average key size. Used with value size, WPS, and TTL when total "
@@ -79,6 +120,11 @@ class NflxValkeyArguments(BaseModel):
             "ISO-8601 key TTL. Used with key size, value size, and WPS when "
             "total state size is not supplied."
         ),
+    )
+    engine_version: ValkeyEngineVersion = Field(
+        alias="valkey.engine_version",
+        default="8.1",
+        description="Valkey engine version used for per-item memory overhead.",
     )
     lua_write_percent: float = Field(
         alias="valkey.lua_write_percent",
@@ -113,19 +159,36 @@ class NflxValkeyCapacityModel(CapacityModel):
         read_ops_per_second = desires.query_pattern.estimated_read_per_second.mid
         write_ops_per_second = desires.query_pattern.estimated_write_per_second.mid
         compression_ratio = max(1.0, desires.data_shape.estimated_compression_ratio.mid)
+        value_size_bytes = math.ceil(
+            desires.query_pattern.estimated_mean_write_size_bytes.mid
+            / compression_ratio
+        )
+        item_payload_size_bytes = args.key_size_bytes + value_size_bytes
+        item_memory_overhead_bytes = _valkey_item_overhead_bytes(
+            key_size_bytes=args.key_size_bytes,
+            value_size_bytes=value_size_bytes,
+            engine_version=args.engine_version,
+        )
         estimated_state_size_gib = desires.data_shape.estimated_state_size_gib.mid
-        if estimated_state_size_gib <= 0:
-            estimated_state_size_gib = (
-                (
-                    args.key_size_bytes
-                    + desires.query_pattern.estimated_mean_write_size_bytes.mid
-                )
-                * write_ops_per_second
-                * iso_to_seconds(args.ttl)
-                / GIB_IN_BYTES
+        if estimated_state_size_gib > 0:
+            uncompressed_item_size_bytes = (
+                args.key_size_bytes
+                + desires.query_pattern.estimated_mean_write_size_bytes.mid
             )
-        estimated_state_size_gib /= compression_ratio
-        required_memory_gib = estimated_state_size_gib / (
+            if uncompressed_item_size_bytes <= 0:
+                raise ValueError(
+                    "Valkey key size or value size must be positive when estimating "
+                    "per-item overhead for explicit state"
+                )
+            item_count = (
+                estimated_state_size_gib * GIB_IN_BYTES / uncompressed_item_size_bytes
+            )
+        else:
+            item_count = write_ops_per_second * iso_to_seconds(args.ttl)
+        estimated_state_size_gib = item_count * item_payload_size_bytes / GIB_IN_BYTES
+        memory_overhead_gib = item_count * item_memory_overhead_bytes / GIB_IN_BYTES
+        total_data_memory_gib = estimated_state_size_gib + memory_overhead_gib
+        required_memory_gib = total_data_memory_gib / (
             1 - VALKEY_AWS_MEMORY_RESERVATION
         )
 
@@ -178,7 +241,13 @@ class NflxValkeyCapacityModel(CapacityModel):
             "valkey.simple_ops_per_second_per_node": simple_ops_per_second,
             "valkey.lua_ops_per_second_per_node": lua_ops_per_second,
             "valkey.cpu_capacity_units_required": total_cpu_units,
+            "valkey.engine_version": args.engine_version,
+            "valkey.item_count": item_count,
+            "valkey.item_payload_size_bytes": item_payload_size_bytes,
+            "valkey.item_memory_overhead_bytes": item_memory_overhead_bytes,
             "valkey.estimated_state_size_gib": estimated_state_size_gib,
+            "valkey.memory_overhead_gib": memory_overhead_gib,
+            "valkey.total_data_memory_gib": total_data_memory_gib,
             "valkey.required_memory_gib": required_memory_gib,
             "valkey.aws_memory_reservation_percent": (VALKEY_AWS_MEMORY_RESERVATION),
             "valkey.usable_memory_per_node_gib": (

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -46,7 +46,7 @@ VALKEY_DURABILITY_THRESHOLD = 1_000
 VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
 VALKEY_ENGINE_VERSION = "8.1"
-VALKEY_ITEM_METADATA_BYTES = 31
+VALKEY_8_1_BENCHMARK_BASE_OVERHEAD_BYTES = 31
 VALKEY_DEFAULT_KEY_SIZE_BYTES = 16
 VALKEY_DEFAULT_VALUE_SIZE_BYTES = 50
 VALKEY_MAX_MEASURED_OVERHEAD_VALUE_BYTES = 128
@@ -70,8 +70,8 @@ def _valkey_ops_per_second(instance: Instance, use_lua: bool) -> int:
     return round(low + speed_ratio * (high - low))
 
 
-def _jemalloc_size_class(requested_bytes: int) -> int:
-    """Return the allocator size class, extrapolating beyond the measured curve."""
+def _valkey_8_1_benchmark_bucket_bytes(requested_bytes: int) -> int:
+    """Return a bucket from the fitted Valkey 8.1 overhead benchmark curve."""
     quantum = 8
     upper_bound = 64
     while requested_bytes > upper_bound:
@@ -84,24 +84,24 @@ def _valkey_item_overhead_bytes(
     key_size_bytes: int,
     value_size_bytes: int,
 ) -> int:
-    """Estimate Valkey 8.1 metadata and allocator slack for one item."""
-    key_allocation = _jemalloc_size_class(key_size_bytes + 4)
-    key_allocation_slack = key_allocation - key_size_bytes
+    """Estimate one item's overhead from the Valkey 8.1 benchmark curve."""
+    key_bucket = _valkey_8_1_benchmark_bucket_bytes(key_size_bytes + 4)
+    key_bucket_slack = key_bucket - key_size_bytes
     if value_size_bytes < 32:
-        # The 8.1 curve has a separate compact-value branch below 32 bytes.
+        # The benchmark curve has a separate branch below 32-byte values.
         baseline_16_byte_key_slack = 8
         return (
-            VALKEY_ITEM_METADATA_BYTES
-            + _jemalloc_size_class(value_size_bytes + 7)
+            VALKEY_8_1_BENCHMARK_BASE_OVERHEAD_BYTES
+            + _valkey_8_1_benchmark_bucket_bytes(value_size_bytes + 7)
             - value_size_bytes
-            + key_allocation_slack
+            + key_bucket_slack
             - baseline_16_byte_key_slack
         )
-    value_allocation = _jemalloc_size_class(value_size_bytes + 4)
+    value_bucket = _valkey_8_1_benchmark_bucket_bytes(value_size_bytes + 4)
     return (
-        VALKEY_ITEM_METADATA_BYTES
-        + key_allocation_slack
-        + value_allocation
+        VALKEY_8_1_BENCHMARK_BASE_OVERHEAD_BYTES
+        + key_bucket_slack
+        + value_bucket
         - value_size_bytes
     )
 

--- a/service_capacity_modeling/models/org/netflix/valkey.py
+++ b/service_capacity_modeling/models/org/netflix/valkey.py
@@ -43,6 +43,8 @@ VALKEY_MIN_OPS_PER_SECOND = 700_000
 VALKEY_MAX_OPS_PER_SECOND = 1_000_000
 VALKEY_MIN_LUA_OPS_PER_SECOND = 50_000
 VALKEY_MAX_LUA_OPS_PER_SECOND = 150_000
+VALKEY_DURABLE_WRITE_OPS_PER_SECOND = 100_000
+VALKEY_DURABLE_LUA_WRITE_OPS_PER_SECOND = 50_000
 VALKEY_DURABILITY_THRESHOLD = 1_000
 VALKEY_AWS_MEMORY_RESERVATION = 0.25
 VALKEY_MAX_READ_REPLICAS_PER_SHARD = 5
@@ -173,6 +175,7 @@ class _ValkeyMemoryRequirement(NamedTuple):
 
 
 class _ValkeyCPURequirement(NamedTuple):
+    read_ops_per_second: int
     simple_ops_per_second: int
     lua_ops_per_second: int
     write_cpu_units: float
@@ -247,8 +250,13 @@ def _estimate_valkey_cpu(
 ) -> _ValkeyCPURequirement:
     read_ops_per_second = desires.query_pattern.estimated_read_per_second.mid
     write_ops_per_second = desires.query_pattern.estimated_write_per_second.mid
-    simple_ops_per_second = _valkey_ops_per_second(instance, use_lua=False)
-    lua_ops_per_second = _valkey_ops_per_second(instance, use_lua=True)
+    read_capacity_ops_per_second = _valkey_ops_per_second(instance, use_lua=False)
+    if desires.data_shape.durability_slo_order.mid >= VALKEY_DURABILITY_THRESHOLD:
+        simple_ops_per_second = VALKEY_DURABLE_WRITE_OPS_PER_SECOND
+        lua_ops_per_second = VALKEY_DURABLE_LUA_WRITE_OPS_PER_SECOND
+    else:
+        simple_ops_per_second = read_capacity_ops_per_second
+        lua_ops_per_second = _valkey_ops_per_second(instance, use_lua=True)
     lua_write_ops_per_second = write_ops_per_second * args.lua_write_percent
     simple_write_ops_per_second = write_ops_per_second - lua_write_ops_per_second
     write_cpu_units = (
@@ -256,10 +264,13 @@ def _estimate_valkey_cpu(
         + lua_write_ops_per_second / lua_ops_per_second
     )
     return _ValkeyCPURequirement(
+        read_ops_per_second=read_capacity_ops_per_second,
         simple_ops_per_second=simple_ops_per_second,
         lua_ops_per_second=lua_ops_per_second,
         write_cpu_units=write_cpu_units,
-        total_cpu_units=(write_cpu_units + read_ops_per_second / simple_ops_per_second),
+        total_cpu_units=(
+            write_cpu_units + read_ops_per_second / read_capacity_ops_per_second
+        ),
         write_network_mbps=(
             write_ops_per_second
             * desires.query_pattern.estimated_mean_write_size_bytes.mid
@@ -361,6 +372,7 @@ class NflxValkeyCapacityModel(CapacityModel):
             "valkey.read_replicas_per_shard": read_replicas_per_shard,
             "valkey.max_read_replicas_per_shard": (VALKEY_MAX_READ_REPLICAS_PER_SHARD),
             "valkey.lua_write_percent": args.lua_write_percent,
+            "valkey.read_ops_per_second_per_node": cpu.read_ops_per_second,
             "valkey.simple_ops_per_second_per_node": cpu.simple_ops_per_second,
             "valkey.lua_ops_per_second_per_node": cpu.lua_ops_per_second,
             "valkey.cpu_capacity_units_required": cpu.total_cpu_units,
@@ -384,7 +396,7 @@ class NflxValkeyCapacityModel(CapacityModel):
             ),
             "valkey.read_capacity_ops_per_second": round(
                 max(0, topology.node_count - cpu.write_cpu_units)
-                * cpu.simple_ops_per_second
+                * cpu.read_ops_per_second
             ),
             "valkey.write_capacity_ops_per_second": (
                 round(

--- a/service_capacity_modeling/tools/fetch_pricing.py
+++ b/service_capacity_modeling/tools/fetch_pricing.py
@@ -193,10 +193,48 @@ def fetch_rds_pricing(pricing_client: Any) -> Dict[str, Dict[str, Union[float, s
     return instances
 
 
+def fetch_elasticache_pricing(
+    pricing_client: Any,
+) -> Dict[str, Dict[str, Union[float, str]]]:
+    paginator = pricing_client.get_paginator("get_products")
+    instances: Dict[str, Dict[str, Union[float, str]]] = {}
+    filter_params = {
+        "ServiceCode": "AmazonElastiCache",
+        "Filters": [
+            {
+                "Type": "TERM_MATCH",
+                "Field": "location",
+                "Value": "US East (N. Virginia)",
+            },
+            {"Type": "TERM_MATCH", "Field": "cacheEngine", "Value": "Valkey"},
+        ],
+    }
+
+    for page in paginator.paginate(**filter_params):
+        for price_item in page["PriceList"]:
+            price_data = json.loads(price_item)
+            attributes = price_data.get("product", {}).get("attributes", {})
+            instance_type = attributes.get("instanceType")
+            usage_type = str(attributes.get("usagetype", ""))
+            if (
+                not instance_type
+                or attributes.get("cacheEngine") != "Valkey"
+                or not str(instance_type).startswith(("cache.r7g.", "cache.r8g."))
+                or not usage_type.startswith("NodeUsage:")
+            ):
+                continue
+
+            annual_cost = extract_3yr_upfront_price(price_data)
+            if annual_cost:
+                instances[instance_type] = {"annual_cost": annual_cost}
+    return instances
+
+
 def fetch_pricing(region: str) -> None:
     pricing_client = boto3.client("pricing", region_name=region)
     ec2_instances = fetch_ec2_pricing(pricing_client)
     rds_instances = fetch_rds_pricing(pricing_client)
+    elasticache_instances = fetch_elasticache_pricing(pricing_client)
 
     # AWS no longer sells standard Reserved Instances for newer families
     # (e.g. i7ie), so their instance types have no RI price above. Fall back to
@@ -253,11 +291,31 @@ def fetch_pricing(region: str) -> None:
         json.dump(rds_output, f, indent=2, sort_keys=True)
         f.write("\n")
     print(f"RDS pricing data written to {rds_output_file}")
+    elasticache_output_file = os.path.join(
+        project_root,
+        "hardware",
+        "profiles",
+        "pricing",
+        "aws",
+        "3yr-reserved_elasticache.json",
+    )
+    elasticache_output = {
+        "us-east-1": {
+            "instances": elasticache_instances,
+            "drives": {},
+            "services": {},
+            "zones_in_region": 3,
+        }
+    }
+    with open(elasticache_output_file, "w", encoding="utf-8") as f:
+        json.dump(elasticache_output, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(f"ElastiCache pricing data written to {elasticache_output_file}")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Fetch EC2 and RDS Reserved Instance pricing data."
+        description="Fetch EC2, RDS, and ElastiCache reserved pricing data."
     )
     parser.add_argument(
         "--region",

--- a/service_capacity_modeling/tools/fetch_pricing.py
+++ b/service_capacity_modeling/tools/fetch_pricing.py
@@ -224,9 +224,14 @@ def fetch_elasticache_pricing(
             ):
                 continue
 
-            annual_cost = extract_3yr_upfront_price(price_data)
-            if annual_cost:
-                instances[instance_type] = {"annual_cost": annual_cost}
+            on_demand_terms = (price_data.get("terms") or {}).get("OnDemand", {})
+            for term in on_demand_terms.values():
+                for dimension in term["priceDimensions"].values():
+                    if dimension["unit"] == "Hrs":
+                        hourly_cost = float(dimension["pricePerUnit"]["USD"])
+                        annual_cost = round(hourly_cost * HOURS_PER_YEAR, 2)
+                        instances[instance_type] = {"annual_cost": annual_cost}
+                        print(f"{instance_type} (on-demand): {annual_cost}")
     return instances
 
 
@@ -297,7 +302,7 @@ def fetch_pricing(region: str) -> None:
         "profiles",
         "pricing",
         "aws",
-        "3yr-reserved_elasticache.json",
+        "3yr-reserved_elasticache-on-demand.json",
     )
     elasticache_output = {
         "us-east-1": {

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -245,8 +245,13 @@ def test_item_overhead_extrapolation_is_reported():
     assert cluster.cluster_params["valkey.item_overhead_extrapolated"] is True
 
 
-@pytest.mark.parametrize("durable", [False, True])
-def test_cluster_shape_for_500k_writes_and_500k_reads(durable):
+@pytest.mark.parametrize(
+    "durable, expected_nodes, expected_shards",
+    [(False, 2, 1), (True, 10, 5)],
+)
+def test_cluster_shape_for_500k_writes_and_500k_reads(
+    durable, expected_nodes, expected_shards
+):
     cluster = _cluster(
         _plan_for_shape(
             "cache.r7g.large",
@@ -256,9 +261,60 @@ def test_cluster_shape_for_500k_writes_and_500k_reads(durable):
         )
     )
 
-    assert cluster.count == 2
-    assert cluster.cluster_params["valkey.shards"] == 1
+    assert cluster.count == expected_nodes
+    assert cluster.cluster_params["valkey.shards"] == expected_shards
     assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
+
+
+@pytest.mark.parametrize(
+    "lua_write_percent, write_ops_per_second",
+    [(0, 100_000), (1, 50_000)],
+)
+def test_durable_write_throughput_limits(lua_write_percent, write_ops_per_second):
+    at_limit = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            write_ops_per_second=write_ops_per_second,
+            durable=True,
+            lua_write_percent=lua_write_percent,
+        )
+    )
+    beyond_limit = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            write_ops_per_second=write_ops_per_second + 1,
+            durable=True,
+            lua_write_percent=lua_write_percent,
+        )
+    )
+
+    assert at_limit.cluster_params["valkey.shards"] == 1
+    assert beyond_limit.cluster_params["valkey.shards"] == 2
+    assert at_limit.cluster_params["valkey.simple_ops_per_second_per_node"] == 100_000
+    assert at_limit.cluster_params["valkey.lua_ops_per_second_per_node"] == 50_000
+    assert (
+        at_limit.cluster_params["valkey.write_capacity_ops_per_second"]
+        == write_ops_per_second
+    )
+
+
+def test_read_throughput_is_not_affected_by_durability():
+    durable = _cluster(
+        _plan_for_shape("cache.r7g.large", read_ops_per_second=500_000, durable=True)
+    )
+    ephemeral = _cluster(
+        _plan_for_shape("cache.r7g.large", read_ops_per_second=500_000, durable=False)
+    )
+
+    assert durable.cluster_params["valkey.read_ops_per_second_per_node"] == 700_000
+    assert (
+        durable.cluster_params["valkey.read_ops_per_second_per_node"]
+        == ephemeral.cluster_params["valkey.read_ops_per_second_per_node"]
+    )
+    assert (
+        durable.cluster_params["valkey.cpu_capacity_units_required"]
+        == (ephemeral.cluster_params["valkey.cpu_capacity_units_required"])
+    )
 
 
 def test_cluster_shape_for_50k_lua_writes_and_500k_reads():
@@ -376,8 +432,8 @@ def test_uniform_reads_require_uniform_replica_layers():
         )
     )
 
-    assert cluster.count == 8
-    assert cluster.cluster_params["valkey.shards"] == 4
+    assert cluster.count == 30
+    assert cluster.cluster_params["valkey.shards"] == 15
     assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
     assert cluster.cluster_params["valkey.assumes_uniform_key_distribution"] is True
 
@@ -385,7 +441,7 @@ def test_uniform_reads_require_uniform_replica_layers():
 def test_default_node_quota_rejects_unprovisionable_cluster():
     desires = CapacityDesires(
         query_pattern=QueryPattern(
-            estimated_write_per_second=certain_int(35_000_000),
+            estimated_write_per_second=certain_int(5_000_000),
         ),
         data_shape=DataShape(estimated_state_size_gib=certain_int(1)),
     )

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -184,7 +184,7 @@ def test_cluster_shape_for_50k_lua_writes_and_500k_reads():
     assert cluster.cluster_params["valkey.shards"] == 1
     assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
     assert cluster.cluster_params["valkey.cpu_capacity_units_required"] == (
-        pytest.approx(50_000 / 60_000 + 500_000 / 730_000)
+        pytest.approx(50_000 / 50_000 + 500_000 / 700_000)
     )
 
 
@@ -211,14 +211,14 @@ def test_read_replica_limit_forces_additional_shards():
     at_replica_limit = _cluster(
         _plan_for_shape(
             "cache.r7g.large",
-            read_ops_per_second=6 * 730_000,
+            read_ops_per_second=6 * 700_000,
             durable=True,
         )
     )
     beyond_replica_limit = _cluster(
         _plan_for_shape(
             "cache.r7g.large",
-            read_ops_per_second=6 * 730_000 + 1,
+            read_ops_per_second=6 * 700_000 + 1,
             durable=True,
         )
     )

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -498,7 +498,7 @@ def test_storage_and_throughput_dominated_shapes():
     assert throughput_cluster.count == 6
 
 
-def test_planner_uses_reserved_elasticache_instance_price():
+def test_planner_uses_on_demand_elasticache_instance_price():
     plans = planner.plan_certain(
         model_name="org.netflix.valkey",
         region="us-east-1",
@@ -516,5 +516,5 @@ def test_planner_uses_reserved_elasticache_instance_price():
     cluster = plans[0].candidate_clusters.regional[0]
     assert cluster.instance.name == "cache.r7g.large"
     assert cluster.count == 2
-    assert cluster.annual_cost == pytest.approx(2 * 690.64)
-    assert plans[0].candidate_clusters.total_annual_cost == pytest.approx(1381.28)
+    assert cluster.annual_cost == pytest.approx(2 * 1534.75)
+    assert plans[0].candidate_clusters.total_annual_cost == pytest.approx(3069.50)

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -44,7 +44,7 @@ def _plan_for_shape(
     key_size_bytes: int = 16,
     ttl: str = "PT24H",
     lua_write_percent: float = 0,
-    sync_durability_surcharge: float = 0,
+    sync_durability_surcharge: Optional[dict[str, float]] = None,
 ):
     durability = 10_000 if durable else 100
     desires = CapacityDesires(
@@ -72,7 +72,7 @@ def _plan_for_shape(
             "valkey.key_size_bytes": key_size_bytes,
             "valkey.ttl": ttl,
             "valkey.lua_write_percent": lua_write_percent,
-            "valkey.sync_durability_surcharge": sync_durability_surcharge,
+            "valkey.sync_durability_surcharge": sync_durability_surcharge or {},
         },
     )
 
@@ -300,7 +300,10 @@ def test_durable_clusters_have_at_least_one_read_replica():
 
 
 def test_sync_durability_surcharge_applies_only_to_durable_clusters():
-    hourly_surcharge = 0.01
+    hourly_surcharge = {
+        "cache.r7g.large": 0.01,
+        "cache.r7g.xlarge": 0.02,
+    }
     durable = _plan_for_shape(
         "cache.r7g.large",
         durable=True,

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -167,8 +167,8 @@ def test_memory_can_be_derived_from_key_value_wps_and_ttl():
     assert cluster.cluster_params["valkey.memory_overhead_gib"] == pytest.approx(
         overhead_gib
     )
-    assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
-        (state_size_gib + overhead_gib) / 0.75
+    assert cluster.cluster_params["valkey.total_data_memory_gib"] == pytest.approx(
+        state_size_gib + overhead_gib
     )
 
 
@@ -180,8 +180,8 @@ def test_aws_memory_reservation_is_applied_to_upfront_state_size():
     item_count = 10 * GIB_IN_BYTES / (16 + 50)
     overhead_gib = item_count * 45 / GIB_IN_BYTES
     assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 45
-    assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
-        (10 + overhead_gib) / 0.75
+    assert cluster.cluster_params["valkey.total_data_memory_gib"] == pytest.approx(
+        10 + overhead_gib
     )
     assert cluster.cluster_params["valkey.usable_memory_per_node_gib"] == (
         pytest.approx(13.07 * 0.75)

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -38,7 +38,7 @@ def _plan_for_shape(
     read_ops_per_second: int = 0,
     write_ops_per_second: int = 0,
     state_size_gib: Optional[int] = 1,
-    value_size_bytes: int = 50,
+    item_size_bytes: int = 66,
     durable: bool = True,
     key_size_bytes: int = 16,
     ttl: str = "PT24H",
@@ -49,8 +49,8 @@ def _plan_for_shape(
         query_pattern=QueryPattern(
             estimated_read_per_second=certain_int(read_ops_per_second),
             estimated_write_per_second=certain_int(write_ops_per_second),
-            estimated_mean_read_size_bytes=certain_int(value_size_bytes),
-            estimated_mean_write_size_bytes=certain_int(value_size_bytes),
+            estimated_mean_read_size_bytes=certain_int(item_size_bytes),
+            estimated_mean_write_size_bytes=certain_int(item_size_bytes),
         ),
         data_shape=DataShape(
             estimated_state_size_gib=certain_int(state_size_gib or 0),
@@ -93,11 +93,11 @@ def test_only_seventh_and_eighth_generation_nodes_are_available():
     }
 
 
-def test_default_value_size_is_50_bytes():
+def test_default_value_size_is_50_bytes_plus_key():
     defaults = nflx_valkey_capacity_model.default_desires(CapacityDesires(), {})
 
-    assert defaults.query_pattern.estimated_mean_read_size_bytes.mid == 50
-    assert defaults.query_pattern.estimated_mean_write_size_bytes.mid == 50
+    assert defaults.query_pattern.estimated_mean_read_size_bytes.mid == 66
+    assert defaults.query_pattern.estimated_mean_write_size_bytes.mid == 66
 
 
 def test_throughput_tracks_core_speed_within_benchmark_bounds():
@@ -150,7 +150,7 @@ def test_memory_can_be_derived_from_key_value_wps_and_ttl():
             "cache.r7g.large",
             write_ops_per_second=100,
             state_size_gib=None,
-            value_size_bytes=960,
+            item_size_bytes=1024,
             key_size_bytes=64,
             ttl="PT10S",
             durable=False,
@@ -172,6 +172,44 @@ def test_memory_can_be_derived_from_key_value_wps_and_ttl():
     )
 
 
+def test_explicit_item_count_is_preserved():
+    item_count = 17_000_000
+    plans = planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=CapacityDesires(
+            query_pattern=QueryPattern(
+                estimated_mean_read_size_bytes=certain_int(53),
+                estimated_mean_write_size_bytes=certain_int(53),
+            ),
+            data_shape=DataShape(
+                estimated_state_item_count=certain_int(item_count),
+            ),
+        ),
+        extra_model_arguments={"valkey.key_size_bytes": 16},
+    )
+
+    params = plans[0].candidate_clusters.regional[0].cluster_params
+    assert params["valkey.item_count"] == item_count
+    assert params["valkey.estimated_state_size_gib"] == pytest.approx(
+        item_count * 53 / GIB_IN_BYTES
+    )
+    assert params["valkey.total_data_memory_gib"] == pytest.approx(
+        item_count * (53 + 50) / GIB_IN_BYTES
+    )
+
+
+@pytest.mark.parametrize("ttl", ["PT0S", "-PT1H", "unlimited"])
+def test_ttl_must_be_positive_and_finite(ttl):
+    with pytest.raises(ValueError, match="positive, finite"):
+        planner.plan_certain(
+            model_name="org.netflix.valkey",
+            region="us-east-1",
+            desires=CapacityDesires(),
+            extra_model_arguments={"valkey.ttl": ttl},
+        )
+
+
 def test_aws_memory_reservation_is_applied_to_upfront_state_size():
     cluster = _cluster(
         _plan_for_shape("cache.r7g.large", state_size_gib=10, durable=False)
@@ -187,6 +225,21 @@ def test_aws_memory_reservation_is_applied_to_upfront_state_size():
         pytest.approx(13.07 * 0.75)
     )
     assert cluster.cluster_params["valkey.shards"] == 2
+
+
+def test_item_overhead_extrapolation_is_reported():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            item_size_bytes=200,
+            state_size_gib=1,
+            durable=False,
+        )
+    )
+
+    assert cluster.cluster_params["valkey.value_size_bytes"] == 184
+    assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 47
+    assert cluster.cluster_params["valkey.item_overhead_extrapolated"] is True
 
 
 @pytest.mark.parametrize("durable", [False, True])
@@ -265,6 +318,65 @@ def test_read_replica_limit_forces_additional_shards():
     assert beyond_replica_limit.count == 8
     assert beyond_replica_limit.cluster_params["valkey.shards"] == 2
     assert beyond_replica_limit.cluster_params["valkey.read_replicas_per_shard"] == 3
+
+
+def test_network_throughput_increases_topology_size():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            read_ops_per_second=1_000,
+            item_size_bytes=1_000_000,
+            state_size_gib=1,
+            durable=False,
+        )
+    )
+
+    assert cluster.count == 9
+    assert cluster.cluster_params["valkey.shards"] == 3
+    assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 2
+    assert cluster.cluster_params["valkey.network_mbps_required"] == 8_000
+    assert cluster.cluster_params["valkey.network_mbps_capacity"] >= 8_000
+
+
+def test_uniform_reads_require_uniform_replica_layers():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            read_ops_per_second=3_400_000,
+            write_ops_per_second=1_500_000,
+            state_size_gib=1,
+            durable=True,
+        )
+    )
+
+    assert cluster.count == 8
+    assert cluster.cluster_params["valkey.shards"] == 4
+    assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
+    assert cluster.cluster_params["valkey.assumes_uniform_key_distribution"] is True
+
+
+def test_default_node_quota_rejects_unprovisionable_cluster():
+    desires = CapacityDesires(
+        query_pattern=QueryPattern(
+            estimated_write_per_second=certain_int(35_000_000),
+        ),
+        data_shape=DataShape(estimated_state_size_gib=certain_int(1)),
+    )
+
+    assert not planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=desires,
+        instance_families=["cache.r7g"],
+    )
+    plans = planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=desires,
+        instance_families=["cache.r7g"],
+        extra_model_arguments={"valkey.max_nodes_per_cluster": 100},
+    )
+    assert plans[0].candidate_clusters.regional[0].count == 100
 
 
 def test_storage_and_throughput_dominated_shapes():

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -15,6 +15,9 @@ from service_capacity_modeling.interface import QueryPattern
 from service_capacity_modeling.interface import RegionContext
 from service_capacity_modeling.models.org.netflix.valkey import _valkey_ops_per_second
 from service_capacity_modeling.models.org.netflix.valkey import (
+    _valkey_item_overhead_bytes,
+)
+from service_capacity_modeling.models.org.netflix.valkey import (
     nflx_valkey_capacity_model,
 )
 from tests.util import shape
@@ -37,7 +40,7 @@ def _plan_for_shape(
     state_size_gib: Optional[int] = 1,
     value_size_bytes: int = 1024,
     durable: bool = True,
-    key_size_bytes: int = 64,
+    key_size_bytes: int = 16,
     ttl: str = "PT24H",
     lua_write_percent: float = 0,
 ):
@@ -117,6 +120,26 @@ def test_taller_instances_do_not_increase_throughput():
     )
 
 
+@pytest.mark.parametrize(
+    "engine_version,expected_overhead",
+    [("7.2", 84), ("8", 76), ("8.0", 76), ("8.1", 55)],
+)
+def test_item_memory_overhead_tracks_engine_curve(engine_version, expected_overhead):
+    assert _valkey_item_overhead_bytes(16, 64, engine_version) == expected_overhead
+
+
+def test_item_memory_overhead_jumps_at_allocator_boundary():
+    assert _valkey_item_overhead_bytes(16, 8, "8.1") == 39
+    assert _valkey_item_overhead_bytes(16, 9, "8.1") == 38
+    assert _valkey_item_overhead_bytes(16, 10, "8.1") == 45
+    assert _valkey_item_overhead_bytes(16, 31, "8.1") == 40
+    assert _valkey_item_overhead_bytes(16, 32, "8.1") == 47
+    assert _valkey_item_overhead_bytes(16, 124, "8.1") == 43
+    assert _valkey_item_overhead_bytes(16, 125, "8.1") == 74
+    assert _valkey_item_overhead_bytes(16, 1020, "8.1") == 43
+    assert _valkey_item_overhead_bytes(16, 1021, "8.1") == 298
+
+
 def test_memory_can_be_derived_from_key_value_wps_and_ttl():
     cluster = _cluster(
         _plan_for_shape(
@@ -130,12 +153,18 @@ def test_memory_can_be_derived_from_key_value_wps_and_ttl():
         )
     )
 
-    state_size_gib = 1024 * 100 * 10 / GIB_IN_BYTES
+    item_count = 100 * 10
+    state_size_gib = 1024 * item_count / GIB_IN_BYTES
+    overhead_gib = 111 * item_count / GIB_IN_BYTES
     assert cluster.cluster_params["valkey.estimated_state_size_gib"] == pytest.approx(
         state_size_gib
     )
+    assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 111
+    assert cluster.cluster_params["valkey.memory_overhead_gib"] == pytest.approx(
+        overhead_gib
+    )
     assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
-        state_size_gib / 0.75
+        (state_size_gib + overhead_gib) / 0.75
     )
 
 
@@ -144,8 +173,11 @@ def test_aws_memory_reservation_is_applied_to_upfront_state_size():
         _plan_for_shape("cache.r7g.large", state_size_gib=10, durable=False)
     )
 
+    item_count = 10 * GIB_IN_BYTES / (16 + 1024)
+    overhead_gib = item_count * 295 / GIB_IN_BYTES
+    assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 295
     assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
-        10 / 0.75
+        (10 + overhead_gib) / 0.75
     )
     assert cluster.cluster_params["valkey.usable_memory_per_node_gib"] == (
         pytest.approx(13.07 * 0.75)
@@ -261,7 +293,7 @@ def test_storage_and_throughput_dominated_shapes():
     storage_cluster = storage_plans[0].candidate_clusters.regional[0]
     throughput_cluster = throughput_plans[0].candidate_clusters.regional[0]
     assert storage_cluster.instance.name == "cache.r8g.2xlarge"
-    assert storage_cluster.cluster_params["valkey.shards"] == 7
+    assert storage_cluster.cluster_params["valkey.shards"] == 9
     assert throughput_cluster.instance.name == "cache.r7g.large"
     assert throughput_cluster.cluster_params["valkey.shards"] == 3
     assert throughput_cluster.count == 6

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -1,0 +1,289 @@
+from typing import Optional
+
+import pytest
+
+from service_capacity_modeling.capacity_planner import planner
+from service_capacity_modeling.hardware import shapes
+from service_capacity_modeling.interface import CapacityDesires
+from service_capacity_modeling.interface import certain_int
+from service_capacity_modeling.interface import DataShape
+from service_capacity_modeling.interface import Drive
+from service_capacity_modeling.interface import FixedInterval
+from service_capacity_modeling.interface import GIB_IN_BYTES
+from service_capacity_modeling.interface import Platform
+from service_capacity_modeling.interface import QueryPattern
+from service_capacity_modeling.interface import RegionContext
+from service_capacity_modeling.models.org.netflix.valkey import _valkey_ops_per_second
+from service_capacity_modeling.models.org.netflix.valkey import (
+    nflx_valkey_capacity_model,
+)
+from tests.util import shape
+
+
+PROPERTY_TEST_CONFIG = {
+    "org.netflix.valkey": {
+        "read_qps_range": (100_000, 2_000_000),
+        "write_qps_range": (50_000, 1_000_000),
+        "data_range_gib": (1, 10),
+    },
+}
+
+
+def _plan_for_shape(
+    instance_name: str,
+    *,
+    read_ops_per_second: int = 0,
+    write_ops_per_second: int = 0,
+    state_size_gib: Optional[int] = 1,
+    value_size_bytes: int = 1024,
+    durable: bool = True,
+    key_size_bytes: int = 64,
+    ttl: str = "PT24H",
+    lua_write_percent: float = 0,
+):
+    durability = 10_000 if durable else 100
+    desires = CapacityDesires(
+        query_pattern=QueryPattern(
+            estimated_read_per_second=certain_int(read_ops_per_second),
+            estimated_write_per_second=certain_int(write_ops_per_second),
+            estimated_mean_write_size_bytes=certain_int(value_size_bytes),
+        ),
+        data_shape=DataShape(
+            estimated_state_size_gib=certain_int(state_size_gib or 0),
+            durability_slo_order=FixedInterval(
+                low=durability,
+                mid=durability,
+                high=durability,
+            ),
+        ),
+    )
+    return nflx_valkey_capacity_model.capacity_plan(
+        instance=shape(instance_name),
+        drive=Drive.get_managed_drive(),
+        context=RegionContext(),
+        desires=desires,
+        extra_model_arguments={
+            "valkey.key_size_bytes": key_size_bytes,
+            "valkey.ttl": ttl,
+            "valkey.lua_write_percent": lua_write_percent,
+        },
+    )
+
+
+def _cluster(plan):
+    assert plan is not None
+    return plan.candidate_clusters.regional[0]
+
+
+def test_only_seventh_and_eighth_generation_nodes_are_available():
+    valkey_instances = [
+        instance
+        for instance in shapes.region("us-east-1").instances.values()
+        if Platform.valkey in instance.platforms
+    ]
+
+    assert valkey_instances
+    assert {instance.family for instance in valkey_instances} == {
+        "cache.r7g",
+        "cache.r8g",
+    }
+
+
+def test_throughput_tracks_core_speed_within_benchmark_bounds():
+    slow = shape("cache.r7g.large").model_copy(update={"cpu_ghz": 2.5})
+    fast = slow.model_copy(update={"cpu_ghz": 3.5})
+
+    assert _valkey_ops_per_second(slow, use_lua=False) == 700_000
+    assert _valkey_ops_per_second(fast, use_lua=False) == 1_000_000
+    assert _valkey_ops_per_second(slow, use_lua=True) == 50_000
+    assert _valkey_ops_per_second(fast, use_lua=True) == 150_000
+
+
+def test_taller_instances_do_not_increase_throughput():
+    small = _cluster(
+        _plan_for_shape("cache.r7g.large", write_ops_per_second=750_000, durable=False)
+    )
+    tall = _cluster(
+        _plan_for_shape(
+            "cache.r7g.16xlarge", write_ops_per_second=750_000, durable=False
+        )
+    )
+
+    assert small.cluster_params["valkey.shards"] == 2
+    assert tall.cluster_params["valkey.shards"] == 2
+    assert (
+        small.cluster_params["valkey.simple_ops_per_second_per_node"]
+        == tall.cluster_params["valkey.simple_ops_per_second_per_node"]
+    )
+
+
+def test_memory_can_be_derived_from_key_value_wps_and_ttl():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            write_ops_per_second=100,
+            state_size_gib=None,
+            value_size_bytes=960,
+            key_size_bytes=64,
+            ttl="PT10S",
+            durable=False,
+        )
+    )
+
+    state_size_gib = 1024 * 100 * 10 / GIB_IN_BYTES
+    assert cluster.cluster_params["valkey.estimated_state_size_gib"] == pytest.approx(
+        state_size_gib
+    )
+    assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
+        state_size_gib / 0.75
+    )
+
+
+def test_aws_memory_reservation_is_applied_to_upfront_state_size():
+    cluster = _cluster(
+        _plan_for_shape("cache.r7g.large", state_size_gib=10, durable=False)
+    )
+
+    assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
+        10 / 0.75
+    )
+    assert cluster.cluster_params["valkey.usable_memory_per_node_gib"] == (
+        pytest.approx(13.07 * 0.75)
+    )
+    assert cluster.cluster_params["valkey.shards"] == 2
+
+
+@pytest.mark.parametrize("durable", [False, True])
+def test_cluster_shape_for_500k_writes_and_500k_reads(durable):
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            write_ops_per_second=500_000,
+            read_ops_per_second=500_000,
+            durable=durable,
+        )
+    )
+
+    assert cluster.count == 2
+    assert cluster.cluster_params["valkey.shards"] == 1
+    assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
+
+
+def test_cluster_shape_for_50k_lua_writes_and_500k_reads():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            write_ops_per_second=50_000,
+            read_ops_per_second=500_000,
+            durable=False,
+            lua_write_percent=1,
+        )
+    )
+
+    assert cluster.count == 2
+    assert cluster.cluster_params["valkey.shards"] == 1
+    assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 1
+    assert cluster.cluster_params["valkey.cpu_capacity_units_required"] == (
+        pytest.approx(50_000 / 60_000 + 500_000 / 730_000)
+    )
+
+
+def test_writes_only_scale_by_adding_shards():
+    cluster = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large", write_ops_per_second=1_500_000, durable=False
+        )
+    )
+
+    assert cluster.cluster_params["valkey.shards"] == 3
+    assert cluster.cluster_params["valkey.read_replicas_per_shard"] == 0
+
+
+def test_durable_clusters_have_at_least_one_read_replica():
+    durable = _cluster(_plan_for_shape("cache.r7g.large", durable=True))
+    ephemeral = _cluster(_plan_for_shape("cache.r7g.large", durable=False))
+
+    assert durable.cluster_params["valkey.read_replicas_per_shard"] == 1
+    assert ephemeral.cluster_params["valkey.read_replicas_per_shard"] == 0
+
+
+def test_read_replica_limit_forces_additional_shards():
+    at_replica_limit = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            read_ops_per_second=6 * 730_000,
+            durable=True,
+        )
+    )
+    beyond_replica_limit = _cluster(
+        _plan_for_shape(
+            "cache.r7g.large",
+            read_ops_per_second=6 * 730_000 + 1,
+            durable=True,
+        )
+    )
+
+    assert at_replica_limit.count == 6
+    assert at_replica_limit.cluster_params["valkey.shards"] == 1
+    assert at_replica_limit.cluster_params["valkey.read_replicas_per_shard"] == 5
+    assert beyond_replica_limit.count == 8
+    assert beyond_replica_limit.cluster_params["valkey.shards"] == 2
+    assert beyond_replica_limit.cluster_params["valkey.read_replicas_per_shard"] == 3
+
+
+def test_storage_and_throughput_dominated_shapes():
+    durability = FixedInterval(low=100, mid=100, high=100)
+    storage_plans = planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=CapacityDesires(
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_int(300),
+                durability_slo_order=durability,
+            ),
+        ),
+    )
+    throughput_plans = planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=CapacityDesires(
+            query_pattern=QueryPattern(
+                estimated_read_per_second=certain_int(2_000_000),
+                estimated_write_per_second=certain_int(2_000_000),
+            ),
+            data_shape=DataShape(
+                estimated_state_size_gib=certain_int(1),
+                durability_slo_order=durability,
+            ),
+        ),
+    )
+
+    storage_cluster = storage_plans[0].candidate_clusters.regional[0]
+    throughput_cluster = throughput_plans[0].candidate_clusters.regional[0]
+    assert storage_cluster.instance.name == "cache.r8g.2xlarge"
+    assert storage_cluster.cluster_params["valkey.shards"] == 7
+    assert throughput_cluster.instance.name == "cache.r7g.large"
+    assert throughput_cluster.cluster_params["valkey.shards"] == 3
+    assert throughput_cluster.count == 6
+
+
+def test_planner_uses_reserved_elasticache_instance_price():
+    plans = planner.plan_certain(
+        model_name="org.netflix.valkey",
+        region="us-east-1",
+        desires=CapacityDesires(
+            query_pattern=QueryPattern(
+                estimated_read_per_second=certain_int(100_000),
+                estimated_write_per_second=certain_int(100_000),
+            ),
+            data_shape=DataShape(estimated_state_size_gib=certain_int(1)),
+        ),
+        instance_families=["cache.r7g"],
+    )
+
+    assert plans
+    cluster = plans[0].candidate_clusters.regional[0]
+    assert cluster.instance.name == "cache.r7g.large"
+    assert cluster.count == 2
+    assert cluster.annual_cost == pytest.approx(2 * 690.64)
+    assert plans[0].candidate_clusters.total_annual_cost == pytest.approx(1381.28)

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -38,7 +38,7 @@ def _plan_for_shape(
     read_ops_per_second: int = 0,
     write_ops_per_second: int = 0,
     state_size_gib: Optional[int] = 1,
-    value_size_bytes: int = 1024,
+    value_size_bytes: int = 50,
     durable: bool = True,
     key_size_bytes: int = 16,
     ttl: str = "PT24H",
@@ -49,6 +49,7 @@ def _plan_for_shape(
         query_pattern=QueryPattern(
             estimated_read_per_second=certain_int(read_ops_per_second),
             estimated_write_per_second=certain_int(write_ops_per_second),
+            estimated_mean_read_size_bytes=certain_int(value_size_bytes),
             estimated_mean_write_size_bytes=certain_int(value_size_bytes),
         ),
         data_shape=DataShape(
@@ -90,6 +91,13 @@ def test_only_seventh_and_eighth_generation_nodes_are_available():
         "cache.r7g",
         "cache.r8g",
     }
+
+
+def test_default_value_size_is_50_bytes():
+    defaults = nflx_valkey_capacity_model.default_desires(CapacityDesires(), {})
+
+    assert defaults.query_pattern.estimated_mean_read_size_bytes.mid == 50
+    assert defaults.query_pattern.estimated_mean_write_size_bytes.mid == 50
 
 
 def test_throughput_tracks_core_speed_within_benchmark_bounds():
@@ -169,9 +177,9 @@ def test_aws_memory_reservation_is_applied_to_upfront_state_size():
         _plan_for_shape("cache.r7g.large", state_size_gib=10, durable=False)
     )
 
-    item_count = 10 * GIB_IN_BYTES / (16 + 1024)
-    overhead_gib = item_count * 295 / GIB_IN_BYTES
-    assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 295
+    item_count = 10 * GIB_IN_BYTES / (16 + 50)
+    overhead_gib = item_count * 45 / GIB_IN_BYTES
+    assert cluster.cluster_params["valkey.item_memory_overhead_bytes"] == 45
     assert cluster.cluster_params["valkey.required_memory_gib"] == pytest.approx(
         (10 + overhead_gib) / 0.75
     )
@@ -289,7 +297,7 @@ def test_storage_and_throughput_dominated_shapes():
     storage_cluster = storage_plans[0].candidate_clusters.regional[0]
     throughput_cluster = throughput_plans[0].candidate_clusters.regional[0]
     assert storage_cluster.instance.name == "cache.r8g.2xlarge"
-    assert storage_cluster.cluster_params["valkey.shards"] == 9
+    assert storage_cluster.cluster_params["valkey.shards"] == 11
     assert throughput_cluster.instance.name == "cache.r7g.large"
     assert throughput_cluster.cluster_params["valkey.shards"] == 3
     assert throughput_cluster.count == 6

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Optional
 
 import pytest
@@ -43,6 +44,7 @@ def _plan_for_shape(
     key_size_bytes: int = 16,
     ttl: str = "PT24H",
     lua_write_percent: float = 0,
+    sync_durability_surcharge: float = 0,
 ):
     durability = 10_000 if durable else 100
     desires = CapacityDesires(
@@ -70,6 +72,7 @@ def _plan_for_shape(
             "valkey.key_size_bytes": key_size_bytes,
             "valkey.ttl": ttl,
             "valkey.lua_write_percent": lua_write_percent,
+            "valkey.sync_durability_surcharge": sync_durability_surcharge,
         },
     )
 
@@ -294,6 +297,27 @@ def test_durable_clusters_have_at_least_one_read_replica():
 
     assert durable.cluster_params["valkey.read_replicas_per_shard"] == 1
     assert ephemeral.cluster_params["valkey.read_replicas_per_shard"] == 0
+
+
+def test_sync_durability_surcharge_applies_only_to_durable_clusters():
+    hourly_surcharge = 0.01
+    durable = _plan_for_shape(
+        "cache.r7g.large",
+        durable=True,
+        sync_durability_surcharge=hourly_surcharge,
+    )
+    ephemeral = _plan_for_shape(
+        "cache.r7g.large",
+        durable=False,
+        sync_durability_surcharge=hourly_surcharge,
+    )
+
+    assert durable is not None
+    assert ephemeral is not None
+    assert durable.candidate_clusters.annual_costs["valkey.sync-durability"] == Decimal(
+        "175.20"
+    )
+    assert "valkey.sync-durability" not in ephemeral.candidate_clusters.annual_costs
 
 
 def test_read_replica_limit_forces_additional_shards():

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -120,24 +120,20 @@ def test_taller_instances_do_not_increase_throughput():
     )
 
 
-@pytest.mark.parametrize(
-    "engine_version,expected_overhead",
-    [("7.2", 84), ("8", 76), ("8.0", 76), ("8.1", 55)],
-)
-def test_item_memory_overhead_tracks_engine_curve(engine_version, expected_overhead):
-    assert _valkey_item_overhead_bytes(16, 64, engine_version) == expected_overhead
+def test_item_memory_overhead_tracks_valkey_8_1_curve():
+    assert _valkey_item_overhead_bytes(16, 64) == 55
 
 
 def test_item_memory_overhead_jumps_at_allocator_boundary():
-    assert _valkey_item_overhead_bytes(16, 8, "8.1") == 39
-    assert _valkey_item_overhead_bytes(16, 9, "8.1") == 38
-    assert _valkey_item_overhead_bytes(16, 10, "8.1") == 45
-    assert _valkey_item_overhead_bytes(16, 31, "8.1") == 40
-    assert _valkey_item_overhead_bytes(16, 32, "8.1") == 47
-    assert _valkey_item_overhead_bytes(16, 124, "8.1") == 43
-    assert _valkey_item_overhead_bytes(16, 125, "8.1") == 74
-    assert _valkey_item_overhead_bytes(16, 1020, "8.1") == 43
-    assert _valkey_item_overhead_bytes(16, 1021, "8.1") == 298
+    assert _valkey_item_overhead_bytes(16, 8) == 39
+    assert _valkey_item_overhead_bytes(16, 9) == 38
+    assert _valkey_item_overhead_bytes(16, 10) == 45
+    assert _valkey_item_overhead_bytes(16, 31) == 40
+    assert _valkey_item_overhead_bytes(16, 32) == 47
+    assert _valkey_item_overhead_bytes(16, 124) == 43
+    assert _valkey_item_overhead_bytes(16, 125) == 74
+    assert _valkey_item_overhead_bytes(16, 1020) == 43
+    assert _valkey_item_overhead_bytes(16, 1021) == 298
 
 
 def test_memory_can_be_derived_from_key_value_wps_and_ttl():

--- a/tests/netflix/test_valkey.py
+++ b/tests/netflix/test_valkey.py
@@ -132,7 +132,7 @@ def test_item_memory_overhead_tracks_valkey_8_1_curve():
     assert _valkey_item_overhead_bytes(16, 64) == 55
 
 
-def test_item_memory_overhead_jumps_at_allocator_boundary():
+def test_item_memory_overhead_jumps_at_benchmark_boundary():
     assert _valkey_item_overhead_bytes(16, 8) == 39
     assert _valkey_item_overhead_bytes(16, 9) == 38
     assert _valkey_item_overhead_bytes(16, 10) == 45

--- a/tests/tools/test_fetch_pricing.py
+++ b/tests/tools/test_fetch_pricing.py
@@ -9,6 +9,7 @@ def _price_item(
     *,
     engine: str = "Valkey",
     usage_type: str = "NodeUsage:cache.r7g.large",
+    hourly_price: str = "0.1752",
     upfront_price: str = "2071.9152",
 ) -> str:
     return json.dumps(
@@ -21,6 +22,16 @@ def _price_item(
                 }
             },
             "terms": {
+                "OnDemand": {
+                    "term": {
+                        "priceDimensions": {
+                            "hourly": {
+                                "unit": "Hrs",
+                                "pricePerUnit": {"USD": hourly_price},
+                            }
+                        },
+                    }
+                },
                 "Reserved": {
                     "term": {
                         "termAttributes": {
@@ -35,13 +46,13 @@ def _price_item(
                             }
                         },
                     }
-                }
+                },
             },
         }
     )
 
 
-def test_fetch_elasticache_pricing_selects_standard_valkey_nodes():
+def test_fetch_elasticache_pricing_selects_on_demand_valkey_nodes():
     paginator = Mock()
     paginator.paginate.return_value = [
         {
@@ -60,7 +71,7 @@ def test_fetch_elasticache_pricing_selects_standard_valkey_nodes():
     pricing_client.get_paginator.return_value = paginator
 
     assert fetch_elasticache_pricing(pricing_client) == {
-        "cache.r7g.large": {"annual_cost": 690.64}
+        "cache.r7g.large": {"annual_cost": 1534.75}
     }
     paginator.paginate.assert_called_once_with(
         ServiceCode="AmazonElastiCache",

--- a/tests/tools/test_fetch_pricing.py
+++ b/tests/tools/test_fetch_pricing.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import Mock
+
+from service_capacity_modeling.tools.fetch_pricing import fetch_elasticache_pricing
+
+
+def _price_item(
+    instance_type: str,
+    *,
+    engine: str = "Valkey",
+    usage_type: str = "NodeUsage:cache.r7g.large",
+    upfront_price: str = "2071.9152",
+) -> str:
+    return json.dumps(
+        {
+            "product": {
+                "attributes": {
+                    "instanceType": instance_type,
+                    "cacheEngine": engine,
+                    "usagetype": usage_type,
+                }
+            },
+            "terms": {
+                "Reserved": {
+                    "term": {
+                        "termAttributes": {
+                            "LeaseContractLength": "3yr",
+                            "PurchaseOption": "All Upfront",
+                            "OfferingClass": "standard",
+                        },
+                        "priceDimensions": {
+                            "upfront": {
+                                "unit": "Quantity",
+                                "pricePerUnit": {"USD": upfront_price},
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+
+def test_fetch_elasticache_pricing_selects_standard_valkey_nodes():
+    paginator = Mock()
+    paginator.paginate.return_value = [
+        {
+            "PriceList": [
+                _price_item("cache.r7g.large"),
+                _price_item(
+                    "cache.r7g.large",
+                    usage_type="USE1-SyncDurability-NodeUsage:cache.r7g.large",
+                ),
+                _price_item("cache.r6g.large"),
+                _price_item("cache.r7g.xlarge", engine="Redis"),
+            ]
+        }
+    ]
+    pricing_client = Mock()
+    pricing_client.get_paginator.return_value = paginator
+
+    assert fetch_elasticache_pricing(pricing_client) == {
+        "cache.r7g.large": {"annual_cost": 690.64}
+    }
+    paginator.paginate.assert_called_once_with(
+        ServiceCode="AmazonElastiCache",
+        Filters=[
+            {
+                "Type": "TERM_MATCH",
+                "Field": "location",
+                "Value": "US East (N. Virginia)",
+            },
+            {"Type": "TERM_MATCH", "Field": "cacheEngine", "Value": "Valkey"},
+        ],
+    )


### PR DESCRIPTION
## Summary

- add `org.netflix.valkey` for managed Valkey clusters on ElastiCache
- support seventh- and eighth-generation managed node families
- size memory from explicit item count, explicit state, or WPS + TTL; read/write sizes represent total key-plus-value bytes
- use 16-byte keys and 50-byte values by default
- apply a benchmark-derived Valkey 8.1 per-item overhead curve, and expose 75% of each node's RAM as usable cache storage
- model ordinary and Lua operations as weighted consumers of the same single-thread CPU capacity
- use network bandwidth as both a primary-shard and total-node constraint
- require at least one read replica for durable clusters and enforce AWS's five-replicas-per-shard maximum
- enforce AWS's default 90-node cluster quota, with an explicit override for approved quota increases

## Why some topology choices look surprising

The planner evaluates the complete valid topology instead of assuming that taller nodes or read replicas are always the next scaling step:

- Taller nodes add memory and network bandwidth but do not increase per-shard operation throughput, so write-heavy workloads add shards even when a larger node appears to be the obvious choice.
- With one shard, a read replica can add read capacity with one node, while adding a durable shard requires both a primary and its replica.
- Reads and keys are assumed uniform across shards. Every shard therefore needs the same replica count; uneven replicas would leave the least-replicated shard overloaded.
- Once memory or writes already require several shards, adding another shard can require fewer total nodes than adding a replica to every existing shard.
- A shard can have at most five read replicas. Once that ceiling is reached, additional read demand must expand the shard count.
- The benchmarked per-item memory curve falls within a fitted bucket and jumps when a larger item crosses the next observed boundary. Values above the measured 128-byte curve continue through the fitted bucket progression and are flagged as extrapolated in plan context.
- Generation and node size are evaluated together: a memory- or network-dominated workload can favor a taller eighth-generation node, while a throughput-dominated workload can favor more small seventh-generation nodes.

## Input contract

| Input | Semantics |
|---|---|
| `query_pattern.estimated_read_per_second` | Ordinary reads per second |
| `query_pattern.estimated_write_per_second` | Total writes per second before applying the Lua share |
| `query_pattern.estimated_mean_read_size_bytes` | Total key-plus-value bytes transferred by one read; defaults to 66 bytes |
| `query_pattern.estimated_mean_write_size_bytes` | Total key-plus-value bytes stored by one write; defaults to 66 bytes |
| `data_shape.estimated_state_item_count` | Preferred state input when item count is known |
| `data_shape.estimated_state_size_gib` | State input when total uncompressed key-plus-value size is known |
| `data_shape.estimated_compression_ratio` | Value compression ratio; keys remain uncompressed; defaults to 1 |
| `data_shape.durability_slo_order` | Values at or above 1,000 require at least one replica per shard |
| `valkey.key_size_bytes` | Key portion of the total item size; defaults to 16 bytes |
| `valkey.ttl` | Positive finite ISO-8601 TTL used with WPS when neither item count nor state size is supplied; defaults to `PT24H` |
| `valkey.lua_write_percent` | Fraction of writes that execute Lua, from 0 to 1; defaults to 0 |
| `valkey.max_nodes_per_cluster` | Cluster node ceiling; defaults to 90 and can reflect an approved quota increase |

State sizing uses item count first, then explicit state size, then `WPS × TTL`.

### Small payload examples

Explicit item count with 16-byte keys and 37-byte values:

```python
desires = CapacityDesires(
    query_pattern=QueryPattern(
        estimated_read_per_second=certain_int(200_000),
        estimated_write_per_second=certain_int(100_000),
        estimated_mean_read_size_bytes=certain_int(53),
        estimated_mean_write_size_bytes=certain_int(53),
    ),
    data_shape=DataShape(
        estimated_state_item_count=certain_int(17_000_000),
        durability_slo_order=FixedInterval(low=10_000, mid=10_000, high=10_000),
    ),
)
extra_model_arguments = {
    "valkey.key_size_bytes": 16,
    "valkey.lua_write_percent": 1.0,
}
```

TTL-derived state using the default 16-byte key and 50-byte value:

```python
desires = CapacityDesires(
    query_pattern=QueryPattern(
        estimated_read_per_second=certain_int(200_000),
        estimated_write_per_second=certain_int(100_000),
    ),
)
extra_model_arguments = {
    "valkey.ttl": "PT1H",
    "valkey.lua_write_percent": 0.25,
}
```

## Weighted operation model

For a `cache.r7g` node, the model uses 700k ordinary operations/second and 50k Lua operations/second. Required CPU units are:

```text
ordinary reads / 700k
+ non-Lua writes / 700k
+ Lua writes / 50k
```

## Example least-regret recommendations

These recommendations use fixed inputs through the uncertain planner and report `least_regret[0]`.

| Durable | State / write workload | RPS | Instance | Topology | Binding behavior |
|---|---|---:|---|---|---|
| Yes | 1 GiB · 500k WPS · 0% Lua | 500k | `cache.r7g.large` | 1 shard · 1 replica / shard | Combined ordinary-operation load requires the second node |
| Yes | 1 GiB · 200k WPS · 25% Lua | 500k | `cache.r8g.large` | 1 shard · 1 replica / shard | Faster core keeps the weighted write load within one shard |
| Yes | 1 GiB · 100k WPS · 100% Lua | 1M | `cache.r7g.large` | 2 shards · 1 replica / shard | Two primaries are fully occupied by 50k Lua each; two replicas serve 500k reads each |
| Yes | 1 GiB · 300k WPS · 0% Lua | 5M | `cache.r7g.large` | 2 shards · 3 replicas / shard | Read demand exceeds one shard's replica ceiling |
| Yes | 300 GiB · 1k WPS · 0% Lua | 1k | `cache.r8g.2xlarge` | 11 shards · 1 replica / shard | Per-item overhead and 75% usable node RAM make memory the binding constraint |
| Yes | 1 GiB · 0 WPS · 0% Lua | 4,740,001 | `cache.r7g.large` | 2 shards · 3 replicas / shard | One shard cannot exceed five replicas |
| Yes | 1 GiB · 1.5M WPS · 0% Lua | 4.3M | `cache.r8g.large` | 2 shards · 3 replicas / shard | Faster core satisfies the weighted demand with two primary shards |

## Validation

- `tox -e pre-commit`
- focused Valkey model and universal property coverage
- explicit item-count preservation and positive finite TTL validation
- Valkey 8.1 benchmark-curve boundaries, including extrapolation reporting
- usable node memory, CPU and network sizing, durability, uniform sharding, and replica-limit expansion
- default cluster quota rejection and approved-quota override
