### PR TITLE
Set explicit cpu_ipc_scale on manually-curated i3 shapes

### DIFF
--- a/service_capacity_modeling/hardware/profiles/shapes/aws/manual_instances.json
+++ b/service_capacity_modeling/hardware/profiles/shapes/aws/manual_instances.json
@@ -12,6 +12,7 @@
       "name": "i3.xlarge",
       "cpu": 4,
       "cpu_ghz": 2.3,
+      "cpu_ipc_scale": 0.8925,
       "ram_gib": 30.65,
       "net_mbps": 1000,
       "drive": {
@@ -29,6 +30,7 @@
       "name": "i3.2xlarge",
       "cpu": 8,
       "cpu_ghz": 2.3,
+      "cpu_ipc_scale": 0.8925,
       "ram_gib": 61.39,
       "net_mbps": 2000,
       "drive": {
@@ -42,6 +44,7 @@
       "name": "i3.4xlarge",
       "cpu": 16,
       "cpu_ghz": 2.3,
+      "cpu_ipc_scale": 0.8925,
       "ram_gib": 122.86,
       "net_mbps": 4000,
       "drive": {

--- a/service_capacity_modeling/tools/instance_families.py
+++ b/service_capacity_modeling/tools/instance_families.py
@@ -9,6 +9,9 @@ from typing import Dict
 
 # Intel
 HASWELL_IPC = 0.85
+BROADWELL_IPC = (
+    HASWELL_IPC * 1.05
+)  # ~5% IPC uplift over Haswell (Intel tick refinement)
 SKYLAKE_IPC = 1.0
 CASCADE_LAKE_IPC = SKYLAKE_IPC
 ICELAKE_IPC = SKYLAKE_IPC * 1.15

--- a/tests/tools/test_manual_instances_ipc_scale.py
+++ b/tests/tools/test_manual_instances_ipc_scale.py
@@ -1,0 +1,33 @@
+"""Ties manually-curated i3.* shapes' cpu_ipc_scale back to BROADWELL_IPC.
+
+i3 is excluded from auto_shape.py generation (see the commented-out entry in
+instance_families.py) and is instead hand-maintained in manual_instances.json.
+Unlike the auto_*.json families, manual entries aren't covered by
+test_cpu_ipc_scale_invariant.py, so a missing or drifted cpu_ipc_scale here
+would silently fall back to Instance's default of 1.0 (Skylake), overstating
+i3's real (Broadwell-era) per-vCPU throughput.
+"""
+
+import json
+from pathlib import Path
+
+from service_capacity_modeling.tools.instance_families import BROADWELL_IPC
+
+SHAPES_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "service_capacity_modeling/hardware/profiles/shapes/aws"
+)
+
+I3_FAMILIES = ("i3.xlarge", "i3.2xlarge", "i3.4xlarge")
+
+
+def test_i3_cpu_ipc_scale_matches_broadwell_ipc() -> None:
+    data = json.loads((SHAPES_DIR / "manual_instances.json").read_text())
+    instances = data["instances"]
+
+    for name in I3_FAMILIES:
+        shape = instances[name]
+        assert shape["cpu_ipc_scale"] == BROADWELL_IPC, (
+            f"{name}: cpu_ipc_scale={shape.get('cpu_ipc_scale')} does not match "
+            f"BROADWELL_IPC={BROADWELL_IPC}"
+        )


### PR DESCRIPTION
# Summary 
i3.xlarge/2xlarge/4xlarge are excluded from auto_shape.py generation and hand-maintained in manual_instances.json, which never set cpu_ipc_scale — they silently took Instance's default of 1.0 (Skylake), overstating i3's real Broadwell-era per-vCPU throughput.

Adds BROADWELL_IPC = HASWELL_IPC * 1.05 (the commonly cited ~5% generational IPC uplift over Haswell, per public Intel architecture reviews) and sets it explicitly on the three i3 entries. Also adds a unit test, since these manual shapes aren't covered by the existing auto_*.json cpu_ipc_scale invariant test (test_cpu_ipc_scale_invariant.py).

Follow-up to [#258](https://github.netflix.net/corp/cie-instance-recommendation-service/pull/258) flagged by Jason Koch as a non-blocking catch-up-pass item for manually-curated shapes with implicit/default cpu_cores/cpu_ipc_scale. Scoped narrowly to i3 for now: it's the only manual family where the default (Skylake 1.0) doesn't match the intended value — m5d/m5dn/r5d/r5dn/db.r5 already are Skylake-era so 1.0 is correct there, just implicit.